### PR TITLE
CPB-92 - Add Retrieve Appointments Endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/client/CommunityPaybackAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/client/CommunityPaybackAndDeliusClient.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.common.client
 
 import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.service.annotation.GetExchange
@@ -21,6 +22,12 @@ interface CommunityPaybackAndDeliusClient {
     @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate,
     @RequestParam teamId: Long,
   ): ProjectAllocations
+
+  @GetExchange("/projects/{projectId}/appointments")
+  fun getProjectAppointments(
+    @PathVariable projectId: Long,
+    @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
+  ): ProjectAppointments
 
   @GetExchange("/references/project-types")
   fun getProjectTypes(): ProjectTypes
@@ -63,6 +70,7 @@ data class ProjectAllocations(
 
 data class ProjectAllocation(
   val id: Long,
+  val projectId: Long,
   val date: LocalDate,
   val projectName: String,
   val projectCode: String,
@@ -71,6 +79,18 @@ data class ProjectAllocation(
   val numberOfOffendersAllocated: Int,
   val numberOfOffendersWithOutcomes: Int,
   val numberOfOffendersWithEA: Int,
+)
+
+data class ProjectAppointments(
+  val appointments: List<ProjectAppointment>,
+)
+
+data class ProjectAppointment(
+  val id: Long,
+  val projectName: String,
+  val crn: String,
+  val requirementMinutes: Int,
+  val completedMinutes: Int,
 )
 
 data class ProjectTypes(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/controller/OffenderDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/controller/OffenderDto.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.common.controller
+
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  property = "objectType",
+)
+@JsonSubTypes(
+  JsonSubTypes.Type(OffenderDto.OffenderNotFoundDto::class, name = "Not_Found"),
+  JsonSubTypes.Type(OffenderDto.OffenderLimitedDto::class, name = "Limited"),
+  JsonSubTypes.Type(OffenderDto.OffenderFullDto::class, name = "Full"),
+)
+sealed interface OffenderDto {
+  val crn: String
+
+  data class OffenderNotFoundDto(
+    override val crn: String,
+  ) : OffenderDto
+
+  data class OffenderLimitedDto(
+    override val crn: String,
+  ) : OffenderDto
+
+  data class OffenderFullDto(
+    override val crn: String,
+    val forename: String,
+    val surname: String,
+    val middleNames: List<String>,
+  ) : OffenderDto
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/service/OffenderInfoResultMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/service/OffenderInfoResultMapper.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.common.service
+
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.controller.OffenderDto
+
+fun OffenderInfoResult.toDto() = when (this) {
+  is OffenderInfoResult.Full -> toDto()
+  is OffenderInfoResult.Limited -> toDto()
+  is OffenderInfoResult.NotFound -> toDto()
+}
+
+private fun OffenderInfoResult.Full.toDto() = OffenderDto.OffenderFullDto(
+  crn = this.crn,
+  forename = this.summary.name.forename,
+  surname = this.summary.name.surname,
+  middleNames = this.summary.name.middleNames,
+)
+
+private fun OffenderInfoResult.Limited.toDto() = OffenderDto.OffenderLimitedDto(crn = this.crn)
+
+private fun OffenderInfoResult.NotFound.toDto() = OffenderDto.OffenderNotFoundDto(crn = this.crn)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/OpenApiConfiguration.kt
@@ -1,12 +1,19 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.config
 
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.databind.JavaType
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.swagger.v3.core.converter.AnnotatedType
+import io.swagger.v3.core.converter.ModelConverterContext
 import io.swagger.v3.core.converter.ModelConverters
+import io.swagger.v3.core.jackson.ModelResolver
+import io.swagger.v3.core.util.RefUtils
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Contact
 import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.media.Discriminator
 import io.swagger.v3.oas.models.media.MediaType
 import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.responses.ApiResponse
@@ -84,6 +91,36 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
         )
     }
   }
