### PR TITLE
Exclude mock endpoints from open api definition

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/mock/MockCommunityPaybackAndDeliusController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/mock/MockCommunityPaybackAndDeliusController.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.mock
 
+import io.swagger.v3.oas.annotations.Hidden
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -15,6 +16,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProviderTe
  *
  * When removing this also remove the related configuration in [uk.gov.justice.digital.hmpps.communitypaybackapi.config.SecurityConfiguration]
  */
+@Hidden
 @RestController
 @RequestMapping(
   value = ["/mocks/community-payback-and-delius"],


### PR DESCRIPTION
The `/mock` endpoints are provided to temporarily emulate upstream upstream services until they’re available. For this reason they shouldn’t be visible in the Open API (Swagger) spec which is used by the user interface to determine which endpoints are available to it.