### PR TITLE
CPB-45 Decrease app insights health endpoint sampling

### DIFF
--- a/applicationinsights.dev.json
+++ b/applicationinsights.dev.json
@@ -25,7 +25,7 @@
             "matchType": "regexp"
           }
         ],
-        "percentage": 100
+        "percentage": 2
       }
     ]
   }

--- a/applicationinsights.json
+++ b/applicationinsights.json
@@ -25,7 +25,7 @@
             "matchType": "regexp"
           }
         ],
-        "percentage": 10
+        "percentage": 5
       }
     ]
   }


### PR DESCRIPTION
We are currently seeing all calls to /health in dev being logged in app insights. This is unneccessary.