### PR TITLE
Improve `ResourceSecurityTest`

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/ResourceSecurityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/ResourceSecurityTest.kt
@@ -1,69 +1,123 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.integration
 
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
-import org.springframework.core.annotation.AnnotationUtils
-import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.servlet.mvc.method.RequestMappingInfo
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping
 import java.io.File
+import kotlin.collections.component1
+import kotlin.collections.component2
 
 class ResourceSecurityTest : IntegrationTestBase() {
+
   @Autowired
   private lateinit var context: ApplicationContext
 
-  private val unprotectedDefaultMethods = setOf(
-    "GET /v3/api-docs.yaml",
-    "GET /swagger-ui.html",
-    "GET /v3/api-docs",
-    "GET /v3/api-docs/swagger-config",
-    "GET /queue-admin/retry-all-dlqs",
-    " /error",
-    "GET /mocks/community-payback-and-delius/providers",
-    "GET /mocks/community-payback-and-delius/provider-teams",
-  )
+  private companion object {
+    private val unprotectedEndpoints = setOf(
+      Endpoint(RequestMethod.GET, "/v3/api-docs.yaml"),
+      Endpoint(RequestMethod.GET, "/swagger-ui.html"),
+      Endpoint(RequestMethod.GET, "/v3/api-docs"),
+      Endpoint(method = RequestMethod.GET, path = "/v3/api-docs/swagger-config"),
+      Endpoint(RequestMethod.GET, "/queue-admin/retry-all-dlqs"),
+      Endpoint(RequestMethod.GET, "/mocks/community-payback-and-delius/providers"),
+      Endpoint(RequestMethod.GET, "/mocks/community-payback-and-delius/provider-teams"),
+    )
+  }
 
   @Test
-  fun `Ensure all endpoints protected with PreAuthorize`() {
-    // need to exclude any that are forbidden in helm configuration
-    val exclusions = File("helm_deploy").walk()
-      .filter { it.name.equals("values.yaml") }
-      .flatMap { file ->
-        file.readLines().map { line ->
-          line.takeIf { it.contains("location") }?.substringAfter("location ")?.substringBefore(" {")
-        }
-      }
-      .filterNotNull()
-      .flatMap { path -> listOf("GET", "POST", "PUT", "DELETE").map { method -> "$method $path" } }
-      .toMutableSet()
-      .also { it.addAll(unprotectedDefaultMethods) }
-
-    val beans = context.getBeansOfType(RequestMappingHandlerMapping::class.java)
-
-    val unprotected = beans.values.asSequence()
-      .flatMap { mapping -> mapping.handlerMethods.asSequence() }
-      .filter { (_, method) ->
-        AnnotationUtils.findAnnotation(method.beanType, PreAuthorize::class.java) == null &&
-          AnnotationUtils.findAnnotation(method.method, PreAuthorize::class.java) == null
-      }
-      .flatMap { (mappingInfo, _) -> mappingInfo.getMappings().asSequence() }
-      .filter { mappingStr -> mappingStr !in exclusions }
-      .toList()
-
-    assertThat(unprotected).withFailMessage {
-      buildString {
-        append("Found unsecured endpoints (no PreAuthorize):\n")
-        unprotected.forEach { append(" - ").append(it).append('\n') }
-      }
-    }.isEmpty()
+  fun `should return unauthorized if no token provided for all secured endpoints`() {
+    forEachEndpoint { httpMethod, uri ->
+      webTestClient
+        .method(httpMethod)
+        .uri(uri)
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
   }
+
+  @Test
+  fun `should return forbidden if no role for all secured endpoints`() {
+    forEachEndpoint { httpMethod, uri ->
+      webTestClient
+        .method(httpMethod)
+        .uri(uri)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = emptyList()))
+        .bodyValue("{}")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
+  @Test
+  fun `should return forbidden if wrong role for all secured endpoints`() {
+    forEachEndpoint { httpMethod, uri ->
+      webTestClient
+        .method(httpMethod)
+        .uri(uri)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+        .bodyValue("{}")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
+  private fun forEachEndpoint(
+    action: (httpMethod: HttpMethod, uri: String) -> Unit,
+  ) {
+    val exclusions = externalAccessAlreadyBlockedByNginx() + unprotectedEndpoints
+    val endpoints = findApiEndpoints()
+
+    endpoints
+      .filter { endpoint -> !exclusions.contains(endpoint) }
+      .forEach { endpoint ->
+        val httpMethod = endpoint.method.toHttpMethod()
+        val uri = endpoint.path.replace(Regex("\\{[^}]*}"), "1234")
+
+        action.invoke(httpMethod, uri)
+      }
+  }
+
+  private fun findApiEndpoints(): List<Endpoint> {
+    val handlerMappings = context.getBeansOfType(RequestMappingHandlerMapping::class.java).values
+    val requestMappingInfos = handlerMappings.flatMap { it.handlerMethods.map { (key, _) -> key } }
+
+    return requestMappingInfos.flatMap { requestMappingInfo ->
+      requestMappingInfo.methodsCondition.methods.flatMap { method ->
+        requestMappingInfo.patternValues.map { pattern -> Endpoint(method, pattern) }
+      }
+    }.sortedBy { it.path }
+  }
+
+  private fun externalAccessAlreadyBlockedByNginx() = File("helm_deploy").walk()
+    .filter { it.name.equals("values.yaml") }
+    .flatMap { file ->
+      file.readLines().map { line ->
+        line.takeIf { it.contains("location") }?.substringAfter("location ")?.substringBefore(" {")
+      }
+    }
+    .filterNotNull()
+    .flatMap { path -> RequestMethod.entries.map { method -> Endpoint(method, path) } }
+    .toMutableSet()
+
+  private fun RequestMethod.toHttpMethod() = when (this) {
+    RequestMethod.GET -> HttpMethod.GET
+    RequestMethod.HEAD -> HttpMethod.HEAD
+    RequestMethod.POST -> HttpMethod.POST
+    RequestMethod.PUT -> HttpMethod.PUT
+    RequestMethod.PATCH -> HttpMethod.PATCH
+    RequestMethod.DELETE -> HttpMethod.DELETE
+    RequestMethod.OPTIONS -> HttpMethod.OPTIONS
+    RequestMethod.TRACE -> HttpMethod.TRACE
+  }
+
+  private data class Endpoint(val method: RequestMethod, val path: String)
 }
-
-private fun RequestMappingInfo.getMappings() = methodsCondition.methods
-  .map { it.name }
-  .ifEmpty { listOf("") } // if no methods defined then match all rather than none
-  .flatMap { method ->
-    pathPatternsCondition?.patternValues?.map { "$method $it" } ?: emptyList()
-  }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/example/ExampleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/example/ExampleTest.kt
@@ -22,36 +22,6 @@ class ExampleTest : IntegrationTestBase() {
   @Nested
   @DisplayName("GET /example")
   inner class ExampleEndpoint {
-
-    @Test
-    fun `should return unauthorized if no token`() {
-      webTestClient.get()
-        .uri("/example")
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-    }
-
-    @Test
-    fun `should return forbidden if no role`() {
-      webTestClient.get()
-        .uri("/example")
-        .headers(setAuthorisation())
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
-    @Test
-    fun `should return forbidden if wrong role`() {
-      webTestClient.get()
-        .uri("/example")
-        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
     @Test
     fun `should return OK`() {
       webTestClient.get()
@@ -73,42 +43,6 @@ class ExampleTest : IntegrationTestBase() {
   @Nested
   @DisplayName("POST /example")
   inner class CreateExampleEndpoint {
-
-    @Test
-    fun `should return unauthorized if no token`() {
-      webTestClient.post()
-        .uri("/example")
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(Example("test-api"))
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-    }
-
-    @Test
-    fun `should return forbidden if no role`() {
-      webTestClient.post()
-        .uri("/example")
-        .headers(setAuthorisation())
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(Example("test-api"))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
-    @Test
-    fun `should return forbidden if wrong role`() {
-      webTestClient.post()
-        .uri("/example")
-        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(Example("test-api"))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
     @Test
     fun `should create and return example, raising a domain event`() {
       webTestClient.post()
@@ -135,42 +69,6 @@ class ExampleTest : IntegrationTestBase() {
   @Nested
   @DisplayName("PUT /example/{id}")
   inner class UpdateExampleEndpoint {
-
-    @Test
-    fun `should return unauthorized if no token`() {
-      webTestClient.put()
-        .uri("/example/123")
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(Example(apiName = "test-api"))
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-    }
-
-    @Test
-    fun `should return forbidden if no role`() {
-      webTestClient.put()
-        .uri("/example/123")
-        .headers(setAuthorisation())
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(Example(apiName = "test-api"))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
-    @Test
-    fun `should return forbidden if wrong role`() {
-      webTestClient.put()
-        .uri("/example/123")
-        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(Example(apiName = "test-api"))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
     @Test
     fun `should update and return example`() {
       webTestClient.put()
@@ -189,36 +87,6 @@ class ExampleTest : IntegrationTestBase() {
   @Nested
   @DisplayName("DELETE /example/{id}")
   inner class DeleteExampleEndpoint {
-
-    @Test
-    fun `should return unauthorized if no token`() {
-      webTestClient.delete()
-        .uri("/example/123")
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-    }
-
-    @Test
-    fun `should return forbidden if no role`() {
-      webTestClient.delete()
-        .uri("/example/123")
-        .headers(setAuthorisation())
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
-    @Test
-    fun `should return forbidden if wrong role`() {
-      webTestClient.delete()
-        .uri("/example/123")
-        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
     @Test
     fun `should delete example`() {
       webTestClient.delete()
@@ -233,36 +101,6 @@ class ExampleTest : IntegrationTestBase() {
   @Nested
   @DisplayName("GET /example/error")
   inner class ErrorEndpoint {
-
-    @Test
-    fun `should return unauthorized if no token`() {
-      webTestClient.get()
-        .uri("/example/error")
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-    }
-
-    @Test
-    fun `should return forbidden if no role`() {
-      webTestClient.get()
-        .uri("/example/error")
-        .headers(setAuthorisation())
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
-    @Test
-    fun `should return forbidden if wrong role`() {
-      webTestClient.get()
-        .uri("/example/error")
-        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
     @Test
     fun `should return a 500 error`() {
       webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/provider/controller/ProvidersIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/provider/controller/ProvidersIntegrationTest.kt
@@ -18,36 +18,6 @@ class ProvidersIntegrationTest : IntegrationTestBase() {
   @Nested
   @DisplayName("GET /providers")
   inner class ProviderEndpoint {
-
-    @Test
-    fun `should return unauthorized if no token`() {
-      webTestClient.get()
-        .uri("/providers")
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-    }
-
-    @Test
-    fun `should return forbidden if no role`() {
-      webTestClient.get()
-        .uri("/providers")
-        .headers(setAuthorisation())
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
-    @Test
-    fun `should return forbidden if wrong role`() {
-      webTestClient.get()
-        .uri("/providers")
-        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
     @Test
     fun `should return OK`() {
       CommunityPaybackAndDeliusMockServer.providers(


### PR DESCRIPTION
**Do not merge - whilst this works now, as we add new endpoints dynamically calling those endpoints with valid data is going to prove tricky so this needs a rethink. Note that authentication failures happen _after_ the inputs have been validated so we need to ensure the input is valid**

Prior to commit the `ResourceSecurityTest` would scan the spring context to find all declared endpoints and then check that a `PreAuthorize` annotation exists for each endpoint.

This commit changes that approach to instead call all declared endpoints for various scenarios to ensure the correct 4xx response is returned (no token, token has no roles, token with a non-applicable group).

Output from one of the tests is shown below, showing all the endpoints the test calls:

```
Before request [GET /example] |
Forbidden (403) returned: Access Denied |
Request data: GET /example] |
Before request [POST /example] |
Forbidden (403) returned: Access Denied |
Request data: POST /example, payload={}] |
Before request [GET /example/error] |
Forbidden (403) returned: Access Denied |
Request data: GET /example/error] |
Before request [PUT /example/placeholder-value] |
Forbidden (403) returned: Access Denied |
Request data: PUT /example/placeholder-value,
Before request [DELETE /example/
Forbidden (403) returned: Access Denied |
Request data: DELETE /example/
Before request [GET /providers] |
Forbidden (403) returned: Access Denied |
Request data: GET /providers] |
Before request [GET /queue-admin/get-dlq-messages/
Forbidden (403) returned: Access Denied |
Request data: GET /queue-admin/get-dlq-messages/
Before request [PUT /queue-admin/purge-queue/
Forbidden (403) returned: Access Denied |
Request data: PUT /queue-admin/purge-queue/
Before request [PUT /queue-admin/retry-dlq/
Forbidden (403) returned: Access Denied |
Request data: PUT /queue-admin/retry-dlq/placeholder-value] |
```