### PR TITLE
CPB-110 - Populate CRN in update appointment domain event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/appointment/controller/AppointmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/appointment/controller/AppointmentController.kt
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import uk.gov.justice.digital.hmpps.communitypaybackapi.appointment.dto.UpdateAppointmentOutcomesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.appointment.service.AppointmentService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.CommunityPaybackController
+import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 @CommunityPaybackController
 class AppointmentController(
@@ -29,6 +30,16 @@ class AppointmentController(
       ApiResponse(
         responseCode = "200",
         description = "Appointment update is (or has already) been recorded",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid appointment ID(s) provided",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
       ),
     ],
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/client/CommunityPaybackAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/client/CommunityPaybackAndDeliusClient.kt
@@ -23,6 +23,11 @@ interface CommunityPaybackAndDeliusClient {
     @RequestParam teamId: Long,
   ): ProjectAllocations
 
+  @GetExchange("/appointments/{appointmentId}")
+  fun getProjectAppointment(
+    @PathVariable appointmentId: Long,
+  ): ProjectAppointment
+
   @GetExchange("/projects/{projectId}/appointments")
   fun getProjectAppointments(
     @PathVariable projectId: Long,
@@ -94,7 +99,9 @@ data class ProjectAppointment(
   val crn: String,
   val requirementMinutes: Int,
   val completedMinutes: Int,
-)
+) {
+  companion object
+}
 
 data class ProjectTypes(
   val projectTypes: List<ProjectType>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/dto/BadRequestException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/dto/BadRequestException.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.common.dto
+
+class BadRequestException(override val message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/service/DomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/service/DomainEventService.kt
@@ -7,6 +7,8 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Service
 import org.springframework.transaction.event.TransactionalEventListener
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.internal.DomainEventPublisher
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.internal.HmmpsEventPersonReference
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.internal.HmmpsEventPersonReferences
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.internal.HmppsAdditionalInformation
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.internal.HmppsDomainEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.service.internal.UrlTemplate
@@ -24,6 +26,7 @@ open class DomainEventService(
     id: UUID,
     type: DomainEventType,
     additionalInformation: Map<AdditionalInformationType, Any> = emptyMap(),
+    personReferences: Map<PersonReferenceType, String> = emptyMap(),
   ) {
     applicationEventPublisher.publishEvent(
       PublishDomainEventCommand(
@@ -34,6 +37,7 @@ open class DomainEventService(
           detailUrl = resolveUrl(id, type),
           occurredAt = OffsetDateTime.now(),
           additionalInformation = additionalInformation.toHmppsAdditionalInformation(),
+          personReference = personReferences.toHmppsPersonReference(),
         ),
       ),
     )
@@ -56,6 +60,12 @@ open class DomainEventService(
     HmppsAdditionalInformation(mapKeys { it.key.name })
   }
 
+  private fun Map<PersonReferenceType, String>.toHmppsPersonReference() = if (this.isEmpty()) {
+    null
+  } else {
+    HmmpsEventPersonReferences(map { HmmpsEventPersonReference(it.key.name, it.value) })
+  }
+
   data class PublishDomainEventCommand(val domainEvent: HmppsDomainEvent) : ApplicationEvent(domainEvent)
 }
 
@@ -71,6 +81,10 @@ enum class DomainEventType(
 
 enum class AdditionalInformationType {
   APPOINTMENT_ID,
+}
+
+enum class PersonReferenceType {
+  CRN,
 }
 
 @Configuration

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CommunityPaybackApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CommunityPaybackApiExceptionHandler.kt
@@ -13,17 +13,18 @@ import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.dto.BadRequestException
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 @RestControllerAdvice
 class CommunityPaybackApiExceptionHandler {
-  @ExceptionHandler(ValidationException::class)
-  fun handleValidationException(e: ValidationException) = validationError(e)
 
-  @ExceptionHandler(MissingServletRequestParameterException::class)
-  fun handleMissingServletRequestParameterException(e: MissingServletRequestParameterException) = validationError(e)
-
-  private fun validationError(e: Exception) = ResponseEntity
+  @ExceptionHandler(
+    ValidationException::class,
+    MissingServletRequestParameterException::class,
+    BadRequestException::class,
+  )
+  fun validationError(e: Exception): ResponseEntity<ErrorResponse> = ResponseEntity
     .status(BAD_REQUEST)
     .body(
       ErrorResponse(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/ProjectAppointmentFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/ProjectAppointmentFactory.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.factory
+
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAppointment
+
+fun ProjectAppointment.Companion.valid() = ProjectAppointment(
+  id = Long.random(),
+  projectName = String.random(),
+  crn = String.random(),
+  requirementMinutes = Int.random(0, 100),
+  completedMinutes = Int.random(0, 100),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/MockCommunityPaybackAndDeliusIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/MockCommunityPaybackAndDeliusIT.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.CaseSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAllocations
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAppointments
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProviderSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProviderTeamSummaries
@@ -104,6 +105,38 @@ class MockCommunityPaybackAndDeliusIT : IntegrationTestBase() {
   }
 
   @Nested
+  @DisplayName("GET /mocks/community-payback-and-delius/appointments/{appointmentId}")
+  inner class GetProjectAppointment {
+
+    @Test
+    fun `no corresponding appointment, return 404`() {
+      webTestClient.get()
+        .uri("/mocks/community-payback-and-delius/appointments/123456789")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @Test
+    fun `return existing appointment`() {
+      val response = webTestClient.get()
+        .uri("/mocks/community-payback-and-delius/appointments/${MockCommunityPaybackAndDeliusRepository.APPOINTMENT2_ID}")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<ProjectAppointment>()
+
+      assertThat(response.id).isEqualTo(MockCommunityPaybackAndDeliusRepository.APPOINTMENT2_ID)
+      assertThat(response.crn).isEqualTo(MockCommunityPaybackAndDeliusRepository.CRN2)
+      assertThat(response.projectName).isEqualTo("Community Garden")
+      assertThat(response.requirementMinutes).isEqualTo(300)
+      assertThat(response.completedMinutes).isEqualTo(30)
+    }
+  }
+
+  @Nested
   @DisplayName("GET /mocks/community-payback-and-delius/projects/{projectId}/appointments")
   inner class GetProjectAppointments {
 
@@ -132,13 +165,13 @@ class MockCommunityPaybackAndDeliusIT : IntegrationTestBase() {
 
       assertThat(response.appointments).hasSize(2)
 
-      assertThat(response.appointments[0].id).isEqualTo(1L)
+      assertThat(response.appointments[0].id).isEqualTo(MockCommunityPaybackAndDeliusRepository.APPOINTMENT1_ID)
       assertThat(response.appointments[0].crn).isEqualTo(MockCommunityPaybackAndDeliusRepository.CRN1)
       assertThat(response.appointments[0].projectName).isEqualTo("Community Garden")
       assertThat(response.appointments[0].requirementMinutes).isEqualTo(600)
       assertThat(response.appointments[0].completedMinutes).isEqualTo(60)
 
-      assertThat(response.appointments[1].id).isEqualTo(2L)
+      assertThat(response.appointments[1].id).isEqualTo(MockCommunityPaybackAndDeliusRepository.APPOINTMENT2_ID)
       assertThat(response.appointments[1].crn).isEqualTo(MockCommunityPaybackAndDeliusRepository.CRN2)
       assertThat(response.appointments[1].projectName).isEqualTo("Community Garden")
       assertThat(response.appointments[1].requirementMinutes).isEqualTo(300)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
@@ -10,6 +10,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.CaseSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAllocations
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProjectAppointments
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProviderSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.client.ProviderTeamSummaries
@@ -58,6 +59,29 @@ object CommunityPaybackAndDeliusMockServer {
           aResponse()
             .withHeader("Content-Type", "application/json")
             .withBody(objectMapper.writeValueAsString(projectAllocations)),
+        ),
+    )
+  }
+
+  fun projectAppointmentNotFound(appointmentId: Long) {
+    WireMock.stubFor(
+      get("/community-payback-and-delius/appointments/$appointmentId")
+        .willReturn(
+          aResponse().withStatus(404),
+        ),
+    )
+  }
+
+  fun projectAppointment(
+    appointmentId: Long,
+    projectAppointment: ProjectAppointment,
+  ) {
+    WireMock.stubFor(
+      get("/community-payback-and-delius/appointments/$appointmentId")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(objectMapper.writeValueAsString(projectAppointment)),
         ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/util/WebClientResponseExceptionFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/util/WebClientResponseExceptionFactory.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.util
+
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import java.nio.charset.Charset
+
+object WebClientResponseExceptionFactory {
+  fun notFound() = WebClientResponseException.create(
+    HttpStatus.NOT_FOUND.value(),
+    "Not Found",
+    HttpHeaders(),
+    "the body".toByteArray(Charset.forName("UTF-8")),
+    null,
+  )
+}


### PR DESCRIPTION
To achieve this we’ve added a call to an upstream service to retrieve an appointment given it’s ID.

This commit also adds validation in the `PUT /appointments` endpoint to ensure the given appointment ID exists in delius.