### PR TITLE
Add OffenderDto discriminator

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/dto/OffenderDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/dto/OffenderDto.kt
@@ -2,15 +2,29 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.common.dto
 
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import io.swagger.v3.oas.annotations.media.DiscriminatorMapping
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.dto.OffenderDto.OffenderFullDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.dto.OffenderDto.OffenderLimitedDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.dto.OffenderDto.OffenderNotFoundDto
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   property = "objectType",
 )
 @JsonSubTypes(
-  JsonSubTypes.Type(OffenderDto.OffenderNotFoundDto::class, name = "Not_Found"),
-  JsonSubTypes.Type(OffenderDto.OffenderLimitedDto::class, name = "Limited"),
-  JsonSubTypes.Type(OffenderDto.OffenderFullDto::class, name = "Full"),
+  JsonSubTypes.Type(OffenderNotFoundDto::class, name = "Not_Found"),
+  JsonSubTypes.Type(OffenderLimitedDto::class, name = "Limited"),
+  JsonSubTypes.Type(OffenderFullDto::class, name = "Full"),
+)
+@Schema(
+  requiredMode = Schema.RequiredMode.REQUIRED,
+  discriminatorProperty = "objectType",
+  discriminatorMapping = [
+    DiscriminatorMapping(value = "Not_Found", schema = OffenderNotFoundDto::class),
+    DiscriminatorMapping(value = "Limited", schema = OffenderLimitedDto::class),
+    DiscriminatorMapping(value = "Full", schema = OffenderFullDto::class),
+  ],
 )
 sealed interface OffenderDto {
   val crn: String


### PR DESCRIPTION
Explicitly define discriminator information for `OffenderDto`. This needs adding explicitly due to [this issue](https://github.com/swagger-api/swagger-core/issues/3411).

Whilst ideally we’d add `one-of` definitions in the `@Schema` annotation, this then causes issues in the type script generator, [detailed here](https://github.com/ferdikoomen/openapi-typescript-codegen/issues/1614).