### PR TITLE
CPB-104 - Publish Domain Event on Appointment Update

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -13,6 +13,8 @@ generic-service:
     SENTRY_ENVIRONMENT: dev
     SPRING_PROFILES_ACTIVE: dev
 
+    COMMUNITY_PAYBACK_URL_TEMPLATES_DOMAIN_EVENT_DETAIL_APPOINTMENT_OUTCOME: https://community-payback-api-dev.hmpps.service.justice.gov.uk/events/appointment_outcome
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -13,6 +13,8 @@ generic-service:
     SENTRY_ENVIRONMENT: preprod
     SPRING_PROFILES_ACTIVE: preprod
 
+    COMMUNITY_PAYBACK_URL_TEMPLATES_DOMAIN_EVENT_DETAIL_APPOINTMENT_OUTCOME: https://community-payback-api-preprod.hmpps.service.justice.gov.uk/events/appointment_outcome
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -10,6 +10,8 @@ generic-service:
     SENTRY_ENVIRONMENT: prod
     SPRING_PROFILES_ACTIVE: prod
 
+    COMMUNITY_PAYBACK_URL_TEMPLATES_DOMAIN_EVENT_DETAIL_APPOINTMENT_OUTCOME: https://community-payback-api.hmpps.service.justice.gov.uk/events/appointment_outcome
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -14,6 +14,8 @@ generic-service:
     SENTRY_ENVIRONMENT: test
     SPRING_PROFILES_ACTIVE: test
 
+    COMMUNITY_PAYBACK_URL_TEMPLATES_DOMAIN_EVENT_DETAIL_APPOINTMENT_OUTCOME: https://community-payback-api-test.hmpps.service.justice.gov.uk/events/appointment_outcome
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/appointment/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/appointment/service/AppointmentService.kt
@@ -10,11 +10,15 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.appointment.entity.Appoi
 import uk.gov.justice.digital.hmpps.communitypaybackapi.appointment.entity.AppointmentOutcomeEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.appointment.entity.Behaviour
 import uk.gov.justice.digital.hmpps.communitypaybackapi.appointment.entity.WorkQuality
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.AdditionalInformationType
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.DomainEventService
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.DomainEventType
 import java.util.UUID
 
 @Service
 class AppointmentService(
   val appointmentOutcomeEntityRepository: AppointmentOutcomeEntityRepository,
+  val domainEventService: DomainEventService,
 ) {
   private companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -41,7 +45,13 @@ class AppointmentService(
       return
     }
 
-    appointmentOutcomeEntityRepository.save(proposedEntity)
+    val persistedEntity = appointmentOutcomeEntityRepository.save(proposedEntity)
+
+    domainEventService.publish(
+      id = persistedEntity.id,
+      type = DomainEventType.APPOINTMENT_OUTCOME,
+      additionalInformation = mapOf(AdditionalInformationType.APPOINTMENT_ID to deliusId),
+    )
   }
 
   fun toEntity(deliusId: Long, outcome: UpdateAppointmentOutcomeDto) = AppointmentOutcomeEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/service/DomainEventService.kt
