### PR TITLE
Add `clear-databases` option to cp-stack

### DIFF
--- a/tools/cp-stack/README.md
+++ b/tools/cp-stack/README.md
@@ -48,7 +48,9 @@ If using the 'local' options, the UI and/or API will be run directly from your c
 
 To stop the stack, use
 
-``cp-stack stop``
+``cp-stack stop [--clear-databases]``
+
+The API database will be retained over stop/starts of the stack, unless `--clear-databases` is specified when stopping the stack
 
 ## Service Ports
 

--- a/tools/cp-stack/bin/cp-stack
+++ b/tools/cp-stack/bin/cp-stack
@@ -11,18 +11,20 @@ pre_reqs() {
   "$(dirname "$0")/utils/launch-docker.sh"
 }
 
-command=$1 ; shift
+command=$1
 
 if [ "$command" = "start" ]; then
   pre_reqs
+  shift
   "$(dirname "$0")/start-server" "$@"
 elif [ "$command" = "stop" ]; then
   pre_reqs
+  shift
   "$(dirname "$0")/stop-server" "$@"
 else
-  echo "Usage: ap-tools <command>"
+  echo "Usage: cp-stack <command>"
   echo "Commands:"
-  echo "  server start [--local-ui] [--local-api]"
-  echo "  server stop"
+  echo "  start [--local-ui] [--local-api]"
+  echo "  stop [--clear-databases]"
   exit 1
 fi

--- a/tools/cp-stack/bin/stop-server
+++ b/tools/cp-stack/bin/stop-server
@@ -7,6 +7,18 @@ set -o pipefail
 cd "$(dirname "$0")"
 script_dir="$(pwd)"
 
+do_clear_databases=0
+
+while [ "$1" != "" ];
+do
+   case $1 in
+    --clear-databases)
+      do_clear_databases=1
+      ;;
+  esac
+  shift
+done
+
 touch "$script_dir/../.env.api"
 touch "$script_dir/../.env.ui"
 
@@ -17,3 +29,12 @@ tilt down -f "$script_dir/../tiltfile"
 # This must run cleanly (not forced) to kill any local resources
 # started by the original tilt command
 killall tilt || true
+
+if [ $do_clear_databases -gt 0 ]; then
+  sleep 3
+
+  echo "Removing API database volume"
+  rootpath="$script_dir/../"
+  # detach volumes, including the composed managed API database volume
+  docker compose -f "$rootpath/compose.yml" down -v
+fi


### PR DESCRIPTION
This will clear the API database when stopping the stack.

This commit also fixes the help text when no arguments are provided