### PR TITLE
Add JPA Gradle Plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,14 +4,18 @@ import java.net.Socket
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.0.2"
   kotlin("plugin.spring") version "2.2.20"
+  kotlin("plugin.jpa") version "2.2.20"
   id("io.gitlab.arturbosch.detekt") version "1.23.8"
   jacoco
   id("io.sentry.jvm.gradle") version "5.11.0"
 }
 
 configurations {
-  testImplementation { exclude(group = "org.junit.vintage") }
-  testImplementation { exclude(group = "org.mockito") }
+  testImplementation {
+    exclude(group = "org.junit.vintage")
+    exclude(group = "org.mockito")
+    exclude(group = "org.mockito.kotlin")
+  }
 }
 
 configurations.matching { it.name == "detekt" }.all {

--- a/src/test/resources/application-integrationtest.yml
+++ b/src/test/resources/application-integrationtest.yml
@@ -5,6 +5,10 @@ management.endpoint:
   health.cache.time-to-live: 0
   info.cache.time-to-live: 0
 
+spring:
+  jpa:
+    show-sql: true
+
 community-payback:
   request-logging-enabled: true
 


### PR DESCRIPTION
This enables persisted data classes as entities, as it will ensure a default constructor exists.

This commit also enables hibernate SQL logging during tests