### PR TITLE
Add OpenAPI groups, optionally excluding sqs admin

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/OpenApiConfiguration.kt
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.models.responses.ApiResponse
 import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.servers.Server
 import org.springdoc.core.customizers.OpenApiCustomizer
+import org.springdoc.core.models.GroupedOpenApi
 import org.springframework.boot.info.BuildProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -47,6 +48,21 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
         SecurityScheme().addBearerJwtRequirement("ROLE_COMMUNITY_PAYBACK__COMMUNITY_PAYBACK_UI"),
       ),
     )
+
+  @Bean
+  fun allEndpoints(): GroupedOpenApi = GroupedOpenApi.builder()
+    .group("All")
+    .displayName("All Endpoints")
+    .addOpenApiCustomizer(errorResponsesCustomizer())
+    .build()
+
+  @Bean
+  fun forCommunityPaybackUI(): GroupedOpenApi = GroupedOpenApi.builder()
+    .group("ForCommunityPaybackUI")
+    .displayName("For Community Payback UI")
+    .pathsToExclude("/queue-admin/**")
+    .addOpenApiCustomizer(errorResponsesCustomizer())
+    .build()
 
   private fun SecurityScheme.addBearerJwtRequirement(role: String): SecurityScheme = type(SecurityScheme.Type.HTTP)
     .scheme("bearer")


### PR DESCRIPTION
If the API is configured to read from one or more queues, the SQS admin endpoints are enabled (`/queue-admin`).

This commit adds a group that can be used by the UI type generation script to retrieve an API that excludes these endpoints, as they will not be called by the UI.