### PR TITLE
Disable oss index for dependency check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,10 @@ detekt {
   }
 }
 
+dependencyCheck {
+  analyzers.ossIndex.enabled = false
+}
+
 tasks {
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21


### PR DESCRIPTION
[OSS Index provides an additional vulnerability database](https://dependency-check.github.io/DependencyCheck/analyzers/oss-index-analyzer.html). An auth key is now requried for this database, which we don’t currently have configured. Following guidance on #hmpps_dev, this commit disables this analyser to ensure dependency check runs continue to work.