### PR TITLE
CPB-58 Add ability to publish domain events

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -41,7 +41,7 @@ jobs:
       environment: ${{ matrix.environments }}
   kotlin_validate:
     name: Validate the kotlin
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/gradle_verify.yml@v2 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/gradle_localstack_verify.yml@v2 # WORKFLOW_VERSION
     secrets: inherit
   build:
     name: Build docker image from hmpps-github-actions

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,8 @@ configurations.matching { it.name == "detekt" }.all {
 
 dependencies {
   implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.5.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.4.10")
+
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.12")
 
@@ -28,6 +30,8 @@ dependencies {
   testImplementation("io.swagger.parser.v3:swagger-parser:2.1.33") {
     exclude(group = "io.swagger.core.v3")
   }
+  testImplementation("org.testcontainers:localstack:1.21.3")
+  testImplementation("org.awaitility:awaitility-kotlin:4.3.0")
 }
 
 kotlin {

--- a/helm_deploy/hmpps-community-payback-api/values.yaml
+++ b/helm_deploy/hmpps-community-payback-api/values.yaml
@@ -13,6 +13,17 @@ generic-service:
     enabled: true
     host: app-hostname.local # override per environment
     tlsSecretName: hmpps-community-payback-api-cert
+    annotations:
+      # See HmppsQueueResource for why this needs securing in the ingress
+      nginx.ingress.kubernetes.io/server-snippet: |
+        server_tokens off;
+        location /queue-admin/retry-all-dlqs {
+          deny all;
+          return 401;
+        }
+
+  # Used to access resources like S3 buckets, SQS queues and SNS topics
+  serviceAccountName: hmpps-community-payback-api
 
   # Environment variables to load into the deployment
   env:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -13,6 +13,10 @@ generic-service:
     SENTRY_ENVIRONMENT: dev
     SPRING_PROFILES_ACTIVE: dev
 
+  namespace_secrets:
+    hmpps-domain-events-topic:
+      HMPPS_SQS_TOPICS_HMPPSEVENTTOPIC_ARN: "topic_arn"
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/DomainEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/DomainEventPublisher.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.common
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.stereotype.Service
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import uk.gov.justice.hmpps.sqs.publish
+import java.time.OffsetDateTime
+
+@Service
+class DomainEventPublisher(
+  private val hmppsQueueService: HmppsQueueService,
+  private val objectMapper: ObjectMapper,
+) {
+  private val domainEventsTopic by lazy {
+    hmppsQueueService.findByTopicId("hmppseventtopic") ?: error("hmppseventtopic not found")
+  }
+
+  fun publish(domainEvent: HmppsDomainEvent) {
+    domainEventsTopic.publish(
+      eventType = domainEvent.eventType,
+      event = objectMapper.writeValueAsString(domainEvent),
+    )
+  }
+}
+
+// https://github.com/ministryofjustice/hmpps-domain-events/blob/main/schema/hmpps-domain-event.json
+data class HmppsDomainEvent(
+  val eventType: String,
+  val version: Int,
+  val description: String?,
+  val detailUrl: String? = null,
+  val occurredAt: OffsetDateTime = OffsetDateTime.now(),
+  val additionalInformation: HmppsAdditionalInformation? = null,
+  val personReference: HmmpsEventPersonReferences? = null,
+)
+
+data class HmppsAdditionalInformation(val map: MutableMap<String, Any?> = mutableMapOf())
+
+data class HmmpsEventPersonReferences(
+  val identifiers: List<HmmpsEventPersonReference>,
+)
+
+data class HmmpsEventPersonReference(
+  val type: String,
+  val value: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/example/ExampleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/example/ExampleController.kt
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.ContextService
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.DomainEventPublisher
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.HmppsDomainEvent
 
 data class Example(
   @param:Schema(description = "Name of the API", example = "hmpps-community-payback-api")
@@ -27,6 +29,7 @@ data class Example(
 @RequestMapping("/example")
 class ExampleController(
   val contextService: ContextService,
+  val domainEventPublisher: DomainEventPublisher,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -58,7 +61,7 @@ class ExampleController(
   @PostMapping(consumes = ["application/json"], produces = ["application/json"])
   @Operation(
     summary = "Create an Example",
-    description = "Creates a new Example resource",
+    description = "Creates a new Example resource and raise a test domain event",
     security = [SecurityRequirement(name = "bearerAuth")],
     requestBody = RequestBody(
       required = true,
@@ -73,7 +76,17 @@ class ExampleController(
     ],
   )
   @ResponseBody
-  fun createExample(@org.springframework.web.bind.annotation.RequestBody example: Example): Example = example.copy()
+  fun createExample(@org.springframework.web.bind.annotation.RequestBody example: Example): Example {
+    domainEventPublisher.publish(
+      HmppsDomainEvent(
+        eventType = "community-payback.test",
+        version = 1,
+        description = "A test domain event to prove integration",
+      ),
+    )
+
+    return example.copy()
+  }
 
   @PutMapping("/{id}", consumes = ["application/json"], produces = ["application/json"])
   @Operation(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/IntegrationTestBase.kt
@@ -6,7 +6,11 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.container.LocalStackContainer
+import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.container.LocalStackContainer.setLocalStackProperties
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.wiremock.HmppsAuthApiExtension.Companion.hmppsAuth
 import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
@@ -21,6 +25,18 @@ abstract class IntegrationTestBase {
 
   @Autowired
   protected lateinit var jwtAuthHelper: JwtAuthorisationHelper
+
+  companion object {
+    private val localStackContainer = LocalStackContainer.instance
+
+    @JvmStatic
+    @DynamicPropertySource
+    fun properties(registry: DynamicPropertyRegistry) {
+      System.setProperty("aws.region", "eu-west-2")
+
+      localStackContainer?.also { setLocalStackProperties(it, registry) }
+    }
+  }
 
   internal fun setAuthorisation(
     username: String? = "AUTH_ADM",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/ResourceSecurityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/ResourceSecurityTest.kt
@@ -19,6 +19,7 @@ class ResourceSecurityTest : IntegrationTestBase() {
     "GET /swagger-ui.html",
     "GET /v3/api-docs",
     "GET /v3/api-docs/swagger-config",
+    "GET /queue-admin/retry-all-dlqs",
     " /error",
   )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/container/LocalStackContainer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/container/LocalStackContainer.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.integration.container
+
+import org.slf4j.LoggerFactory
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.containers.output.Slf4jLogConsumer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import java.io.IOException
+import java.net.ServerSocket
+
+/**
+ * Manages a LocalStack instance for integration tests using Test Containers
+ *
+ * If a running instance is found, a new instance won't be started. This is required
+ * when running in github actions, where local stack is managed by gradle. This also
+ * means that when using cp-stack, the cp-stack managed instance will be used instead
+ */
+object LocalStackContainer {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  val instance by lazy { startLocalStackIfNotRunning() }
+
+  fun setLocalStackProperties(localStackContainer: LocalStackContainer, registry: DynamicPropertyRegistry) {
+    val localstackSnsUrl = localStackContainer.getEndpointOverride(LocalStackContainer.Service.SNS).toString()
+    val region = localStackContainer.region
+    registry.add("hmpps.sqs.localstackUrl") { localstackSnsUrl }
+    registry.add("hmpps.sqs.region") { region }
+  }
+
+  private fun startLocalStackIfNotRunning(): LocalStackContainer? {
+    if (localstackIsRunning()) return null
+    val logConsumer = Slf4jLogConsumer(log).withPrefix("localstack")
+    return LocalStackContainer(
+      DockerImageName.parse("localstack/localstack"),
+    ).apply {
+      withServices(LocalStackContainer.Service.SQS, LocalStackContainer.Service.SNS)
+      withEnv("DEFAULT_REGION", "eu-west-2")
+      waitingFor(
+        Wait.forLogMessage(".*Ready.\n", 1),
+      )
+      start()
+      followOutput(logConsumer)
+    }
+  }
+
+  private fun localstackIsRunning(): Boolean = try {
+    val serverSocket = ServerSocket(4566)
+    serverSocket.localPort == 0
+  } catch (_: IOException) {
+    true
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/util/DomainEventListener.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/util/DomainEventListener.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.integration.util
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.awspring.cloud.sqs.annotation.SqsListener
+import org.awaitility.Awaitility.await
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.test.context.event.annotation.BeforeTestMethod
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.HmppsDomainEvent
+import java.util.concurrent.TimeUnit
+import kotlin.collections.first
+import kotlin.collections.firstOrNull
+import kotlin.jvm.java
+
+@Service
+class DomainEventListener(private val objectMapper: ObjectMapper) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  private val messages = mutableListOf<HmppsDomainEvent>()
+
+  @SqsListener(queueNames = ["hmppsdomaineventsqueue"], factory = "hmppsQueueContainerFactoryProxy", pollTimeoutSeconds = "1")
+  fun processMessage(rawMessage: String?) {
+    val sqsMessage = objectMapper.readValue(rawMessage, SqsMessage::class.java)
+    val event = objectMapper.readValue(sqsMessage.Message, HmppsDomainEvent::class.java)
+
+    log.info("Received Domain Event: $event")
+    synchronized(messages) {
+      messages.add(event)
+    }
+  }
+
+  @BeforeTestMethod
+  fun clearMessages() = messages.clear()
+
+  fun blockForDomainEventOfType(eventType: String): HmppsDomainEvent {
+    await()
+      .atMost(1, TimeUnit.SECONDS)
+      .until { contains(eventType) }
+
+    synchronized(messages) {
+      return messages.first { it.eventType == eventType }
+    }
+  }
+
+  private fun contains(eventType: String): Boolean {
+    synchronized(messages) {
+      return messages.firstOrNull { it.eventType == eventType } != null
+    }
+  }
+}
+
+// Warning suppressed because we have to match the SNS attribute naming case
+@SuppressWarnings("ConstructorParameterNaming")
+data class SqsMessage(
+  val Message: String,
+)

--- a/src/test/resources/application-integrationtest.yml
+++ b/src/test/resources/application-integrationtest.yml
@@ -5,11 +5,23 @@ management.endpoint:
   health.cache.time-to-live: 0
   info.cache.time-to-live: 0
 
+community-payback:
+  request-logging-enabled: true
+
 hmpps-auth:
   url: "http://localhost:8090/auth"
 
-community-payback:
-  request-logging-enabled: true
+hmpps.sqs:
+  provider: localstack
+  queues:
+    # this queue listens to the domain event topics so we can retrieve produced events
+    hmppsdomaineventsqueue:
+      queueName: ${random.uuid}
+      dlqName: ${random.uuid}
+      subscribeTopicId: hmppseventtopic
+  topics:
+    hmppseventtopic:
+      arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}
 
 logging:
   level:

--- a/tools/cp-stack/.env.api.template
+++ b/tools/cp-stack/.env.api.template
@@ -6,4 +6,13 @@ SENTRY_ENABLED=false
 
 HMPPS_AUTH_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 
+HMPPS_SQS_PROVIDER=localstack
+HMPPS_SQS_LOCALSTACKURL=http://localhost:4566
+HMPPS_SQS_TOPICS_HMPPSEVENTTOPIC_ARN=arn:aws:sns:eu-west-2:000000000000:cp_stack_domainevents
+
+# we setup an SQS topic subscriber so we can view what's sent to the topic via awslocal
+HMPPS_SQS_QUEUES_HMPPSDOMAINEVENTSQUEUE_QUEUENAME=cp_stack_domain_event_subscriber
+HMPPS_SQS_QUEUES_HMPPSDOMAINEVENTSQUEUE_DLQNAME=cp_stack_domain_event_subscriber_dlq
+HMPPS_SQS_QUEUES_HMPPSDOMAINEVENTSQUEUE_SUBSCRIBETOPICID=hmppseventtopic
+
 COMMUNITY-PAYBACK_REQUEST-LOGGING-ENABLED=true

--- a/tools/cp-stack/README.md
+++ b/tools/cp-stack/README.md
@@ -75,6 +75,25 @@ Then update compose.yml to refer to this image instead
 
 All requests to upstream services are proxied by wiremock. Mocks can be configured for specific requests. For more information see the [wiremock README](./wiremock/README.md)
 
+## Localstack
+
+We start localstack to provide us with an SNS topic to send domain events to
+
+We also configure an SQS queue that listens to the topic so we can debug messages being sent
+
+This can be monitored as follows:
+
+```bash
+brew install awscli-local
+AWS_DEFAULT_REGION=eu-west-2
+# list topics (if running integration tests there may be many)
+awslocal sns list-topics
+# list topic subscriber (if running integration tests there may be many)
+awslocal sqs list-queues 
+# show domain events sent to the cp-stack API instance
+awslocal sqs receive-message --max-number-of-messages 10 --visibility-timeout 0 --queue-url http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/cp_stack_domain_event_subscriber
+```
+
 ## Debugging the API
 
 Note : this only works when using the `--local-api` option

--- a/tools/cp-stack/Tiltfile
+++ b/tools/cp-stack/Tiltfile
@@ -1,6 +1,7 @@
 docker_compose("./compose.yml")
 
 resources = [
+    "localstack",
     "wiremock",
 ]
 

--- a/tools/cp-stack/compose.yml
+++ b/tools/cp-stack/compose.yml
@@ -28,6 +28,21 @@ services:
       - "3000:3000"
     entrypoint: "node dist/server.js | bunyan"
 
+  localstack:
+    image: localstack/localstack:latest
+    container_name: cp-tools-localstack
+    ports:
+      - "4566:4566"
+      - "4571:4571"
+    environment:
+      - JAVA_TOOL_OPTIONS=-XX:UseSVE=0
+      - SERVICES=sns,sqs
+      - DEBUG=${DEBUG:-0}
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
   wiremock:
     image: wiremock/wiremock
     container_name: cp-stack-wiremock


### PR DESCRIPTION
This commit adds the ability to publish domain events to the HMPPS domain event queue, and enables it in the dev environment for testing via the `POST /example` endpoint.

The configuration follows the [HMPPS Kotlin API Patterns documentation](https://tech-docs.hmpps.service.justice.gov.uk/common-kotlin-patterns/domain-events/), making use of the [HMPPS SQS Library](https://github.com/ministryofjustice/hmpps-spring-boot-sqs/blob/main/README.md) to manage most of the heavy lifting.

Following this guidance, we are using Test Containers to spin up Localstack when running integration tests. This orchestrated by the `LocalStackContainer` class taken from the `hmpps-alerts-api` project and referenced in the aforementioned kotlin patterns documentation.

When tests are ran within github actions we delegate starting localstack to the actions instead (`LocalStackContainer` detects this and doesn’t start Local Stack).

Following guidance in the [HMPPS SQS Library README](https://github.com/ministryofjustice/hmpps-spring-boot-sqs/blob/main/README.md), we have secured the `/queue-admin/retry-all-dlqs` endpoint via the ingress, allowing internal requests to be made to it from k8s without authentication. See the documentation on `HmppsQueueResource` for more information.

cp-stack has also been updated to use local stack when running the stack locally. see the cp-stack README for information on how to debug the topic