### PR TITLE
CPB-92 - Return 400 if request param is missing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CommunityPaybackApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CommunityPaybackApiExceptionHandler.kt
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.AccessDeniedException
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.servlet.resource.NoResourceFoundException
@@ -17,7 +18,12 @@ import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 @RestControllerAdvice
 class CommunityPaybackApiExceptionHandler {
   @ExceptionHandler(ValidationException::class)
-  fun handleValidationException(e: ValidationException): ResponseEntity<ErrorResponse> = ResponseEntity
+  fun handleValidationException(e: ValidationException) = validationError(e)
+
+  @ExceptionHandler(MissingServletRequestParameterException::class)
+  fun handleMissingServletRequestParameterException(e: MissingServletRequestParameterException) = validationError(e)
+
+  private fun validationError(e: Exception) = ResponseEntity
     .status(BAD_REQUEST)
     .body(
       ErrorResponse(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/ProjectsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/ProjectsIT.kt
@@ -54,7 +54,7 @@ class ProjectsIT : IntegrationTestBase() {
         .addUiAuthHeader()
         .exchange()
         .expectStatus()
-        .is5xxServerError
+        .is4xxClientError
     }
 
     @Test


### PR DESCRIPTION
Add exception handling logic to ensure a 400 is returned if a request parameter is missing (previously it was returning a 500)