### PR TITLE
Fix cp-stack localstack config when using docker api image

### DIFF
--- a/tools/cp-stack/.env.api.template
+++ b/tools/cp-stack/.env.api.template
@@ -7,6 +7,7 @@ SENTRY_ENABLED=false
 HMPPS_AUTH_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 
 HMPPS_SQS_PROVIDER=localstack
+# this is overridden in docker-compose when using the docker image
 HMPPS_SQS_LOCALSTACKURL=http://localhost:4566
 HMPPS_SQS_TOPICS_HMPPSEVENTTOPIC_ARN=arn:aws:sns:eu-west-2:000000000000:cp_stack_domainevents
 

--- a/tools/cp-stack/.env.ui.template
+++ b/tools/cp-stack/.env.ui.template
@@ -12,6 +12,7 @@ NO_HTTPS=true
 ENVIRONMENT_NAME=DEV
 AUDIT_ENABLED=false
 
+# this is overridden in docker-compose when using the docker image
 COMMUNITY_PAYBACK_API_URL=http://localhost:8080
 
 CLIENT_CREDS_CLIENT_ID=${CLIENT_CREDS_CLIENT_ID}

--- a/tools/cp-stack/compose.yml
+++ b/tools/cp-stack/compose.yml
@@ -12,6 +12,8 @@ services:
     env_file:
       - path: .env.api
         format: raw
+    environment:
+      - HMPPS_SQS_LOCALSTACKURL=http://localstack:4566
     ports:
       - "8080:8080"
 


### PR DESCRIPTION
When running the API in docker we can’t use `localhost` to connect to localstack