### PR TITLE
CPB-47 Add endpoint to test alerting

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/example/ExampleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/example/ExampleController.kt
@@ -111,4 +111,17 @@ class ExampleController {
   fun deleteExample(@PathVariable id: String) {
     log.info("Example $id deleted.")
   }
+
+  @GetMapping("/error")
+  @Operation(
+    summary = "Raise an error",
+    description = "Throws an exception to allow us to test alerting",
+    security = [SecurityRequirement(name = "bearerAuth")],
+    responses = [
+      ApiResponse(responseCode = "500", description = "An error has been raised"),
+    ],
+  )
+  fun error() {
+    error("This is an example error to test alerting")
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/example/ExampleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/example/ExampleTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.integration.example
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.example.Example
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.IntegrationTestBase
@@ -204,6 +205,50 @@ class ExampleTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isOk
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /example/error")
+  inner class ErrorEndpoint {
+
+    @Test
+    fun `should return unauthorized if no token`() {
+      webTestClient.get()
+        .uri("/example/error")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden if no role`() {
+      webTestClient.get()
+        .uri("/example/error")
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `should return forbidden if wrong role`() {
+      webTestClient.get()
+        .uri("/example/error")
+        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `should return a 500 error`() {
+      webTestClient.get()
+        .uri("/example/error")
+        .headers(setAuthorisation(roles = listOf("ROLE_COMMUNITY_PAYBACK__COMMUNITY_PAYBACK_UI")))
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
     }
   }
 }


### PR DESCRIPTION
This commit adds an endpoint that will always throw an exception and consequently return a 500 error. This provides us with a simple mechanism to alerting configuration.