### PR TITLE
Exclude domain events from open api ‘for ui’ group

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/OpenApiConfiguration.kt
@@ -67,7 +67,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
   fun forCommunityPaybackUI(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("ForCommunityPaybackUI")
     .displayName("For Community Payback UI")
-    .pathsToExclude("/queue-admin/**")
+    .pathsToExclude("/queue-admin/**", "/domain-event-details/**")
     .addOpenApiCustomizer(defaultErrorResponseCustomizer())
     .build()
 


### PR DESCRIPTION
This will ensure the UI type generation doesn’t generate domain event types