### PR TITLE
Ensure entities doesn’t use data class `toString`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/appointment/entity/AppointmentOutcomeEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/appointment/entity/AppointmentOutcomeEntity.kt
@@ -59,6 +59,8 @@ data class AppointmentOutcomeEntity(
   }
 
   override fun hashCode(): Int = id.hashCode()
+
+  override fun toString(): String = "AppointmentOutcomeEntity(id=$id, appointmentDeliusId='$appointmentDeliusId')"
 }
 
 enum class WorkQuality {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/reference/entity/ContactOutcomeEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/reference/entity/ContactOutcomeEntity.kt
@@ -28,4 +28,6 @@ data class ContactOutcomeEntity(
   }
 
   override fun hashCode(): Int = id.hashCode()
+
+  override fun toString(): String = "ContactOutcomeEntity(id=$id, code='$code', name='$name')"
 }


### PR DESCRIPTION
Best practice is to not use a data class’ toString implementation as it can lead to unneccessary lazy loading