### PR TITLE
CPB-47 Add Sentry Configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
   kotlin("plugin.spring") version "2.2.0"
   id("io.gitlab.arturbosch.detekt") version "1.23.8"
   jacoco
+  id("io.sentry.jvm.gradle") version "5.9.0"
 }
 
 configurations {
@@ -99,4 +100,9 @@ tasks {
     dependsOn(named("jacocoTestCoverageVerification"))
     dependsOn(named("detekt"))
   }
+}
+
+sentry {
+  includeSourceContext = false
+  projectName = rootProject.name
 }

--- a/helm_deploy/hmpps-community-payback-api/values.yaml
+++ b/helm_deploy/hmpps-community-payback-api/values.yaml
@@ -18,6 +18,8 @@ generic-service:
   env:
     JAVA_OPTS: "-Xmx512m"
     SERVER_PORT: "8080"
+    SENTRY_SAMPLE-RATE: 1
+    SENTRY_TRACES-SAMPLE-RATE: 0.01
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
@@ -28,6 +30,8 @@ generic-service:
   namespace_secrets:
     hmpps-community-payback-api-application-insights:
       APPLICATIONINSIGHTS_CONNECTION_STRING: "APPLICATIONINSIGHTS_CONNECTION_STRING"
+    hmpps-community-payback-api-sentry:
+      SENTRY_DSN: "SENTRY_DSN"
 
   allowlist:
     groups:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -10,6 +10,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+    SENTRY_ENVIRONMENT: dev
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,6 +10,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
+    SENTRY_ENVIRONMENT: preprod
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -7,6 +7,7 @@ generic-service:
 
   env:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
+    SENTRY_ENVIRONMENT: prod
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CommunityPaybackApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CommunityPaybackApiExceptionHandler.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.config
 
+import io.sentry.Sentry
 import jakarta.validation.ValidationException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus.BAD_REQUEST
@@ -57,7 +58,9 @@ class CommunityPaybackApiExceptionHandler {
         userMessage = "Unexpected error: ${e.message}",
         developerMessage = e.message,
       ),
-    ).also { log.error("Unexpected exception", e) }
+    )
+    .also { Sentry.captureException(e) }
+    .also { log.error("Unexpected exception", e) }
 
   private companion object {
     private val log = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/SentryConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/SentryConfig.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.config
+
+import io.sentry.SentryOptions
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SentryConfig {
+  @Bean
+  fun ignoreHealthRequests() = SentryOptions.BeforeSendTransactionCallback { transaction, _ ->
+    transaction.transaction?.let { if (it.startsWith("GET /health") || it.startsWith("GET /info")) null else transaction }
+  }
+}

--- a/src/main/resources/application-localdev.yml
+++ b/src/main/resources/application-localdev.yml
@@ -1,2 +1,5 @@
 hmpps-auth:
   url: "http://localhost:8090/auth"
+
+sentry:
+  enabled: false


### PR DESCRIPTION
This commit adds configuration to ensure unhandled exceptions are sent to Sentry, whilst ensuring we don’t sample the actuator endpoints `GET /health` and `GET /info`.