### PR TITLE
Example of potential functional error handling

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/ServiceResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/ServiceResult.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.common
+
+sealed interface ServiceResult<V> {
+  data class Success<V>(val value: V) : ServiceResult<V>
+
+  sealed interface Error<V> : ServiceResult<V> {
+    data class BadRequest<V>(val message: String) : Error<V>
+    data class NotFound<V>(val entityType: String, val id: String) : Error<V>
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/client/ClientResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/client/ClientResult.kt
@@ -1,0 +1,58 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.common.client
+
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.ResponseEntity
+import org.springframework.web.reactive.function.client.WebClientResponseException
+
+sealed interface ClientResult<T> {
+  data class Success<T>(
+    val status: HttpStatus,
+    val body: T,
+  ) : ClientResult<T>
+
+  sealed interface Failure<T> : ClientResult<T> {
+    fun throwException(): Nothing
+
+    data class HttpResponse<T>(
+      val method: HttpMethod,
+      val path: String,
+      val status: HttpStatus,
+      val body: String?,
+    ) : Failure<T> {
+      override fun throwException() = error("Unable to complete $method request to $path: $status")
+    }
+
+    data class Other<T>(
+      val exception: Exception,
+    ) : Failure<T> {
+      override fun throwException() = throw exception
+    }
+  }
+}
+
+@SuppressWarnings("TooGenericExceptionCaught")
+fun <T> callForClientResult(
+  action: () -> ResponseEntity<T>,
+): ClientResult<T> {
+  try {
+    val response = action.invoke()
+
+    return ClientResult.Success(
+      status = response.statusCode.toHttpStatus(),
+      body = response.body,
+    )
+  } catch (e: WebClientResponseException) {
+    return ClientResult.Failure.HttpResponse(
+      e.request!!.method,
+      e.request!!.uri.toString(),
+      e.statusCode.toHttpStatus(),
+      e.responseBodyAsString,
+    )
+  } catch (e: Exception) {
+    return ClientResult.Failure.Other(e)
+  }
+}
+
+private fun HttpStatusCode.toHttpStatus(): HttpStatus = HttpStatus.valueOf(this.value())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/client/CommunityPaybackAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/client/CommunityPaybackAndDeliusClient.kt
@@ -1,14 +1,15 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.common.client
 
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.service.annotation.GetExchange
 
 interface CommunityPaybackAndDeliusClient {
   @GetExchange("/providers")
-  fun providers(): ProviderSummaries
+  fun providers(): ResponseEntity<ProviderSummaries>
 
   @GetExchange("/provider-teams")
-  fun providerTeams(@RequestParam providerId: Long): ProviderTeamSummaries
+  fun providerTeams(@RequestParam providerId: Long): ResponseEntity<ProviderTeamSummaries>
 }
 
 data class ProviderSummaries(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/controller/CommunityPaybackController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/controller/CommunityPaybackController.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.communitypaybackapi.common
+package uk.gov.justice.digital.hmpps.communitypaybackapi.common.controller
 
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import org.springframework.http.MediaType

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/controller/ServiceResultApiFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/controller/ServiceResultApiFunctions.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.common.controller
+
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.ServiceResult
+import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
+
+fun <T> ServiceResult<T>.getOrThrow(): T = when (this) {
+  is ServiceResult.Success<T> -> value
+  is ServiceResult.Error.BadRequest -> throw HmppsErrorResponseException(
+    ErrorResponse(
+      status = HttpStatus.BAD_REQUEST,
+      userMessage = message,
+      developerMessage = message,
+    ),
+  )
+  is ServiceResult.Error.NotFound<T> -> throw HmppsErrorResponseException(
+    ErrorResponse(
+      status = HttpStatus.NOT_FOUND,
+      userMessage = "Could not find $entityType for id '$id'",
+      developerMessage = "Could not find $entityType for id '$id'",
+    ),
+  )
+}
+
+class HmppsErrorResponseException(val response: ErrorResponse) : Exception(response.developerMessage)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CommunityPaybackApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CommunityPaybackApiExceptionHandler.kt
@@ -12,6 +12,7 @@ import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.controller.HmppsErrorResponseException
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 @RestControllerAdvice
@@ -61,6 +62,12 @@ class CommunityPaybackApiExceptionHandler {
     )
     .also { Sentry.captureException(e) }
     .also { log.error("Unexpected exception", e) }
+
+  @ExceptionHandler(HmppsErrorResponseException::class)
+  fun hmppsErrorResponseException(e: HmppsErrorResponseException): ResponseEntity<ErrorResponse> = ResponseEntity
+    .status(e.response.status)
+    .body(e.response)
+    .also { log.debug("Service call returned an Error Result", e) }
 
   private companion object {
     private val log = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/example/ExampleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/example/ExampleController.kt
@@ -14,10 +14,10 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.CommunityPaybackController
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.ContextService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.DomainEventPublisher
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.HmppsDomainEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.controller.CommunityPaybackController
 
 data class Example(
   @param:Schema(description = "Name of the API", example = "hmpps-community-payback-api")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/provider/controller/ProviderController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/provider/controller/ProviderController.kt
@@ -7,7 +7,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.CommunityPaybackController
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.controller.CommunityPaybackController
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.controller.getOrThrow
 import uk.gov.justice.digital.hmpps.communitypaybackapi.provider.service.ProviderService
 
 data class ProviderSummariesDto(
@@ -55,7 +56,7 @@ class ProviderController(val providerService: ProviderService) {
       ApiResponse(responseCode = "403", description = "Forbidden"),
     ],
   )
-  fun getProviders(): ProviderSummariesDto = providerService.getProviders()
+  fun getProviders() = providerService.getProviders().getOrThrow()
 
   @GetMapping("/{providerId}/teams")
   @Operation(
@@ -76,5 +77,5 @@ class ProviderController(val providerService: ProviderService) {
       ApiResponse(responseCode = "404", description = "Provider not found"),
     ],
   )
-  fun getProviderTeam(@PathVariable providerId: Long): ProviderTeamSummariesDto = providerService.getProviderTeams(providerId)
+  fun getProviderTeam(@PathVariable providerId: Long): ProviderTeamSummariesDto = providerService.getProviderTeams(providerId).getOrThrow()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
@@ -22,6 +22,7 @@ object CommunityPaybackAndDeliusMockServer {
       ),
     )
   }
+
   fun providerTeams(
     providerId: Long,
     providerTeams: ProviderTeamSummaries,
@@ -31,6 +32,15 @@ object CommunityPaybackAndDeliusMockServer {
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withBody(objectMapper.writer().writeValueAsString(providerTeams)),
+      ),
+    )
+  }
+
+  fun providerTeamsNotFound(providerId: Long) {
+    WireMock.stubFor(
+      get("/community-payback-and-delius/provider-teams?providerId=$providerId").willReturn(
+        aResponse()
+          .withStatus(404),
       ),
     )
   }


### PR DESCRIPTION
example of functional error handling in two errors:

* for upstream calls via clients
* for responses from internal services

A more exception-centric approach can be seen here - https://github.com/ministryofjustice/hmpps-person-integration-api/blob/4ab7ca8514b013baf465b4e3dfde194e9f213a0b/src/main/kotlin/uk/gov/justice/digital/hmpps/personintegrationapi/common/config/HmppsPersonIntegrationApiExceptionHandler.kt