@@ -1,0 +1,80 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.common.service
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.ApplicationEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.annotation.Configuration
+import org.springframework.stereotype.Service
+import org.springframework.transaction.event.TransactionalEventListener
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.internal.DomainEventPublisher
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.internal.HmppsAdditionalInformation
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.internal.HmppsDomainEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.internal.UrlTemplate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Service
+open class DomainEventService(
+  private val applicationEventPublisher: ApplicationEventPublisher,
+  private val domainEventUrlConfig: DomainEventUrlConfig,
+  private val domainEventPublisher: DomainEventPublisher,
+) {
+
+  fun publish(
+    id: UUID,
+    type: DomainEventType,
+    additionalInformation: Map<AdditionalInformationType, Any> = emptyMap(),
+  ) {
+    applicationEventPublisher.publishEvent(
+      PublishDomainEventCommand(
+        HmppsDomainEvent(
+          eventType = type.eventType,
+          version = 1,
+          description = type.description,
+          detailUrl = resolveUrl(id, type),
+          occurredAt = OffsetDateTime.now(),
+          additionalInformation = additionalInformation.toHmppsAdditionalInformation(),
+        ),
+      ),
+    )
+  }
+
+  @TransactionalEventListener
+  fun publishDomainEventCommandListener(command: PublishDomainEventCommand) {
+    domainEventPublisher.publish(command.domainEvent)
+  }
+
+  private fun resolveUrl(id: UUID, type: DomainEventType): String {
+    val key = type.name.lowercase()
+    val urlTemplate = domainEventUrlConfig.domainEventDetail[key] ?: error("Could not find domain event url with key '$key'")
+    return urlTemplate.resolve(mapOf("id" to id.toString()))
+  }
+
+  private fun Map<AdditionalInformationType, Any>.toHmppsAdditionalInformation() = if (this.isEmpty()) {
+    null
+  } else {
+    HmppsAdditionalInformation(mapKeys { it.key.name })
+  }
+
+  data class PublishDomainEventCommand(val domainEvent: HmppsDomainEvent) : ApplicationEvent(domainEvent)
+}
+
+enum class DomainEventType(
+  val eventType: String,
+  val description: String,
+) {
+  APPOINTMENT_OUTCOME(
+    eventType = "community-payback.appointment.outcome",
+    description = "A community payback appointment has been updated with an outcome",
+  ),
+}
+
+enum class AdditionalInformationType {
+  APPOINTMENT_ID,
+}
+
+@Configuration
+@ConfigurationProperties(prefix = "community-payback.url-templates")
+class DomainEventUrlConfig {
+  lateinit var domainEventDetail: Map<String, UrlTemplate>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/service/internal/DomainEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/service/internal/DomainEventPublisher.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.communitypaybackapi.common
+package uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.internal
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Service
@@ -34,7 +34,7 @@ data class HmppsDomainEvent(
   val personReference: HmmpsEventPersonReferences? = null,
 )
 
-data class HmppsAdditionalInformation(val map: MutableMap<String, Any?> = mutableMapOf())
+data class HmppsAdditionalInformation(val map: Map<String, Any?> = mapOf())
 
 data class HmmpsEventPersonReferences(
   val identifiers: List<HmmpsEventPersonReference>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/service/internal/UrlTemplate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/service/internal/UrlTemplate.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.internal
+
+import org.springframework.core.convert.TypeDescriptor
+import org.springframework.core.convert.converter.GenericConverter
+import org.springframework.stereotype.Component
+
+class UrlTemplate(val template: String) {
+  fun resolve(args: Map<String, String>) = args.entries.fold(template) { acc, (key, value) -> acc.replace("#$key", value) }
+}
+
+@Component
+class UrlTemplateConverter : GenericConverter {
+  override fun getConvertibleTypes(): MutableSet<GenericConverter.ConvertiblePair> = mutableSetOf(GenericConverter.ConvertiblePair(String::class.java, UrlTemplate::class.java))
+
+  override fun convert(source: Any?, sourceType: TypeDescriptor, targetType: TypeDescriptor): Any {
+    val input = source as String
+    return UrlTemplate(input)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/architecture/ArchitectureTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/architecture/ArchitectureTest.kt
@@ -13,10 +13,11 @@ class ArchitectureTest {
         val controller = Layer("controller", "..communitypaybackapi..controller..")
         val dto = Layer("dto", "..communitypaybackapi..dto..")
         val service = Layer("service", "..communitypaybackapi..service..")
+        val serviceInternal = Layer("service.internal", "..communitypaybackapi..service.internal..")
         val client = Layer("client", "..communitypaybackapi....client..")
 
         dto.dependsOnNothing()
-        controller.doesNotDependOn(client)
+        controller.doesNotDependOn(client, serviceInternal)
         service.doesNotDependOn(controller)
         client.dependsOnNothing()
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/util/DomainEventListener.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/util/DomainEventListener.kt
@@ -6,10 +6,9 @@ import org.awaitility.Awaitility.await
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.test.context.event.annotation.BeforeTestMethod
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.HmppsDomainEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.internal.HmppsDomainEvent
 import java.util.concurrent.TimeUnit
 import kotlin.collections.first
-import kotlin.collections.firstOrNull
 import kotlin.jvm.java
 
 @Service
@@ -30,21 +29,29 @@ class DomainEventListener(private val objectMapper: ObjectMapper) {
   }
 
   @BeforeTestMethod
-  fun clearMessages() = messages.clear()
+  fun clearMessages() = synchronized(messages) {
+    messages.clear()
+  }
 
   fun blockForDomainEventOfType(eventType: String): HmppsDomainEvent {
     await()
       .atMost(1, TimeUnit.SECONDS)
-      .until { contains(eventType) }
+      .until { containsCount(eventType, 1) }
 
     synchronized(messages) {
       return messages.first { it.eventType == eventType }
     }
   }
 
-  private fun contains(eventType: String): Boolean {
+  fun assertEventCount(eventType: String, count: Int) {
+    await()
+      .atMost(1, TimeUnit.SECONDS)
+      .until { containsCount(eventType, count) }
+  }
+
+  private fun containsCount(eventType: String, count: Int): Boolean {
     synchronized(messages) {
-      return messages.firstOrNull { it.eventType == eventType } != null
+      return messages.filter { it.eventType == eventType }.size == count
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/appointment/service/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/appointment/service/AppointmentServiceTest.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.appointment.service
 
+import io.mockk.Runs
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.just
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -20,6 +22,9 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.appointment.entity.Appoi
 import uk.gov.justice.digital.hmpps.communitypaybackapi.appointment.entity.Behaviour
 import uk.gov.justice.digital.hmpps.communitypaybackapi.appointment.entity.WorkQuality
 import uk.gov.justice.digital.hmpps.communitypaybackapi.appointment.service.AppointmentService
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.AdditionalInformationType
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.DomainEventService
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.DomainEventType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.valid
 import java.time.LocalDate
 import java.time.LocalTime
@@ -31,6 +36,9 @@ class AppointmentServiceTest {
   @MockK
   lateinit var appointmentOutcomeEntityRepository: AppointmentOutcomeEntityRepository
 
+  @MockK
+  lateinit var domainEventService: DomainEventService
+
   @InjectMockKs
   private lateinit var service: AppointmentService
 
@@ -38,12 +46,14 @@ class AppointmentServiceTest {
   inner class UpdateAppointmentsOutcome {
 
     @Test
-    fun `if there's no existing entries for the delius appointment ids, persist new entries`() {
+    fun `if there's no existing entries for the delius appointment ids, persist new entries and raise domain events`() {
       every { appointmentOutcomeEntityRepository.findTopByAppointmentDeliusIdOrderByUpdatedAtDesc(1L) } returns null
       every { appointmentOutcomeEntityRepository.findTopByAppointmentDeliusIdOrderByUpdatedAtDesc(2L) } returns null
 
       val entityCaptor = mutableListOf<AppointmentOutcomeEntity>()
       every { appointmentOutcomeEntityRepository.save(capture(entityCaptor)) } returnsArgument 0
+
+      every { domainEventService.publish(any(), any(), any()) } just Runs
 
       service.updateAppointmentsOutcome(
         UpdateAppointmentOutcomesDto(
@@ -91,10 +101,26 @@ class AppointmentServiceTest {
       assertThat(firstEntity.behaviour).isEqualTo(Behaviour.UNSATISFACTORY)
       assertThat(firstEntity.enforcementActionDeliusId).isEqualTo(12L)
       assertThat(firstEntity.respondBy).isEqualTo(LocalDate.of(2026, 8, 10))
+
+      verify {
+        domainEventService.publish(
+          id = entityCaptor[0].id,
+          type = DomainEventType.APPOINTMENT_OUTCOME,
+          additionalInformation = mapOf(AdditionalInformationType.APPOINTMENT_ID to 1L),
+        )
+      }
+
+      verify {
+        domainEventService.publish(
+          id = entityCaptor[1].id,
+          type = DomainEventType.APPOINTMENT_OUTCOME,
+          additionalInformation = mapOf(AdditionalInformationType.APPOINTMENT_ID to 2L),
+        )
+      }
     }
 
     @Test
-    fun `if there's an existing entry for the delius appointment id but it's not logically identical, persist new entry`() {
+    fun `if there's an existing entry for the delius appointment id and it's logically identical, do not persist a new entry`() {
       val updateAppointmentDto = UpdateAppointmentOutcomesDto.valid(1L)
 
       val existingIdenticalEntity = service.toEntity(1L, updateAppointmentDto.outcomeData)
@@ -108,7 +134,7 @@ class AppointmentServiceTest {
     }
 
     @Test
-    fun `if there's an existing entry for the delius appointment id and it's logically identical, do not persist a new entry`() {
+    fun `if there's an existing entry for the delius appointment id but it's not logically identical, persist new entry and raise domain event`() {
       val updateAppointmentDto = UpdateAppointmentOutcomesDto.valid(1L)
 
       val existingAlmostIdenticalEntity = service.toEntity(1L, updateAppointmentDto.outcomeData)
@@ -121,9 +147,12 @@ class AppointmentServiceTest {
         appointmentOutcomeEntityRepository.save(any())
       } returnsArgument 0
 
+      every { domainEventService.publish(any(), any(), any()) } just Runs
+
       service.updateAppointmentsOutcome(updateAppointmentDto)
 
       verify { appointmentOutcomeEntityRepository.save(any()) }
+      verify { domainEventService.publish(any(), DomainEventType.APPOINTMENT_OUTCOME, any()) }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/appointment/service/DomainEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/appointment/service/DomainEventServiceTest.kt
@@ -1,0 +1,121 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.appointment.service
+
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.just
+import io.mockk.slot
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.context.ApplicationEventPublisher
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.AdditionalInformationType
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.DomainEventService
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.DomainEventService.PublishDomainEventCommand
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.DomainEventType
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.DomainEventUrlConfig
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.internal.DomainEventPublisher
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.internal.HmppsDomainEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.internal.UrlTemplate
+import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
+import java.util.Map.entry
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class DomainEventServiceTest {
+
+  @MockK
+  lateinit var applicationEventPublisher: ApplicationEventPublisher
+
+  @MockK
+  lateinit var domainEventUrlConfig: DomainEventUrlConfig
+
+  @MockK
+  lateinit var domainEventPublisher: DomainEventPublisher
+
+  @InjectMockKs
+  private lateinit var service: DomainEventService
+
+  private companion object {
+    val id: UUID = UUID.randomUUID()
+  }
+
+  @Nested
+  inner class Publish {
+
+    @Test
+    fun `enqueues a spring application event containing a fully populated HmppsDomainEvent`() {
+      val commandEventCaptor = slot<PublishDomainEventCommand>()
+      every { applicationEventPublisher.publishEvent(capture(commandEventCaptor)) } just Runs
+
+      every { domainEventUrlConfig.domainEventDetail } returns mapOf(
+        "appointment_outcome" to UrlTemplate("http://somepath/#id"),
+      )
+
+      service.publish(
+        id = id,
+        type = DomainEventType.APPOINTMENT_OUTCOME,
+        additionalInformation = mapOf(AdditionalInformationType.APPOINTMENT_ID to "the appointment id"),
+      )
+
+      val publishDomainEventCommand = commandEventCaptor.captured
+      assertThat(publishDomainEventCommand.domainEvent.eventType).isEqualTo("community-payback.appointment.outcome")
+      assertThat(publishDomainEventCommand.domainEvent.detailUrl).isEqualTo("http://somepath/$id")
+      assertThat(publishDomainEventCommand.domainEvent.description).isEqualTo("A community payback appointment has been updated with an outcome")
+      assertThat(publishDomainEventCommand.domainEvent.version).isEqualTo(1)
+      assertThat(publishDomainEventCommand.domainEvent.occurredAt).isCloseTo(OffsetDateTime.now(), within(1, ChronoUnit.MINUTES))
+      assertThat(publishDomainEventCommand.domainEvent.additionalInformation!!.map).containsExactly(entry("APPOINTMENT_ID", "the appointment id"))
+      assertThat(publishDomainEventCommand.domainEvent.personReference).isNull()
+    }
+
+    @Test
+    fun `dont populate additional information if no values`() {
+      val commandEventCaptor = slot<PublishDomainEventCommand>()
+      every { applicationEventPublisher.publishEvent(capture(commandEventCaptor)) } just Runs
+
+      every { domainEventUrlConfig.domainEventDetail } returns mapOf(
+        "appointment_outcome" to UrlTemplate("http://somepath/#id"),
+      )
+
+      service.publish(
+        id = id,
+        type = DomainEventType.APPOINTMENT_OUTCOME,
+        additionalInformation = emptyMap(),
+      )
+
+      val publishDomainEventCommand = commandEventCaptor.captured
+      assertThat(publishDomainEventCommand.domainEvent.additionalInformation).isNull()
+    }
+  }
+
+  @Nested
+  inner class PublishDomainEventCommandListener {
+
+    @Test
+    fun `pass event through to domain event publisher`() {
+      val domainEvent = HmppsDomainEvent(
+        eventType = "eventType",
+        version = 1,
+        description = "the description",
+        detailUrl = "theUrl",
+        occurredAt = OffsetDateTime.now(),
+      )
+
+      every { domainEventPublisher.publish(domainEvent) } just Runs
+
+      service.publishDomainEventCommandListener(
+        PublishDomainEventCommand(
+          domainEvent,
+        ),
+      )
+
+      verify { domainEventPublisher.publish(domainEvent) }
+    }
+  }
+}

--- a/src/test/resources/application-integrationtest.yml
+++ b/src/test/resources/application-integrationtest.yml
@@ -10,8 +10,8 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        format_sql: true
-        generate_statistics: true
+        #format_sql: true
+        #generate_statistics: true
 
   datasource:
     url: 'jdbc:postgresql://localhost:5432/community_payback'
@@ -20,6 +20,9 @@ spring:
 
 community-payback:
   request-logging-enabled: true
+  url-templates:
+    domain-event-detail:
+      appointment_outcome: http://localhost:8080/events/community-payback-appointment-outcome/#id
 
 hmpps-auth:
   url: "http://localhost:${wiremock.server.port}/auth"


### PR DESCRIPTION
This commit adds a `DomainEventService` to build a thin domain event for a given Domain Event Type, and delegates to the `DomainEventPublisher` to publish the domain event. If there is a transaction the publisher will wait until the transaction commits before publishing the domain event.

The `DomainEventService` is then used to raise a domain event whenever an appointment is updated.

The endpoint used to retrieve domain event details will be added in a subsequent commit.

This satisfies the section outlined in purple in the image below

<img width="1035" height="555" alt="Screenshot 2025-09-22 at 10 43 03" src="https://github.com/user-attachments/assets/c69233d8-998d-4cf5-a2f4-32738bbb4427" />