### PR TITLE
Add eager loading for appointment domain event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/appointment/entity/AppointmentOutcomeEntityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/appointment/entity/AppointmentOutcomeEntityRepository.kt
@@ -8,7 +8,14 @@ import java.util.UUID
 @Repository
 interface AppointmentOutcomeEntityRepository : JpaRepository<AppointmentOutcomeEntity, UUID> {
 
-  @Query("select ao from AppointmentOutcomeEntity ao join fetch ao.contactOutcomeEntity where ao.id = :id")
+  @Query(
+    """
+    select ao from AppointmentOutcomeEntity ao
+    join fetch ao.contactOutcomeEntity 
+    join fetch ao.enforcementActionEntity
+    join fetch ao.projectTypeEntity
+    where ao.id = :id""",
+  )
   fun findByIdOrNullForDomainEventDetails(id: UUID): AppointmentOutcomeEntity?
 
   fun findTopByAppointmentDeliusIdOrderByUpdatedAtDesc(appointmentDeliusId: Long): AppointmentOutcomeEntity?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/reference/entity/ContactOutcomeEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/reference/entity/ContactOutcomeEntity.kt
@@ -4,10 +4,12 @@ import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.Immutable
 import org.hibernate.annotations.UpdateTimestamp
 import java.time.OffsetDateTime
 import java.util.UUID
 
+@Immutable
 @Entity
 @Table(name = "contact_outcomes")
 data class ContactOutcomeEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/reference/entity/EnforcementActionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/reference/entity/EnforcementActionEntity.kt
@@ -5,10 +5,12 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.Immutable
 import org.hibernate.annotations.UpdateTimestamp
 import java.time.OffsetDateTime
 import java.util.UUID
 
+@Immutable
 @Entity
 @Table(name = "enforcement_actions")
 data class EnforcementActionEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/reference/entity/ProjectTypeEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/reference/entity/ProjectTypeEntity.kt
@@ -4,10 +4,12 @@ import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.Immutable
 import org.hibernate.annotations.UpdateTimestamp
 import java.time.OffsetDateTime
 import java.util.UUID
 
+@Immutable
 @Entity
 @Table(name = "project_types")
 data class ProjectTypeEntity(


### PR DESCRIPTION
Optimise SQL when retrieving an appointment to build a domain event.

This PR also marks the corresponding reference data entities as immutable to clarify in-code that they should be treated as read-only (updates are made via SQL migrations).