+
+  /**
+   * Taken from https://github.com/swagger-api/swagger-core/issues/3411
+   * Ensures discriminator mappings are provided in the open api spec.
+   * Used by [uk.gov.justice.digital.hmpps.communitypaybackapi.common.controller.OffenderDto]
+   */
+  @Bean
+  fun discriminatorMappingResolver(objectMapper: ObjectMapper?) = object : ModelResolver(objectMapper) {
+    override fun resolveDiscriminator(
+      type: JavaType?,
+      context: ModelConverterContext?,
+    ): Discriminator? {
+      val discriminator = super.resolveDiscriminator(type, context)
+      if (context != null &&
+        type != null &&
+        discriminator.hasPropertyButNoMapping()
+      ) {
+        val jsonSubTypes = type.rawClass.getDeclaredAnnotation(JsonSubTypes::class.java)
+        jsonSubTypes?.value?.forEach { subtype: JsonSubTypes.Type ->
+          discriminator.mapping(
+            subtype.name,
+            RefUtils.constructRef(context.resolve(AnnotatedType(subtype.value.java)).name),
+          )
+        }
+      }
+      return discriminator
+    }
+  }
+
+  private fun Discriminator?.hasPropertyButNoMapping() = this != null && propertyName != null && (mapping == null || mapping.isEmpty())
 
   private fun createProblemSchema(): Schema<*> = ModelConverters.getInstance()
     .resolveAsResolvedSchema(AnnotatedType(ErrorResponse::class.java))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/mock/MockCommunityPaybackAndDeliusController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/mock/MockCommunityPaybackAndDeliusController.kt
@@ -2,8 +2,10 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.mock
 
 import io.swagger.v3.oas.annotations.Hidden
 import jakarta.validation.constraints.Size
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,6 +19,8 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ContactOut
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ContactOutcomes
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAllocation
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAllocations
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAppointment
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAppointments
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectTypes
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProviderSummaries
@@ -31,6 +35,7 @@ import java.time.LocalTime
  * Temporary mock controller until we have the actual endpoint in test environments
  *
  * When removing this also remove the related configuration in [uk.gov.justice.digital.hmpps.communitypaybackapi.config.SecurityConfiguration]
+ * and [ResourceSecurityIT]
  */
 @Hidden
 @RestController
