### PR TITLE
Fix deploy_to_test permissions

### DIFF
--- a/.github/workflows/deploy_to_test.yml
+++ b/.github/workflows/deploy_to_test.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   docker_build:


### PR DESCRIPTION
Permissions were previously added to the workflow to satisfy github security warnings, but `packages: write` is required for the workflow to run (because it publishes a docker image).

```
Error calling workflow 'ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2'. The workflow is requesting 'packages: write', but is only allowed 'packages: none'.
```