### PR TITLE
CPB-52 - Add example of accessing username in the API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/ContextService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/ContextService.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.common
+
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Service
+
+@Service
+class ContextService {
+  fun getUserName(): String? = SecurityContextHolder.getContext().authentication.name
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/example/CommunityPaybackController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/example/CommunityPaybackController.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.example
+
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@RestController
+@RequestMapping(
+  produces = [MediaType.APPLICATION_JSON_VALUE],
+)
+@PreAuthorize("hasRole('ROLE_COMMUNITY_PAYBACK__COMMUNITY_PAYBACK_UI')")
+internal annotation class CommunityPaybackController

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/example/ExampleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/example/ExampleController.kt
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import org.slf4j.LoggerFactory
-import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -16,7 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.ContextService
 
 data class Example(
   @param:Schema(description = "Name of the API", example = "hmpps-community-payback-api")
@@ -24,10 +23,11 @@ data class Example(
   val apiName: String? = null,
 )
 
-@RestController
+@CommunityPaybackController
 @RequestMapping("/example")
-@PreAuthorize("hasRole('ROLE_COMMUNITY_PAYBACK__COMMUNITY_PAYBACK_UI')")
-class ExampleController {
+class ExampleController(
+  val contextService: ContextService,
+) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
   @GetMapping(produces = ["application/json"])
@@ -50,7 +50,10 @@ class ExampleController {
       ApiResponse(responseCode = "403", description = "Forbidden"),
     ],
   )
-  fun getExample(): Example = Example(apiName = "hmpps-community-payback-api")
+  fun getExample(): Example {
+    log.info("Received call from user '${contextService.getUserName()}'")
+    return Example(apiName = "hmpps-community-payback-api")
+  }
 
   @PostMapping(consumes = ["application/json"], produces = ["application/json"])
   @Operation(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/ResourceSecurityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/ResourceSecurityTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
+import org.springframework.core.annotation.AnnotationUtils
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping
@@ -41,8 +42,8 @@ class ResourceSecurityTest : IntegrationTestBase() {
     val unprotected = beans.values.asSequence()
       .flatMap { mapping -> mapping.handlerMethods.asSequence() }
       .filter { (_, method) ->
-        method.beanType.getAnnotation(PreAuthorize::class.java) == null &&
-          method.getMethodAnnotation(PreAuthorize::class.java) == null
+        AnnotationUtils.findAnnotation(method.beanType, PreAuthorize::class.java) == null &&
+          AnnotationUtils.findAnnotation(method.method, PreAuthorize::class.java) == null
       }
       .flatMap { (mappingInfo, _) -> mappingInfo.getMappings().asSequence() }
       .filter { mappingStr -> mappingStr !in exclusions }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/example/ExampleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/example/ExampleTest.kt
@@ -47,7 +47,12 @@ class ExampleTest : IntegrationTestBase() {
     fun `should return OK`() {
       webTestClient.get()
         .uri("/example")
-        .headers(setAuthorisation(roles = listOf("ROLE_COMMUNITY_PAYBACK__COMMUNITY_PAYBACK_UI")))
+        .headers(
+          setAuthorisation(
+            username = "INTEGRATION_TEST",
+            roles = listOf("ROLE_COMMUNITY_PAYBACK__COMMUNITY_PAYBACK_UI"),
+          ),
+        )
         .exchange()
         .expectStatus()
         .isOk


### PR DESCRIPTION
This commit updates the `GET /example` endpoint, showing how we can log the username of the calling user, retrieved from the client token. e.g.

```
u.g.j.d.h.c.example.ExampleController    : Received call from user 'INTEGRATION_TEST' |
```

This commit also introduces a custom annotation `CommunityPaybackController` that can be used for all controllers, adding common configuration for all endpoints requiring authorisation. This required a small tweak to the `ResourceSecurityTest` to support finding inherited annotations