@@ -40,11 +45,19 @@ import java.time.LocalTime
 )
 class MockCommunityPaybackAndDeliusController {
 
-  companion object {
+  companion object MockCommunityPaybackAndDeliusRepository {
+
+    const val PROJECT1_ID = 101L
+    const val PROJECT2_ID = 202L
+
+    const val CRN1 = "CRN0001"
+    const val CRN2 = "CRN0002"
+    const val CRN3 = "CRN0003"
+
     val cases = listOf(
       CaseSummaryWithRestrictions(
         caseSummary = CaseSummary(
-          crn = "CRN0001",
+          crn = CRN1,
           name = CaseName("Jack", "Sparrow", middleNames = emptyList()),
           currentExclusion = false,
           currentRestriction = false,
@@ -54,7 +67,7 @@ class MockCommunityPaybackAndDeliusController {
       ),
       CaseSummaryWithRestrictions(
         caseSummary = CaseSummary(
-          crn = "CRN0002",
+          crn = CRN2,
           name = CaseName("Norman", "Osbourn", middleNames = listOf("Green")),
           currentExclusion = true,
           currentRestriction = false,
@@ -64,13 +77,67 @@ class MockCommunityPaybackAndDeliusController {
       ),
       CaseSummaryWithRestrictions(
         caseSummary = CaseSummary(
-          crn = "CRN0003",
+          crn = CRN3,
           name = CaseName("Otto", "Octavius", middleNames = listOf("on")),
           currentExclusion = true,
           currentRestriction = false,
         ),
         isCrnRestricted = { it.endsWith("s") },
         isCrnExcluded = { false },
+      ),
+    )
+
+    val mockProject1 = MockProject(
+      id = PROJECT1_ID,
+      name = "Community Garden",
+      code = "cg",
+    )
+
+    val mockProject2 = MockProject(
+      id = PROJECT2_ID,
+      name = "Park Cleanup",
+      code = "pc",
+    )
+
+    val mockProjectAllocations = listOf(
+      MockProjectAllocation(
+        id = 1L,
+        project = mockProject1,
+        date = LocalDate.of(2025, 9, 1),
+        startTime = LocalTime.of(9, 0),
+        endTime = LocalTime.of(17, 0),
+        appointments = listOf(
+          MockProjectAppointment(
+            id = 1L,
+            project = mockProject1,
+            crn = CRN1,
+            requirementMinutes = 600,
+            completedMinutes = 60,
+          ),
+          MockProjectAppointment(
+            id = 2L,
+            project = mockProject1,
+            crn = CRN2,
+            requirementMinutes = 300,
+            completedMinutes = 30,
+          ),
+        ),
+      ),
+      MockProjectAllocation(
+        id = 2L,
+        project = mockProject2,
+        date = LocalDate.of(2025, 9, 8),
+        startTime = LocalTime.of(8, 0),
+        endTime = LocalTime.of(16, 0),
+        appointments = listOf(
+          MockProjectAppointment(
+            id = 1L,
+            project = mockProject1,
+            crn = CRN1,
+            requirementMinutes = 1200,
+            completedMinutes = 0,
+          ),
+        ),
       ),
     )
   }
@@ -99,31 +166,46 @@ class MockCommunityPaybackAndDeliusController {
   @SuppressWarnings("MagicNumber", "UnusedParameter")
   @GetMapping("/project-allocations")
   fun getProjectAllocations(@RequestParam teamId: Long) = ProjectAllocations(
-    listOf(
+    mockProjectAllocations.map {
       ProjectAllocation(
-        id = 1L,
-        projectName = "Community Garden",
-        date = LocalDate.of(2025, 9, 1),
-        startTime = LocalTime.of(9, 0),
-        endTime = LocalTime.of(17, 0),
-        projectCode = "cg",
-        numberOfOffendersAllocated = 40,
+        id = it.id,
+        projectId = it.project.id,
+        projectName = it.project.name,
+        date = it.date,
+        startTime = it.startTime,
+        endTime = it.endTime,
+        projectCode = it.project.code,
+        numberOfOffendersAllocated = it.appointments.size,
         numberOfOffendersWithOutcomes = 0,
         numberOfOffendersWithEA = 0,
-      ),
-      ProjectAllocation(
-        id = 2L,
-        projectName = "Park Cleanup",
-        date = LocalDate.of(2025, 9, 8),
-        startTime = LocalTime.of(8, 0),
-        endTime = LocalTime.of(16, 0),
-        projectCode = "pc",
-        numberOfOffendersAllocated = 3,
-        numberOfOffendersWithOutcomes = 4,
-        numberOfOffendersWithEA = 5,
-      ),
-    ),
+      )
+    },
   )
+
+  @GetMapping("/projects/{projectId}/appointments")
+  fun getProjectAppointments(
+    @PathVariable projectId: Long,
+    @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
+  ): ProjectAppointments {
+    val matchingAllocation = mockProjectAllocations
+      .firstOrNull { it.project.id == projectId && it.date == date }
+
+    if (matchingAllocation == null) {
+      return ProjectAppointments(emptyList())
+    }
+
+    return ProjectAppointments(
+      matchingAllocation.appointments.map {
+        ProjectAppointment(
+          id = it.id,
+          projectName = it.project.name,
+          crn = it.crn,
+          requirementMinutes = it.requirementMinutes,
+          completedMinutes = it.completedMinutes,
+        )
+      },
+    )
+  }
 
   @GetMapping("/references/project-types")
   fun getReferenceProjectTypes() = ProjectTypes(
@@ -173,5 +255,28 @@ class MockCommunityPaybackAndDeliusController {
     val caseSummary: CaseSummary,
     val isCrnRestricted: (String) -> Boolean,
     val isCrnExcluded: (String) -> Boolean,
+  )
+
+  data class MockProject(
+    val id: Long,
+    val name: String,
+    val code: String,
+  )
+
+  data class MockProjectAllocation(
+    val id: Long,
+    val project: MockProject,
+    val date: LocalDate,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+    val appointments: List<MockProjectAppointment>,
+  )
+
+  data class MockProjectAppointment(
+    val id: Long,
+    val project: MockProject,
+    val crn: String,
+    val requirementMinutes: Int,
+    val completedMinutes: Int,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/project/controller/ProjectController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/project/controller/ProjectController.kt
@@ -7,9 +7,11 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.CommunityPaybackController
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.controller.OffenderDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.project.service.ProjectService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDate
@@ -23,6 +25,7 @@ data class ProjectAllocationsDto(
 data class ProjectAllocationDto(
   @param:Schema(description = "Project allocation id", example = "1")
   val id: Long,
+  val projectId: Long,
   @param:Schema(description = "Project name", example = "Community Garden Maintenance")
   val projectName: String,
   @param:Schema(description = "Project code", example = "123")
@@ -39,6 +42,21 @@ data class ProjectAllocationDto(
   val numberOfOffendersWithOutcomes: Int,
   @param:Schema(description = "Number of offenders with enforcements", example = "3")
   val numberOfOffendersWithEA: Int,
+)
+
+data class AppointmentsDto(
+  val appointments: List<AppointmentDto>,
+)
+
+data class AppointmentDto(
+  val id: Long,
+  @param:Schema(description = "Project name", example = "Community Garden Maintenance")
+  val projectName: String,
+  @param:Schema(description = "How many community payback minutes the offender is required to complete", example = "2400")
+  val requirementMinutes: Int,
+  @param:Schema(description = "How many community payback minutes the offender has completed to date", example = "480")
+  val completedMinutes: Int,
+  val offender: OffenderDto,
 )
 
 @CommunityPaybackController
@@ -82,12 +100,45 @@ class ProjectController(val projectService: ProjectService) {
     ],
   )
   fun getProjectAllocations(
-    @Parameter(description = "Start date in format dd/MM/yyyy", example = "01/09/2025")
+    @Parameter(description = "Start date", example = "2025-09-01")
     @RequestParam
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate,
-    @Parameter(description = "End date in format dd/MM/yyyy", example = "07/09/2025")
+    @Parameter(description = "End date", example = "2025-09-01")
     @RequestParam
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate,
     @RequestParam teamId: Long,
   ): ProjectAllocationsDto = projectService.getProjectAllocations(startDate, endDate, teamId)
+
+  @GetMapping("/{projectId}/appointments")
+  @Operation(
+    description = "Get project allocations within date range for a specific team",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Successful project allocations response",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = AppointmentsDto::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad request - invalid date format or parameters",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun getAppointments(
+    @PathVariable projectId: Long,
+    @Parameter(description = "Appointment date", example = "2025-01-01")
+    @RequestParam
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
+  ) = projectService.getAppointments(projectId, date)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/project/service/ProjectMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/project/service/ProjectMappers.kt
@@ -2,12 +2,19 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.project.service
 
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAllocation
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAllocations
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAppointment
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAppointments
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.OffenderInfoResult
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.toDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.project.controller.AppointmentDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.project.controller.AppointmentsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.project.controller.ProjectAllocationDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.project.controller.ProjectAllocationsDto
 
 fun ProjectAllocations.toDto() = ProjectAllocationsDto(this.allocations.map { it.toDto() })
 fun ProjectAllocation.toDto() = ProjectAllocationDto(
   this.id,
+  this.projectId,
   this.projectName,
   this.projectCode,
   this.date,
@@ -16,4 +23,18 @@ fun ProjectAllocation.toDto() = ProjectAllocationDto(
   this.numberOfOffendersAllocated,
   this.numberOfOffendersWithOutcomes,
   this.numberOfOffendersWithEA,
+)
+
+fun ProjectAppointments.toDto(
+  offenderInfoResults: List<OffenderInfoResult>,
+) = AppointmentsDto(this.appointments.map { it.toDto(offenderInfoResults) })
+
+fun ProjectAppointment.toDto(
+  offenderInfoResults: List<OffenderInfoResult>,
+) = AppointmentDto(
+  id = this.id,
+  projectName = this.projectName,
+  requirementMinutes = this.requirementMinutes,
+  completedMinutes = this.completedMinutes,
+  offender = offenderInfoResults.first { it.crn == this.crn }.toDto(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/project/service/ProjectService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/project/service/ProjectService.kt
@@ -2,15 +2,29 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.project.service
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.CommunityPaybackAndDeliusClient
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.OffenderService
+import uk.gov.justice.digital.hmpps.communitypaybackapi.project.controller.AppointmentsDto
 import java.time.LocalDate
 
 @Service
 class ProjectService(
   val communityPaybackAndDeliusClient: CommunityPaybackAndDeliusClient,
+  val offenderService: OffenderService,
 ) {
   fun getProjectAllocations(
     startDate: LocalDate,
     endDate: LocalDate,
     teamId: Long,
   ) = communityPaybackAndDeliusClient.getProjectAllocations(startDate, endDate, teamId).toDto()
+
+  fun getAppointments(
+    projectId: Long,
+    date: LocalDate,
+  ): AppointmentsDto {
+    val appointments = communityPaybackAndDeliusClient.getProjectAppointments(projectId, date)
+
+    return appointments.toDto(
+      offenderService.getOffenderInfo(appointments.appointments.map { it.crn }.toSet()),
+    )
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/IntegrationTestBase.kt
@@ -47,7 +47,10 @@ abstract class IntegrationTestBase {
     HmppsAuthMockServer.stubHealthPing(status)
   }
 
-  fun <S : WebTestClient.RequestHeadersSpec<S>> S.addUiAuthHeader(): S = this.headers(
-    setAuthorisation(roles = listOf("ROLE_COMMUNITY_PAYBACK__COMMUNITY_PAYBACK_UI")),
+  fun <S : WebTestClient.RequestHeadersSpec<S>> S.addUiAuthHeader(username: String = "AUTH_ADM"): S = this.headers(
+    setAuthorisation(
+      username = username,
+      roles = listOf("ROLE_COMMUNITY_PAYBACK__COMMUNITY_PAYBACK_UI"),
+    ),
   ) as S
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/ProjectsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/ProjectsIT.kt
@@ -1,13 +1,22 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.integration
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.CaseAccess
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.CaseName
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.CaseSummaries
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.CaseSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAllocation
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAllocations
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAppointment
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAppointments
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.UserAccess
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.controller.OffenderDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.util.bodyAsObject
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.wiremock.CommunityPaybackAndDeliusMockServer
+import uk.gov.justice.digital.hmpps.communitypaybackapi.project.controller.AppointmentsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.project.controller.ProjectAllocationsDto
 import java.time.LocalDate
 import java.time.LocalTime
@@ -64,6 +73,7 @@ class ProjectsIT : IntegrationTestBase() {
           listOf(
             ProjectAllocation(
               id = 1L,
+              projectId = 101L,
               projectName = "Community Garden Maintenance",
               date = LocalDate.of(2025, 9, 1),
               startTime = LocalTime.of(9, 0),
@@ -75,6 +85,7 @@ class ProjectsIT : IntegrationTestBase() {
             ),
             ProjectAllocation(
               id = 2L,
+              projectId = 201L,
               projectName = "Park Cleanup",
               date = LocalDate.of(2025, 9, 8),
               startTime = LocalTime.of(8, 0),
@@ -96,16 +107,16 @@ class ProjectsIT : IntegrationTestBase() {
         .isOk
         .bodyAsObject<ProjectAllocationsDto>()
 
-      Assertions.assertThat(allocations.allocations).hasSize(2)
-      Assertions.assertThat(allocations.allocations[0].id).isEqualTo(1L)
-      Assertions.assertThat(allocations.allocations[0].projectName).isEqualTo("Community Garden Maintenance")
-      Assertions.assertThat(allocations.allocations[0].date).isEqualTo(LocalDate.of(2025, 9, 1))
-      Assertions.assertThat(allocations.allocations[0].startTime).isEqualTo(LocalTime.of(9, 0))
-      Assertions.assertThat(allocations.allocations[0].endTime).isEqualTo(LocalTime.of(17, 0))
-      Assertions.assertThat(allocations.allocations[0].projectCode).isEqualTo("cgm")
-      Assertions.assertThat(allocations.allocations[0].numberOfOffendersAllocated).isEqualTo(0)
-      Assertions.assertThat(allocations.allocations[0].numberOfOffendersWithOutcomes).isEqualTo(1)
-      Assertions.assertThat(allocations.allocations[0].numberOfOffendersWithEA).isEqualTo(2)
+      assertThat(allocations.allocations).hasSize(2)
+      assertThat(allocations.allocations[0].id).isEqualTo(1L)
+      assertThat(allocations.allocations[0].projectName).isEqualTo("Community Garden Maintenance")
+      assertThat(allocations.allocations[0].date).isEqualTo(LocalDate.of(2025, 9, 1))
+      assertThat(allocations.allocations[0].startTime).isEqualTo(LocalTime.of(9, 0))
+      assertThat(allocations.allocations[0].endTime).isEqualTo(LocalTime.of(17, 0))
+      assertThat(allocations.allocations[0].projectCode).isEqualTo("cgm")
+      assertThat(allocations.allocations[0].numberOfOffendersAllocated).isEqualTo(0)
+      assertThat(allocations.allocations[0].numberOfOffendersWithOutcomes).isEqualTo(1)
+      assertThat(allocations.allocations[0].numberOfOffendersWithEA).isEqualTo(2)
     }
 
     @Test
@@ -122,7 +133,164 @@ class ProjectsIT : IntegrationTestBase() {
         .isOk
         .bodyAsObject<ProjectAllocationsDto>()
 
-      Assertions.assertThat(allocations.allocations).isEmpty()
+      assertThat(allocations.allocations).isEmpty()
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /projects/{projectId}/appointments")
+  inner class ProjectAppointmentsEndpoint {
+
+    @Test
+    fun `should return unauthorized if no token`() {
+      webTestClient.get()
+        .uri("/projects/123/appointments?date=2025-03-11")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden if no role`() {
+      webTestClient.get()
+        .uri("/projects/123/appointments?date=2025-03-11")
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `should return forbidden if wrong role`() {
+      webTestClient.get()
+        .uri("/projects/123/appointments?date=2025-03-11")
+        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `should return bad request if missing parameters`() {
+      webTestClient.get()
+        .uri("/projects/123/appointments")
+        .addUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .is4xxClientError
+    }
+
+    @Test
+    fun `should return OK with project appointments`() {
+      CommunityPaybackAndDeliusMockServer.projectAppointments(
+        projectId = 123L,
+        date = LocalDate.of(2025, 1, 9),
+        ProjectAppointments(
+          listOf(
+            ProjectAppointment(
+              id = 1L,
+              projectName = "Community Garden Maintenance",
+              crn = "CRN1",
+              requirementMinutes = 520,
+              completedMinutes = 30,
+            ),
+            ProjectAppointment(
+              id = 2L,
+              projectName = "Park Cleanup",
+              crn = "CRN2",
+              requirementMinutes = 600,
+              completedMinutes = 60,
+            ),
+          ),
+        ),
+      )
+
+      CommunityPaybackAndDeliusMockServer.probationCasesSummaries(
+        crns = listOf("CRN1", "CRN2"),
+        response = CaseSummaries(
+          listOf(
+            CaseSummary(crn = "CRN1", name = CaseName("Jeff", "Jeffity")),
+            CaseSummary(crn = "CRN2", name = CaseName("Jim", "Jimmity")),
+          ),
+        ),
+      )
+
+      val allocations = webTestClient.get()
+        .uri("/projects/123/appointments?date=2025-01-09")
+        .addUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<AppointmentsDto>()
+
+      assertThat(allocations.appointments).hasSize(2)
+      assertThat(allocations.appointments[0].id).isEqualTo(1L)
+      assertThat(allocations.appointments[0].projectName).isEqualTo("Community Garden Maintenance")
+      assertThat(allocations.appointments[0].requirementMinutes).isEqualTo(520)
+      assertThat(allocations.appointments[0].completedMinutes).isEqualTo(30)
+      assertThat(allocations.appointments[0].offender.crn).isEqualTo("CRN1")
+      assertThat(allocations.appointments[0].offender).isInstanceOf(OffenderDto.OffenderFullDto::class.java)
+    }
+
+    @Test
+    fun `Correctly handles limited and not found offenders`() {
+      CommunityPaybackAndDeliusMockServer.projectAppointments(
+        projectId = 123L,
+        date = LocalDate.of(2025, 1, 9),
+        ProjectAppointments(
+          listOf(
+            ProjectAppointment(
+              id = 1L,
+              projectName = "Community Garden Maintenance",
+              crn = "CRN1",
+              requirementMinutes = 520,
+              completedMinutes = 30,
+            ),
+            ProjectAppointment(
+              id = 2L,
+              projectName = "Park Cleanup",
+              crn = "CRN2",
+              requirementMinutes = 600,
+              completedMinutes = 60,
+            ),
+          ),
+        ),
+      )
+
+      CommunityPaybackAndDeliusMockServer.probationCasesSummaries(
+        crns = listOf("CRN1", "CRN2"),
+        response = CaseSummaries(
+          listOf(
+            CaseSummary(crn = "CRN2", name = CaseName("Jim", "Jimmity"), currentExclusion = true),
+          ),
+        ),
+      )
+
+      CommunityPaybackAndDeliusMockServer.usersAccess(
+        username = "USER1",
+        crns = listOf("CRN2"),
+        response = UserAccess(
+          listOf(
+            CaseAccess(crn = "CRN2", userExcluded = true, userRestricted = false),
+          ),
+        ),
+      )
+
+      val allocations = webTestClient.get()
+        .uri("/projects/123/appointments?date=2025-01-09")
+        .addUiAuthHeader(username = "USER1")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<AppointmentsDto>()
+
+      assertThat(allocations.appointments).hasSize(2)
+
+      assertThat(allocations.appointments[0].offender.crn).isEqualTo("CRN1")
+      assertThat(allocations.appointments[0].offender).isInstanceOf(OffenderDto.OffenderNotFoundDto::class.java)
+
+      assertThat(allocations.appointments[1].offender.crn).isEqualTo("CRN2")
+      assertThat(allocations.appointments[1].offender).isInstanceOf(OffenderDto.OffenderLimitedDto::class.java)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/common/service/OffenderInfoResultMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/common/service/OffenderInfoResultMapperTest.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.common.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.CaseName
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.CaseSummary
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.controller.OffenderDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.OffenderInfoResult
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.toDto
+
+class OffenderInfoResultMapperTest {
+
+  @Nested
+  inner class OffenderInfoResultMapper {
+
+    @Test
+    fun `Full`() {
+      val result = OffenderInfoResult.Full(
+        crn = "CRN1",
+        summary = CaseSummary(
+          crn = "CRN1",
+          name = CaseName(
+            forename = "John",
+            surname = "Smith",
+            middleNames = listOf("J", "Jam"),
+          ),
+        ),
+      ).toDto()
+
+      assertThat(result.crn).isEqualTo("CRN1")
+      assertThat(result).isInstanceOf(OffenderDto.OffenderFullDto::class.java)
+      result as OffenderDto.OffenderFullDto
+      assertThat(result.forename).isEqualTo("John")
+      assertThat(result.surname).isEqualTo("Smith")
+      assertThat(result.middleNames).isEqualTo(listOf("J", "Jam"))
+    }
+
+    @Test
+    fun `Limited`() {
+      val result = OffenderInfoResult.Limited("CRN2").toDto()
+
+      assertThat(result.crn).isEqualTo("CRN2")
+      assertThat(result).isInstanceOf(OffenderDto.OffenderLimitedDto::class.java)
+    }
+
+    @Test
+    fun `Not Found`() {
+      val result = OffenderInfoResult.NotFound("CRN3").toDto()
+
+      assertThat(result.crn).isEqualTo("CRN3")
+      assertThat(result).isInstanceOf(OffenderDto.OffenderNotFoundDto::class.java)
+    }
+  }
+}

--- a/tools/cp-stack/wiremock/mappings/proxies/community-payback-and-delius-proxy.json
+++ b/tools/cp-stack/wiremock/mappings/proxies/community-payback-and-delius-proxy.json
@@ -1,7 +1,6 @@
 {
   "priority": 100,
   "request": {
-    "method": "GET",
     "urlPattern": "/community-payback-and-delius-proxy/.*"
   },
   "response": {


### PR DESCRIPTION
This commit adds an endpoint to retrieve appointments for a project on a given date.

To support this, the following is also included in this commit:

* Add mappers to convert offender results into DTO equivalents (i.e. Full, Limited, Not Found)
* Tidy up the `MockCommunityPaybackAndDeliusController` to move towards using an in-memory repository to ensure interrelated responses are logically consistent
* Reconfigure wiremock proxy to also support POST requests
* Add configuration to ensure OpenApi correctly generated discriminators for the OffenderDto types