### PR TITLE
Add default error responses to open api

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/OpenApiConfiguration.kt
@@ -1,26 +1,35 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.config
 
+import io.swagger.v3.core.converter.AnnotatedType
+import io.swagger.v3.core.converter.ModelConverters
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Contact
 import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.media.MediaType
+import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.responses.ApiResponse
 import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.servers.Server
+import org.springdoc.core.customizers.OpenApiCustomizer
 import org.springframework.boot.info.BuildProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 @Configuration
 class OpenApiConfiguration(buildProperties: BuildProperties) {
   private val version: String = buildProperties.version
 
   @Bean
-  fun customOpenAPI(): OpenAPI = OpenAPI()
+  fun customOpenAPI() = OpenAPI()
     .servers(
       listOf(
         Server().url("https://community-payback-api-dev.hmpps.service.justice.gov.uk").description("Development"),
         Server().url("https://community-payback-api-test.hmpps.service.justice.gov.uk").description("Test"),
-        Server().url("https://community-payback-api-preprod.hmpps.service.justice.gov.uk").description("Pre-Production"),
+        Server().url("https://community-payback-api-preprod.hmpps.service.justice.gov.uk")
+          .description("Pre-Production"),
         Server().url("https://community-payback-api.hmpps.service.justice.gov.uk").description("Production"),
         Server().url("http://localhost:8080").description("Local"),
       ),
@@ -45,4 +54,38 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
     .`in`(SecurityScheme.In.HEADER)
     .name("Authorization")
     .description("A HMPPS Auth access token with the `$role` role.")
+
+  @Bean
+  fun errorResponsesCustomizer(): OpenApiCustomizer = OpenApiCustomizer { openApi: OpenAPI ->
+    openApi.paths.values.forEach { pathItem ->
+      pathItem.readOperations().forEach { operation ->
+        val responses = operation.responses
+
+        addDefaultErrorResponse(responses, "401", "Not authenticated")
+        addDefaultErrorResponse(responses, "403", "Unauthorized")
+        addDefaultErrorResponse(responses, "500", "Unexpected error")
+      }
+    }
+  }
+
+  private fun addDefaultErrorResponse(
+    responses: MutableMap<String, ApiResponse>,
+    code: String,
+    description: String,
+  ) {
+    if (!responses.containsKey(code)) {
+      responses[code] = ApiResponse()
+        .description(description)
+        .content(
+          Content().addMediaType(
+            "application/json",
+            MediaType().schema(createProblemSchema()),
+          ),
+        )
+    }
+  }
+
+  private fun createProblemSchema(): Schema<*> = ModelConverters.getInstance()
+    .resolveAsResolvedSchema(AnnotatedType(ErrorResponse::class.java))
+    .schema
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/example/ExampleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/example/ExampleController.kt
@@ -48,8 +48,6 @@ class ExampleController(
           ),
         ],
       ),
-      ApiResponse(responseCode = "401", description = "Unauthorized"),
-      ApiResponse(responseCode = "403", description = "Forbidden"),
     ],
   )
   fun getExample(): Example {
@@ -69,8 +67,6 @@ class ExampleController(
     responses = [
       ApiResponse(responseCode = "201", description = "Created", content = [Content(mediaType = "application/json")]),
       ApiResponse(responseCode = "400", description = "Invalid request"),
-      ApiResponse(responseCode = "401", description = "Unauthorized"),
-      ApiResponse(responseCode = "403", description = "Forbidden"),
     ],
   )
   @ResponseBody
@@ -98,9 +94,6 @@ class ExampleController(
     responses = [
       ApiResponse(responseCode = "200", description = "Updated successfully", content = [Content(mediaType = "application/json")]),
       ApiResponse(responseCode = "400", description = "Invalid request"),
-      ApiResponse(responseCode = "401", description = "Unauthorized"),
-      ApiResponse(responseCode = "403", description = "Forbidden"),
-      ApiResponse(responseCode = "404", description = "Example not found"),
     ],
   )
   @ResponseBody
@@ -115,9 +108,6 @@ class ExampleController(
     description = "Deletes an Example resource by ID",
     responses = [
       ApiResponse(responseCode = "204", description = "Deleted successfully"),
-      ApiResponse(responseCode = "401", description = "Unauthorized"),
-      ApiResponse(responseCode = "403", description = "Forbidden"),
-      ApiResponse(responseCode = "404", description = "Example not found"),
     ],
   )
   fun deleteExample(@PathVariable id: String) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/project/controller/ProjectController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/project/controller/ProjectController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.CommunityPaybackController
 import uk.gov.justice.digital.hmpps.communitypaybackapi.project.service.ProjectService
+import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -58,10 +59,26 @@ class ProjectController(val projectService: ProjectService) {
           ),
         ],
       ),
-      ApiResponse(responseCode = "400", description = "Bad request - invalid date format or parameters"),
-      ApiResponse(responseCode = "401", description = "Unauthorized"),
-      ApiResponse(responseCode = "403", description = "Forbidden"),
-      ApiResponse(responseCode = "404", description = "Team not found"),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad request - invalid date format or parameters",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Team not found",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
     ],
   )
   fun getProjectAllocations(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/provider/controller/ProviderController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/provider/controller/ProviderController.kt
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.CommunityPaybackController
 import uk.gov.justice.digital.hmpps.communitypaybackapi.provider.service.ProviderService
+import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 data class ProviderSummariesDto(
   @param:Schema(description = "List of Community Payback (UPW) providers")
@@ -51,8 +52,6 @@ class ProviderController(val providerService: ProviderService) {
           ),
         ],
       ),
-      ApiResponse(responseCode = "401", description = "Unauthorized"),
-      ApiResponse(responseCode = "403", description = "Forbidden"),
     ],
   )
   fun getProviders(): ProviderSummariesDto = providerService.getProviders()
@@ -71,9 +70,16 @@ class ProviderController(val providerService: ProviderService) {
           ),
         ],
       ),
-      ApiResponse(responseCode = "401", description = "Unauthorized"),
-      ApiResponse(responseCode = "403", description = "Forbidden"),
-      ApiResponse(responseCode = "404", description = "Provider not found"),
+      ApiResponse(
+        responseCode = "404",
+        description = "Provider not found",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
     ],
   )
   fun getProviderTeam(@PathVariable providerId: Long): ProviderTeamSummariesDto = providerService.getProviderTeams(providerId)


### PR DESCRIPTION
Customise the open api configuration to add a default response for 401, 403 and 500, all of which can potentially occur for all endpoints