### PR TITLE
Simplify Open API Documentation Annotations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/appointment/controller/AppointmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/appointment/controller/AppointmentController.kt
@@ -45,15 +45,16 @@ class AppointmentController(
     @PathVariable appointmentId: Long,
   ) = appointmentService.getAppointment(appointmentId)
 
-  @PutMapping("/appointments")
+  @PutMapping(
+    path = ["/appointments"],
+    consumes = [MediaType.APPLICATION_JSON_VALUE],
+  )
   @Operation(
     description = """Record one or more appointment outcomes. This endpoint is idempotent. 
       If the most recent recorded outcome for a given delius appointment ID matches the values in the request, 
       nothing will be done for that delius appointment ID""",
     requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
-      required = true,
       description = "Provides IDs of delius appointments to update, and the values to use for the update",
-      content = [Content(mediaType = "application/json", schema = Schema(implementation = UpdateAppointmentOutcomesDto::class))],
     ),
     responses = [
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/project/controller/ProjectController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/project/controller/ProjectController.kt
@@ -6,12 +6,12 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.CommunityPaybackController
-import uk.gov.justice.digital.hmpps.communitypaybackapi.project.dto.AppointmentsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.project.dto.ProjectAllocationsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.project.service.ProjectService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
@@ -21,26 +21,22 @@ import java.time.LocalDate
 @RequestMapping("/projects")
 class ProjectController(val projectService: ProjectService) {
 
-  @GetMapping("/allocations")
+  @GetMapping(
+    path = [ "/allocations"],
+    produces = [ APPLICATION_JSON_VALUE ],
+  )
   @Operation(
     description = "Get project allocations within date range for a specific team",
     responses = [
       ApiResponse(
         responseCode = "200",
         description = "Successful project allocations response",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = ProjectAllocationsDto::class),
-          ),
-        ],
       ),
       ApiResponse(
         responseCode = "400",
         description = "Bad request - invalid date format or parameters",
         content = [
           Content(
-            mediaType = "application/json",
             schema = Schema(implementation = ErrorResponse::class),
           ),
         ],
@@ -50,7 +46,6 @@ class ProjectController(val projectService: ProjectService) {
         description = "Team not found",
         content = [
           Content(
-            mediaType = "application/json",
             schema = Schema(implementation = ErrorResponse::class),
           ),
         ],
@@ -67,26 +62,22 @@ class ProjectController(val projectService: ProjectService) {
     @RequestParam teamId: Long,
   ): ProjectAllocationsDto = projectService.getProjectAllocations(startDate, endDate, teamId)
 
-  @GetMapping("/{projectId}/appointments")
+  @GetMapping(
+    path = [ "/{projectId}/appointments"],
+    produces = [ APPLICATION_JSON_VALUE ],
+  )
   @Operation(
     description = "Get project allocations within date range for a specific team",
     responses = [
       ApiResponse(
         responseCode = "200",
         description = "Successful project allocations response",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = AppointmentsDto::class),
-          ),
-        ],
       ),
       ApiResponse(
         responseCode = "400",
         description = "Bad request - invalid date format or parameters",
         content = [
           Content(
-            mediaType = "application/json",
             schema = Schema(implementation = ErrorResponse::class),
           ),
         ],

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/provider/controller/ProviderController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/provider/controller/ProviderController.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -15,7 +16,10 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.provider.service.Provide
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 @CommunityPaybackController
-@RequestMapping("/providers")
+@RequestMapping(
+  path = [ "/providers" ],
+  produces = [ APPLICATION_JSON_VALUE ],
+)
 class ProviderController(val providerService: ProviderService) {
 
   @GetMapping
@@ -25,12 +29,6 @@ class ProviderController(val providerService: ProviderService) {
       ApiResponse(
         responseCode = "200",
         description = "Successful providers summaries response",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = ProviderSummariesDto::class),
-          ),
-        ],
       ),
     ],
   )
@@ -43,19 +41,12 @@ class ProviderController(val providerService: ProviderService) {
       ApiResponse(
         responseCode = "200",
         description = "Successful team response",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = ProviderTeamSummariesDto::class),
-          ),
-        ],
       ),
       ApiResponse(
         responseCode = "404",
         description = "Provider not found",
         content = [
           Content(
-            mediaType = "application/json",
             schema = Schema(implementation = ErrorResponse::class),
           ),
         ],
@@ -71,19 +62,12 @@ class ProviderController(val providerService: ProviderService) {
       ApiResponse(
         responseCode = "200",
         description = "Successful supervisors response",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = SupervisorSummariesDto::class),
-          ),
-        ],
       ),
       ApiResponse(
         responseCode = "404",
         description = "Provider or team not found",
         content = [
           Content(
-            mediaType = "application/json",
             schema = Schema(implementation = ErrorResponse::class),
           ),
         ],

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/reference/controller/ReferenceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/reference/controller/ReferenceController.kt
@@ -1,9 +1,8 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.reference.controller
 
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.media.Content
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.CommunityPaybackController
@@ -13,7 +12,10 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.reference.dto.ProjectTyp
 import uk.gov.justice.digital.hmpps.communitypaybackapi.reference.service.ReferenceService
 
 @CommunityPaybackController
-@RequestMapping("/references")
+@RequestMapping(
+  path = [ "/references" ],
+  produces = [ APPLICATION_JSON_VALUE ],
+)
 class ReferenceController(val referenceService: ReferenceService) {
 
   @GetMapping("/project-types")
@@ -23,12 +25,6 @@ class ReferenceController(val referenceService: ReferenceService) {
       ApiResponse(
         responseCode = "200",
         description = "Successful project types response",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = ProjectTypesDto::class),
-          ),
-        ],
       ),
     ],
   )
@@ -41,31 +37,12 @@ class ReferenceController(val referenceService: ReferenceService) {
       ApiResponse(
         responseCode = "200",
         description = "Successful contact outcomes response",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = ContactOutcomesDto::class),
-          ),
-        ],
       ),
     ],
   )
   fun getContactOutcomes(): ContactOutcomesDto = referenceService.getContactOutcomes()
 
   @GetMapping("/enforcement-actions")
-  @Operation(
-    description = "Get all enforcement actions",
-    responses = [
-      ApiResponse(
-        responseCode = "200",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = EnforcementActionsDto::class),
-          ),
-        ],
-      ),
-    ],
-  )
+  @Operation(description = "Get all enforcement actions")
   fun getEnforcementActions(): EnforcementActionsDto = referenceService.getEnforcementActions()
 }


### PR DESCRIPTION
Before this commit we were duplicating some elements of the API already defined by code or spring annotations in the Open API Annotations. This made it possible to declare one reponse type in the function but document a different response type in Open API.

This commit removes all redundant open api annotations, using code or spring annotations to determine elements of the documentation instead.