### PR TITLE
Add NDelius Rollback Framework

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
@@ -9,6 +9,7 @@ import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.service.annotation.DeleteExchange
 import org.springframework.web.service.annotation.GetExchange
 import org.springframework.web.service.annotation.PostExchange
 import org.springframework.web.service.annotation.PutExchange
@@ -125,6 +126,11 @@ interface CommunityPaybackAndDeliusClient {
 
   @GetExchange("/case/{crn}/summary")
   fun getUpwDetailsSummary(@PathVariable crn: String, @RequestParam username: String?): NDCaseDetailsSummary
+
+  @DeleteExchange("/adjustments/{adjustmentId}")
+  fun deleteAdjustment(
+    @PathVariable adjustmentId: Long,
+  )
 
   @PostExchange("/adjustments")
   fun postAdjustments(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CommunityPaybackApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CommunityPaybackApiExceptionHandler.kt
@@ -17,12 +17,14 @@ import org.springframework.web.servlet.resource.NoResourceFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.NotFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.BadRequestException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.ConflictException
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.NDeliusRollbackService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SentryService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 @RestControllerAdvice
 class CommunityPaybackApiExceptionHandler(
   val sentryService: SentryService,
+  val rollbackService: NDeliusRollbackService,
 ) {
 
   @ExceptionHandler(
@@ -82,6 +84,7 @@ class CommunityPaybackApiExceptionHandler(
         developerMessage = e.message,
       ),
     )
+    .also { rollbackService.publishEventsForRollback() }
     .also { sentryService.captureException(e) }
     .also { log.error("Unexpected exception", e) }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/listener/DomainEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/listener/DomainEventListener.kt
@@ -24,6 +24,7 @@ import java.util.UUID
 class DomainEventListener(
   private val jsonMapper: JsonMapper,
   private val sqsListenerErrorHandler: SqsListenerErrorHandler,
+  private val sqsListenerRequestScope: SqsListenerRequestScope,
   private val schedulingDomainEventHandler: SchedulingDomainEventHandler,
   private val config: DomainEventListenerConfig,
 ) {
@@ -62,7 +63,9 @@ class DomainEventListener(
     }
 
     sqsListenerErrorHandler.withErrorHandler(headers) {
-      handleDomainEvent(messageString)
+      sqsListenerRequestScope.withRequestScope {
+        handleDomainEvent(messageString)
+      }
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/listener/SqsListenerRequestScope.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/listener/SqsListenerRequestScope.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.listener
+
+import org.springframework.stereotype.Service
+import org.springframework.web.context.request.RequestAttributes
+import org.springframework.web.context.request.RequestContextHolder
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.NDeliusRollbackService
+
+/**
+ * Request scope is required to support capturing spring events for
+ * potential rollback, managed by the [NDeliusRollbackService]
+ */
+@Service
+class SqsListenerRequestScope {
+
+  fun withRequestScope(
+    action: () -> Unit,
+  ) {
+    try {
+      RequestContextHolder.setRequestAttributes(SimpleRequestAttributes())
+      action.invoke()
+    } finally {
+      RequestContextHolder.resetRequestAttributes()
+    }
+  }
+}
+
+private class SimpleRequestAttributes : RequestAttributes {
+  private val requestAttributeMap = mutableMapOf<String, Any>()
+
+  override fun getAttribute(name: String, scope: Int): Any? = if (scope.isScopeRequest()) {
+    this.requestAttributeMap[name]
+  } else {
+    null
+  }
+
+  override fun setAttribute(name: String, value: Any, scope: Int) {
+    if (scope.isScopeRequest()) {
+      this.requestAttributeMap[name] = value
+    }
+  }
+
+  override fun removeAttribute(name: String, scope: Int) {
+    if (scope.isScopeRequest()) {
+      this.requestAttributeMap.remove(name)
+    }
+  }
+
+  override fun getAttributeNames(scope: Int): Array<String> {
+    if (scope.isScopeRequest()) {
+      return this.requestAttributeMap.keys.toTypedArray<String>()
+    }
+    return emptyArray()
+  }
+
+  override fun registerDestructionCallback(name: String, callback: Runnable, scope: Int): Unit = throw UnsupportedOperationException()
+
+  override fun resolveReference(key: String): Any? = throw UnsupportedOperationException()
+
+  override fun getSessionId(): String = throw UnsupportedOperationException()
+
+  override fun getSessionMutex(): Any = throw UnsupportedOperationException()
+
+  private fun Int.isScopeRequest() = this == RequestAttributes.SCOPE_REQUEST
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentEventEntityFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentEventEntityFactory.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventAd
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventTriggerType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventType
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CreateAdjustmentEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -14,7 +14,7 @@ import java.util.UUID
 class AdjustmentEventEntityFactory {
 
   fun buildAdjustmentCreated(
-    details: CreateAdjustmentEvent,
+    details: AdjustmentCreatedEvent,
   ) = AdjustmentEventEntity(
     id = UUID.randomUUID(),
     eventType = AdjustmentEventType.CREATE,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentEventService.kt
@@ -6,7 +6,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventType
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CreateAdjustmentEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toAdjustmentCreatedDomainEvent
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -22,7 +22,7 @@ class AdjustmentEventService(
   fun getEvent(eventId: UUID) = adjustmentEventEntityRepository.findByIdOrNull(eventId)
 
   @EventListener
-  fun persistAndPublishCreateAdjustmentDomainEvent(event: CreateAdjustmentEvent) {
+  fun persistAndPublishCreateAdjustmentDomainEvent(event: AdjustmentCreatedEvent) {
     val persistedEvent = adjustmentEventEntityRepository.save(
       adjustmentEventEntityFactory.buildAdjustmentCreated(event),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentService.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackA
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UnpaidWorkDetailsIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventTriggerType
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CreateAdjustmentEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toNDAdjustmentRequest
 import java.time.Clock
@@ -42,7 +42,7 @@ class AdjustmentService(
     ).single().id
 
     springEventPublisher.publishEvent(
-      CreateAdjustmentEvent(
+      AdjustmentCreatedEvent(
         createDto = createAdjustment,
         appointmentEntity = validatedAdjustment.task.appointment,
         reason = validatedAdjustment.reason,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentService.kt
@@ -1,11 +1,13 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 
 import jakarta.transaction.Transactional
+import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UnpaidWorkDetailsIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventTriggerType
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toNDAdjustmentRequest
@@ -54,5 +56,15 @@ class AdjustmentService(
         ),
       ),
     )
+  }
+
+  @EventListener
+  fun rollbackAdjustment(
+    rollbackEvent: CommunityPaybackSpringEvent.NDeliusRollbackRequired,
+  ) {
+    val event = rollbackEvent.event
+    if (event is AdjustmentCreatedEvent) {
+      communityPaybackAndDeliusClient.deleteAdjustment(event.deliusAdjustmentId)
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentEventEntityFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentEventEntityFactory.kt
@@ -58,7 +58,7 @@ class AppointmentEventEntityFactory(
   }
 
   fun buildUpdatedEvent(
-    details: CommunityPaybackSpringEvent.UpdateAppointmentEvent,
+    details: CommunityPaybackSpringEvent.AppointmentUpdatedEvent,
   ): AppointmentEventEntity {
     val existingAppointment = details.existingAppointment
     val outcome = details.updateDto.dto

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentEventService.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEventE
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEventEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEventType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentCreatedEvent
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.UpdateAppointmentEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentUpdatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toAppointmentCreatedDomainEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toAppointmentUpdatedDomainEvent
 import java.time.OffsetDateTime
@@ -26,7 +26,7 @@ class AppointmentEventService(
 
   fun getEvent(eventId: UUID) = appointmentEventEntityRepository.findByIdOrNull(eventId)
 
-  fun hasUpdateAlreadyBeenSent(proposedUpdateDetails: UpdateAppointmentEvent): Boolean {
+  fun hasUpdateAlreadyBeenSent(proposedUpdateDetails: AppointmentUpdatedEvent): Boolean {
     val proposedUpdate = appointmentEventEntityFactory.buildUpdatedEvent(proposedUpdateDetails)
 
     return appointmentEventEntityRepository
@@ -54,7 +54,7 @@ class AppointmentEventService(
 
   @EventListener
   fun persistAndPublishAppointmentUpdateDomainEvent(
-    event: UpdateAppointmentEvent,
+    event: AppointmentUpdatedEvent,
   ) {
     persistAndPublishDomainEventOnTransactionCommit(appointmentEventEntityFactory.buildUpdatedEvent(event))
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentTaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentTaskService.kt
@@ -20,9 +20,9 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskSt
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeGroup
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentCreatedEvent
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CreateAdjustmentEvent
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.UpdateAppointmentEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentUpdatedEvent
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -49,7 +49,7 @@ class AppointmentTaskService(
   @EventListener
   @Transactional(Transactional.TxType.REQUIRED)
   fun createTravelTimeTaskOnAppointmentUpdate(
-    event: UpdateAppointmentEvent,
+    event: AppointmentUpdatedEvent,
   ) {
     createTravelTimeTaskIfRequired(
       appointment = event.appointmentEntity,
@@ -61,7 +61,7 @@ class AppointmentTaskService(
   @EventListener
   @Transactional(Transactional.TxType.REQUIRED)
   fun closeTravelTimeTaskOnAdjustmentCreation(
-    event: CreateAdjustmentEvent,
+    event: AdjustmentCreatedEvent,
   ) {
     val trigger = event.trigger
     if (trigger.triggerType == AdjustmentEventTriggerType.APPOINTMENT_TASK) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentUpdateService.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOut
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.ConflictException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.InternalServerErrorException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService.ValidatedAppointment
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.UpdateAppointmentEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentUpdatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toNDUpdateAppointment
 
@@ -36,7 +36,7 @@ class AppointmentUpdateService(
 
     val validatedUpdateDto = appointmentUpdateValidationService.validateUpdate(existingAppointment, update)
 
-    val updateEventDetails = UpdateAppointmentEvent(
+    val updateEventDetails = AppointmentUpdatedEvent(
       updateDto = appointmentUpdateValidationService.validateUpdate(existingAppointment, update),
       appointmentEntity = appointmentEntity,
       existingAppointment = existingAppointment,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/NDeliusRollbackService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/NDeliusRollbackService.kt
@@ -1,0 +1,90 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.getBean
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Scope
+import org.springframework.context.annotation.ScopedProxyMode
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
+import org.springframework.web.context.WebApplicationContext
+import org.springframework.web.context.request.RequestContextHolder
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.NDeliusRollbackRequired
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SentryService
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
+
+/**
+ * If a request cannot be completed we want to rollback any changes made in NDelius. To do
+ * this we wrap any internally raised [CommunityPaybackSpringEvent]s in an [NDeliusRollbackRequired]
+ * event and publish them in the received order. The service responsible for making the original
+ * change in NDelius can then revert the change made (i.e. apply a compensating transaction)
+ *
+ * This doesn't currently apply to application-scheduling, which is triggered by SQS message
+ * consumer which doesn't have a request scope. This should be a solve-able problem.
+ */
+@Service
+class NDeliusRollbackService(
+  val springEventPublisher: SpringEventPublisher,
+  val sentryService: SentryService,
+  val applicationContext: ApplicationContext,
+) {
+  private val log = LoggerFactory.getLogger(this::class.java)
+
+  @EventListener
+  fun captureEvent(event: CommunityPaybackSpringEvent) {
+    if (!requestScopeActive()) {
+      log.debug("Ignoring event because request scope isn't active")
+      return
+    }
+
+    getRequestScopedEvents().add(event)
+  }
+
+  @SuppressWarnings("TooGenericExceptionCaught")
+  fun publishEventsForRollback() {
+    if (!requestScopeActive()) {
+      log.debug("Ignoring rollback becuase request scope isn't active")
+      return
+    }
+
+    val events = getRequestScopedEvents().getAll()
+
+    if (events.size > 50) {
+      log.error("Unexpectedly large number of events (${events.size}) requested for rollback. Will not rollback. Events are $events")
+      return
+    }
+
+    events.toList().forEach {
+      try {
+        log.info("Rolling back event $it")
+        springEventPublisher.publishEvent(NDeliusRollbackRequired(it))
+      } catch (e: Throwable) {
+        log.error("Failed to rollback event $it", e)
+        sentryService.captureException(e)
+      }
+    }
+  }
+
+  private fun getRequestScopedEvents() = applicationContext.getBean<RequestScopedEvents>()
+
+  /**
+   * Request scope isn't active when consuming SQS messages, leading to exceptions.
+   * This guards against that
+   */
+  private fun requestScopeActive() = RequestContextHolder.getRequestAttributes() != null
+}
+
+@Component
+@Scope(
+  value = WebApplicationContext.SCOPE_REQUEST,
+  proxyMode = ScopedProxyMode.TARGET_CLASS,
+)
+class RequestScopedEvents {
+  val events = mutableListOf<CommunityPaybackSpringEvent>()
+
+  fun add(event: CommunityPaybackSpringEvent) = events.add(event)
+
+  fun getAll() = events.toList()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/NDeliusRollbackService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/NDeliusRollbackService.kt
@@ -9,7 +9,6 @@ import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import org.springframework.stereotype.Service
 import org.springframework.web.context.WebApplicationContext
-import org.springframework.web.context.request.RequestContextHolder
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.NDeliusRollbackRequired
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SentryService
@@ -34,21 +33,11 @@ class NDeliusRollbackService(
 
   @EventListener
   fun captureEvent(event: CommunityPaybackSpringEvent) {
-    if (!requestScopeActive()) {
-      log.debug("Ignoring event because request scope isn't active")
-      return
-    }
-
     getRequestScopedEvents().add(event)
   }
 
   @SuppressWarnings("TooGenericExceptionCaught")
   fun publishEventsForRollback() {
-    if (!requestScopeActive()) {
-      log.debug("Ignoring rollback becuase request scope isn't active")
-      return
-    }
-
     val events = getRequestScopedEvents().getAll()
 
     if (events.size > 50) {
@@ -68,12 +57,6 @@ class NDeliusRollbackService(
   }
 
   private fun getRequestScopedEvents() = applicationContext.getBean<RequestScopedEvents>()
-
-  /**
-   * Request scope isn't active when consuming SQS messages, leading to exceptions.
-   * This guards against that
-   */
-  private fun requestScopeActive() = RequestContextHolder.getRequestAttributes() != null
 }
 
 @Component

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SentryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SentryService.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service
 
 interface SentryService {
   fun captureException(throwable: Throwable)
+  fun captureMessage(message: String)
 }
 
 @Service
@@ -17,5 +18,10 @@ class SentryServiceImpl : SentryService {
   override fun captureException(throwable: Throwable) {
     log.debug("Will capture exception in sentry", throwable)
     Sentry.captureException(throwable)
+  }
+
+  override fun captureMessage(message: String) {
+    log.debug("Will capture message in sentry '{}'", message)
+    Sentry.captureMessage(message)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
@@ -35,7 +35,7 @@ sealed interface CommunityPaybackSpringEvent {
     companion object
   }
 
-  data class CreateAdjustmentEvent(
+  data class AdjustmentCreatedEvent(
     val createDto: CreateAdjustmentDto,
     val appointmentEntity: AppointmentEntity,
     val reason: AdjustmentReasonEntity,
@@ -45,7 +45,7 @@ sealed interface CommunityPaybackSpringEvent {
     companion object
   }
 
-  data class UpdateAppointmentEvent(
+  data class AppointmentUpdatedEvent(
     val updateDto: AppointmentValidationService.ValidatedAppointment<UpdateAppointmentOutcomeDto>,
     val appointmentEntity: AppointmentEntity,
     val existingAppointment: AppointmentDto,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
@@ -53,4 +53,18 @@ sealed interface CommunityPaybackSpringEvent {
   ) : CommunityPaybackSpringEvent {
     companion object
   }
+
+  /**
+   * Used to indicate that any NDelius entities/changes applied for a
+   * prior event should be rolled back. This will typically be raised
+   * when the corresponding thread of execution cannot complete
+   * (e.g. database transaction fails to commit)
+   *
+   * The handler function should _not_ be transacted to minimise the
+   * chance of failure (and this shouldn't be required anyway if
+   * just dealing with NDelius)
+   */
+  data class NDeliusRollbackRequired(
+    val event: CommunityPaybackSpringEvent,
+  ) : CommunityPaybackSpringEvent
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/event/AdjustmentCreatedEventFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/event/AdjustmentCreatedEventFactory.kt
@@ -8,10 +8,10 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentEventTrigger
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CreateAdjustmentEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import java.time.OffsetDateTime
 
-fun CreateAdjustmentEvent.Companion.valid() = CreateAdjustmentEvent(
+fun AdjustmentCreatedEvent.Companion.valid() = AdjustmentCreatedEvent(
   createDto = CreateAdjustmentDto.valid(),
   appointmentEntity = AppointmentEntity.valid(),
   reason = AdjustmentReasonEntity.valid(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/event/AppointmentUpdatedEventFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/event/AppointmentUpdatedEventFactory.kt
@@ -7,9 +7,9 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.validUpdateA
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentEventTrigger
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.UpdateAppointmentEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentUpdatedEvent
 
-fun UpdateAppointmentEvent.Companion.valid() = UpdateAppointmentEvent(
+fun AppointmentUpdatedEvent.Companion.valid() = AppointmentUpdatedEvent(
   updateDto = AppointmentValidationService.ValidatedAppointment.validUpdateAppointment(),
   appointmentEntity = AppointmentEntity.valid(),
   existingAppointment = AppointmentDto.valid(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAdjustmentIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAdjustmentIT.kt
@@ -4,9 +4,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.MediaType
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDUpwDetails
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentDto
@@ -20,6 +23,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.persist
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.util.DomainEventAsserter
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.wiremock.CommunityPaybackAndDeliusMockServer
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentService
 
 class AdminAdjustmentIT : IntegrationTestBase() {
 
@@ -28,6 +32,9 @@ class AdminAdjustmentIT : IntegrationTestBase() {
 
   @Autowired
   lateinit var domainEventAsserter: DomainEventAsserter
+
+  @MockitoSpyBean
+  lateinit var adjustmentService: AdjustmentService
 
   companion object {
     const val CRN = "X123456"
@@ -78,6 +85,57 @@ class AdminAdjustmentIT : IntegrationTestBase() {
       val appointment = AppointmentEntity.valid().copy(crn = CRN, deliusEventNumber = DELIUS_EVENT_NUMBER).persist(ctx)
       val task = AppointmentTaskEntity.valid().copy(appointment = appointment).persist(ctx)
 
+      setupGetUpwDetailsResponse()
+      CommunityPaybackAndDeliusMockServer.setupPostAdjustmentResponse(username = "theusername")
+
+      callCreateAdjustment(
+        request = CreateAdjustmentDto.valid(ctx).copy(taskId = task.id),
+        expectedStatus = 200,
+      )
+
+      CommunityPaybackAndDeliusMockServer.verifyPostAdjustment(username = "theusername")
+
+      domainEventAsserter.assertEventCount("community-payback.adjustment.created", 1)
+      assertThat(appointmentTaskEntityRepository.findByIdOrNull(task.id)!!.taskStatus).isEqualTo(AppointmentTaskStatus.COMPLETE)
+    }
+
+    @Test
+    fun `Rollback on unexpected request failure, ensuring previously created adjustments aren't rolled back too`() {
+      val appointment = AppointmentEntity.valid().copy(crn = CRN, deliusEventNumber = DELIUS_EVENT_NUMBER).persist(ctx)
+      val task = AppointmentTaskEntity.valid().copy(appointment = appointment).persist(ctx)
+
+      setupGetUpwDetailsResponse()
+      CommunityPaybackAndDeliusMockServer.setupPostAdjustmentResponse(username = "theusername", adjustmentId = 25L)
+
+      // successful request
+      callCreateAdjustment(
+        request = CreateAdjustmentDto.valid(ctx).copy(taskId = task.id),
+        expectedStatus = 200,
+      )
+      CommunityPaybackAndDeliusMockServer.verifyPostAdjustment(username = "theusername", count = 1)
+
+      // setup request that fails after adjustment is created
+      doAnswer { invocation ->
+        invocation.callRealMethod()
+        error("Test-managed exception used to test rollback behaviour")
+      }.`when`(adjustmentService).createAdjustment(any(), any(), any())
+
+      CommunityPaybackAndDeliusMockServer.setupDeleteAdjustmentResponse(25)
+
+      callCreateAdjustment(
+        request = CreateAdjustmentDto.valid(ctx).copy(taskId = task.id),
+        expectedStatus = 500,
+      )
+
+      // ensure both creations worked, but only one was deleted
+      CommunityPaybackAndDeliusMockServer.verifyPostAdjustment(username = "theusername", count = 2)
+      CommunityPaybackAndDeliusMockServer.verifyDeleteAdjustment(adjustmentId = 25L, count = 1)
+
+      // only 1 domain event is published because the second transaction is rolled back
+      domainEventAsserter.assertEventCount("community-payback.adjustment.created", 1)
+    }
+
+    private fun setupGetUpwDetailsResponse() {
       CommunityPaybackAndDeliusMockServer.setupGetUpwDetailsSummaryResponse(
         crn = CRN,
         case = NDCaseSummary.valid(),
@@ -86,26 +144,19 @@ class AdminAdjustmentIT : IntegrationTestBase() {
         ),
         username = "theusername",
       )
+    }
 
-      CommunityPaybackAndDeliusMockServer.setupPostAdjustmentResponse(username = "theusername")
-
+    private fun callCreateAdjustment(
+      request: CreateAdjustmentDto,
+      expectedStatus: Int = 200,
+    ) {
       webTestClient.post()
         .uri("/admin/offenders/$CRN/unpaid-work-details/$DELIUS_EVENT_NUMBER/adjustments")
         .addAdminUiAuthHeader("theusername")
         .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(
-          CreateAdjustmentDto.valid(ctx).copy(
-            taskId = task.id,
-          ),
-        )
+        .bodyValue(request)
         .exchange()
-        .expectStatus()
-        .isOk
-
-      CommunityPaybackAndDeliusMockServer.verifyPostAdjustment(username = "theusername")
-
-      domainEventAsserter.assertEventCount("community-payback.adjustment.created", 1)
-      assertThat(appointmentTaskEntityRepository.findByIdOrNull(task.id)!!.taskStatus).isEqualTo(AppointmentTaskStatus.COMPLETE)
+        .expectStatus().isEqualTo(expectedStatus)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/util/MockSentryService.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/util/MockSentryService.kt
@@ -23,6 +23,10 @@ class MockSentryService : SentryService {
     capturedExceptions.add(throwable)
   }
 
+  override fun captureMessage(message: String) {
+    // do nothing
+  }
+
   fun getRaisedExceptions(): List<Throwable> {
     await()
       .atMost(1, TimeUnit.SECONDS)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.integration.wiremock
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.absent
+import com.github.tomakehurst.wiremock.client.WireMock.delete
+import com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.exactly
 import com.github.tomakehurst.wiremock.client.WireMock.get
@@ -45,6 +47,15 @@ import kotlin.Long
 object CommunityPaybackAndDeliusMockServer {
 
   val jsonMapper: JsonMapper = JsonMapper()
+
+  fun setupDeleteAdjustmentResponse(adjustmentId: Long) {
+    WireMock.stubFor(
+      delete("/community-payback-and-delius/adjustments/$adjustmentId")
+        .willReturn(
+          aResponse().withStatus(200),
+        ),
+    )
+  }
 
   fun setupGetAppointment404Response(
     projectCode: String,
@@ -372,13 +383,16 @@ object CommunityPaybackAndDeliusMockServer {
     )
   }
 
-  fun setupPostAdjustmentResponse(username: String) {
+  fun setupPostAdjustmentResponse(
+    username: String,
+    adjustmentId: Long = 1L,
+  ) {
     WireMock.stubFor(
       post("/community-payback-and-delius/adjustments?username=$username")
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
-            .withBody(jsonMapper.writeValueAsString(listOf(NDAdjustmentPostResponse(1L))))
+            .withBody(jsonMapper.writeValueAsString(listOf(NDAdjustmentPostResponse(adjustmentId))))
             .withTransformers("response-template"),
         ),
     )
@@ -484,8 +498,12 @@ object CommunityPaybackAndDeliusMockServer {
     WireMock.verify(0, postRequestedFor(urlMatching("/community-payback-and-delius/.*/appointments")))
   }
 
-  fun verifyPostAdjustment(username: String) {
-    WireMock.verify(postRequestedFor(urlEqualTo("/community-payback-and-delius/adjustments?username=$username")))
+  fun verifyPostAdjustment(username: String, count: Int = 1) {
+    WireMock.verify(count, postRequestedFor(urlEqualTo("/community-payback-and-delius/adjustments?username=$username")))
+  }
+
+  fun verifyDeleteAdjustment(adjustmentId: Long, count: Int = 1) {
+    WireMock.verify(count, deleteRequestedFor(urlMatching("/community-payback-and-delius/adjustments/$adjustmentId")))
   }
 
   object Aggregates {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentEventEntityFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentEventEntityFactoryTest.kt
@@ -13,7 +13,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentEventEntityFactory
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentEventTrigger
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CreateAdjustmentEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
@@ -26,7 +26,7 @@ class AdjustmentEventEntityFactoryTest {
     val reason = AdjustmentReasonEntity.valid()
 
     val result = AdjustmentEventEntityFactory().buildAdjustmentCreated(
-      CreateAdjustmentEvent(
+      AdjustmentCreatedEvent(
         createDto = CreateAdjustmentDto.valid().copy(
           type = CreateAdjustmentTypeDto.Negative,
           minutes = 61,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentServiceTest.kt
@@ -21,7 +21,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.config.Clock
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentEventTrigger
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentValidationService
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CreateAdjustmentEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toNDAdjustmentRequest
 import java.time.Clock
@@ -93,7 +93,7 @@ class AdjustmentServiceTest {
 
       verify {
         springEventPublisher.publishEvent(
-          CreateAdjustmentEvent(
+          AdjustmentCreatedEvent(
             createDto = request,
             appointmentEntity = appointmentTask.appointment,
             reason = validatedAdjustment.reason,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentEventEntityFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentEventEntityFactoryTest.kt
@@ -38,7 +38,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ProviderService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.TeamId
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentCreatedEvent
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.UpdateAppointmentEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentUpdatedEvent
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
@@ -268,7 +268,7 @@ class AppointmentEventEntityFactoryTest {
       )
 
       val result = factory.buildUpdatedEvent(
-        UpdateAppointmentEvent(
+        AppointmentUpdatedEvent(
           updateDto = ValidatedAppointment.validUpdateAppointment().copy(
             dto = UpdateAppointmentOutcomeDto(
               deliusId = 101L,
@@ -346,7 +346,7 @@ class AppointmentEventEntityFactoryTest {
       val deliusVersion = UUID.randomUUID()
 
       val result = factory.buildUpdatedEvent(
-        UpdateAppointmentEvent(
+        AppointmentUpdatedEvent(
           updateDto = ValidatedAppointment.validUpdateAppointment().copy(
             dto = UpdateAppointmentOutcomeDto(
               deliusId = 101L,
@@ -412,7 +412,7 @@ class AppointmentEventEntityFactoryTest {
     @Test
     fun `use penaltyMinutes instead of penaltyTime if defined`() {
       val result = factory.buildUpdatedEvent(
-        UpdateAppointmentEvent(
+        AppointmentUpdatedEvent(
           updateDto = ValidatedAppointment.validUpdateAppointment().copy(
             UpdateAppointmentOutcomeDto.valid().copy(
               contactOutcomeCode = null,
@@ -438,7 +438,7 @@ class AppointmentEventEntityFactoryTest {
     @Test
     fun `use legacy penaltyTime if penaltyMinutes not defined`() {
       val result = factory.buildUpdatedEvent(
-        UpdateAppointmentEvent(
+        AppointmentUpdatedEvent(
           updateDto = ValidatedAppointment.validUpdateAppointment().copy(
             UpdateAppointmentOutcomeDto.valid().copy(
               contactOutcomeCode = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentEventServiceTest.kt
@@ -28,7 +28,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.DomainEventServi
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.DomainEventType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.PersonReferenceType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentCreatedEvent
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.UpdateAppointmentEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentUpdatedEvent
 
 @ExtendWith(MockKExtension::class)
 class AppointmentEventServiceTest {
@@ -48,7 +48,7 @@ class AppointmentEventServiceTest {
   @Nested
   inner class HasUpdateAlreadyBeenSent {
 
-    val baselineUpdateDetails = UpdateAppointmentEvent(
+    val baselineUpdateDetails = AppointmentUpdatedEvent(
       updateDto = ValidatedAppointment.validUpdateAppointment(),
       appointmentEntity = AppointmentEntity.valid(),
       existingAppointment = AppointmentDto.valid(),
@@ -183,7 +183,7 @@ class AppointmentEventServiceTest {
         crn = "CRN1",
       )
 
-      val updateDetails = UpdateAppointmentEvent(
+      val updateDetails = AppointmentUpdatedEvent(
         updateDto = ValidatedAppointment.validUpdateAppointment(),
         appointmentEntity = AppointmentEntity.valid(),
         existingAppointment = AppointmentDto.valid(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentTaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentTaskServiceTest.kt
@@ -40,9 +40,9 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentRetri
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentTaskService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService.ValidatedAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ContextService
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentCreatedEvent
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CreateAdjustmentEvent
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.UpdateAppointmentEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentUpdatedEvent
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
@@ -142,7 +142,7 @@ class AppointmentTaskServiceTest {
 
     @Test
     fun `no outcome, do nothing`() {
-      val event = UpdateAppointmentEvent.valid().copy(
+      val event = AppointmentUpdatedEvent.valid().copy(
         updateDto = ValidatedAppointment.validUpdateAppointment().copy(
           contactOutcome = null,
         ),
@@ -155,7 +155,7 @@ class AppointmentTaskServiceTest {
 
     @Test
     fun `outcome not attended, do nothing`() {
-      val event = UpdateAppointmentEvent.valid().copy(
+      val event = AppointmentUpdatedEvent.valid().copy(
         updateDto = ValidatedAppointment.validUpdateAppointment().copy(
           contactOutcome = ContactOutcomeEntity.valid().copy(attended = false),
         ),
@@ -171,7 +171,7 @@ class AppointmentTaskServiceTest {
     fun `project group time doesn't support travel time, do nothing`(
       projectTypeGroup: ProjectTypeGroupDto,
     ) {
-      val event = UpdateAppointmentEvent.valid().copy(
+      val event = AppointmentUpdatedEvent.valid().copy(
         updateDto = ValidatedAppointment.validUpdateAppointment().copy(
           contactOutcome = ContactOutcomeEntity.valid().copy(attended = true),
           project = ProjectDto.valid().copy(projectType = ProjectTypeDto.valid().copy(group = projectTypeGroup)),
@@ -188,7 +188,7 @@ class AppointmentTaskServiceTest {
     fun `only create task if outcome is attended and project group type supports travel time`(
       projectTypeGroup: ProjectTypeGroupDto,
     ) {
-      val event = UpdateAppointmentEvent.valid().copy(
+      val event = AppointmentUpdatedEvent.valid().copy(
         updateDto = ValidatedAppointment.validUpdateAppointment().copy(
           contactOutcome = ContactOutcomeEntity.valid().copy(attended = true),
           project = ProjectDto.valid().copy(projectType = ProjectTypeDto.valid().copy(group = projectTypeGroup)),
@@ -220,7 +220,7 @@ class AppointmentTaskServiceTest {
       every { appointmentTaskEntityRepository.save(any()) } returnsArgument 0
 
       service.closeTravelTimeTaskOnAdjustmentCreation(
-        CreateAdjustmentEvent.valid().copy(
+        AdjustmentCreatedEvent.valid().copy(
           trigger = AdjustmentEventTrigger.valid().copy(
             triggeredAt = triggeredAt,
             triggeredBy = task.id.toString(),


### PR DESCRIPTION
If a request cannot be completed we want to rollback any changes made in NDelius. To do this we wrap any internally raised `CommunityPaybackSpringEvents` in an `NDeliusRollbackRequired` event and publish them in the received order. The service responsible for making the original change in NDelius can then revert the change made (i.e. apply a compensating transaction)

Currently there is only a rollback listener for amendments, for which an integration test has been added. Once an upstream delete application endpoint is available rollback functionality should also be added for applications.