### PR TITLE
CPB-823 - Add date & time changes to appointment notes on update

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
@@ -113,32 +113,6 @@ class AppointmentMappers(
     projectTypeCode = appointmentSummary.project.projectType.code,
     projectTypeName = appointmentSummary.project.projectType.description,
   )
-
-  fun toSummaryDtoFromDto(
-    appointmentDto: AppointmentDto,
-    requirementMinutes: Int,
-    adjustmentMinutes: Int,
-    completedMinutes: Int,
-  ) = AppointmentSummaryDto(
-    id = appointmentDto.id,
-    contactOutcome = appointmentDto.contactOutcomeCode?.let {
-      contactOutcomeEntityRepository.findByCode(it)?.toDto()
-    },
-    requirementMinutes = requirementMinutes,
-    adjustmentMinutes = adjustmentMinutes,
-    completedMinutes = completedMinutes,
-    offender = appointmentDto.offender,
-    date = appointmentDto.date,
-    startTime = appointmentDto.startTime,
-    endTime = appointmentDto.endTime,
-    minutesCredited = appointmentDto.minutesCredited,
-    daysOverdue = null,
-    notes = appointmentDto.notes,
-    projectCode = appointmentDto.projectCode,
-    projectName = appointmentDto.projectName.orEmpty(),
-    projectTypeCode = appointmentDto.projectTypeCode.orEmpty(),
-    projectTypeName = appointmentDto.projectTypeName.orEmpty(),
-  )
 }
 
 fun AppointmentEventEntity.toAppointmentCreatedDomainEvent() = AppointmentCreatedDomainEventDetailDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointmentWork
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCode
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCreateAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDUpdateAppointment
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.formatForUser
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentBehaviourDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
@@ -145,6 +146,7 @@ fun ValidatedAppointment<UpdateAppointmentOutcomeDto>.toNDUpdateAppointment(
   existingAppointment: AppointmentDto,
 ): NDUpdateAppointment {
   val updateDto = dto
+
   return NDUpdateAppointment(
     version = updateDto.deliusVersionToUpdate,
     date = updateDto.resolveDate(existingAppointment),
@@ -152,7 +154,7 @@ fun ValidatedAppointment<UpdateAppointmentOutcomeDto>.toNDUpdateAppointment(
     endTime = updateDto.endTime,
     outcome = this.contactOutcome?.let { NDCode(it.code) },
     supervisor = NDCode(updateDto.supervisorOfficerCode),
-    notes = updateDto.notes,
+    notes = buildUpdateNote(existingAppointment),
     hiVisWorn = updateDto.attendanceData?.hiVisWorn,
     workedIntensively = updateDto.attendanceData?.workedIntensively,
     penaltyMinutes = updateDto.attendanceData?.derivePenaltyMinutesDuration()?.toMinutes(),
@@ -169,6 +171,34 @@ fun ValidatedAppointment<UpdateAppointmentOutcomeDto>.toNDUpdateAppointment(
     },
   )
 }
+
+private fun ValidatedAppointment<UpdateAppointmentOutcomeDto>.buildUpdateNote(
+  existingAppointment: AppointmentDto,
+) = buildString {
+  val updateDto = dto
+
+  val existingDate = existingAppointment.date
+  val updatedDate = updateDto.resolveDate(existingAppointment)
+  if (updatedDate != existingDate) {
+    appendLine("Appointment Date changed from ${existingDate.formatForUser()} to ${updatedDate.formatForUser()}")
+  }
+
+  val existingStartTime = existingAppointment.startTime
+  val updatedStartTime = updateDto.startTime
+  if (updatedStartTime != existingStartTime) {
+    appendLine("Appointment Start Time changed from ${existingStartTime.formatForUser()} to ${updatedStartTime.formatForUser()}")
+  }
+
+  val existingEndTime = existingAppointment.endTime
+  val updatedEndTime = updateDto.endTime
+  if (updatedEndTime != existingEndTime) {
+    appendLine("Appointment End Time changed from ${existingEndTime.formatForUser()} to ${updatedEndTime.formatForUser()}")
+  }
+
+  if (updateDto.notes?.isNotBlank() == true) {
+    appendLine(updateDto.notes)
+  }
+}.trimEnd().ifBlank { null }
 
 fun ValidatedAppointment<CreateAppointmentDto>.toNDCreateAppointment(): NDCreateAppointment {
   val createDto = this.dto

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
@@ -188,8 +188,18 @@ class AppointmentMappersTest {
   inner class ValidatedUpdateAppointmentDtoToNDUpdateAppointment {
 
     @Test
-    fun success() {
+    fun `success with all fields updated`() {
       val priorDeliusVersion = UUID.randomUUID()
+
+      val existingAppointment = AppointmentDto.valid().copy(
+        date = LocalDate.of(2020, 1, 2),
+        startTime = LocalTime.of(2, 2, 1),
+        endTime = LocalTime.of(11, 11, 10),
+        pickUpData = PickUpDataDto.valid().copy(
+          time = LocalTime.of(1, 0, 0),
+          locationCode = "PICKUP1",
+        ),
+      )
 
       val dto = ValidatedAppointment.validUpdateAppointment().copy(
         dto = UpdateAppointmentOutcomeDto.valid().copy(
@@ -214,14 +224,7 @@ class AppointmentMappersTest {
         contactOutcome = ContactOutcomeEntity.valid().copy(code = "COE1"),
       )
 
-      val result = dto.toNDUpdateAppointment(
-        existingAppointment = AppointmentDto.valid().copy(
-          pickUpData = PickUpDataDto.valid().copy(
-            time = LocalTime.of(1, 0, 0),
-            locationCode = "PICKUP1",
-          ),
-        ),
-      )
+      val result = dto.toNDUpdateAppointment(existingAppointment)
 
       assertThat(result.version).isEqualTo(priorDeliusVersion)
       assertThat(result.date).isEqualTo(LocalDate.of(2018, 12, 9))
@@ -229,7 +232,14 @@ class AppointmentMappersTest {
       assertThat(result.endTime).isEqualTo(LocalTime.of(12, 11, 10))
       assertThat(result.outcome!!.code).isEqualTo("COE1")
       assertThat(result.supervisor.code).isEqualTo("WO3736")
-      assertThat(result.notes).isEqualTo("The notes")
+      assertThat(result.notes).isEqualTo(
+        """
+          |Appointment Date changed from 02/01/2020 to 09/12/2018
+          |Appointment Start Time changed from 02:02:01 to 03:02:01
+          |Appointment End Time changed from 11:11:10 to 12:11:10
+          |The notes
+        """.trimMargin(),
+      )
       assertThat(result.hiVisWorn).isTrue
       assertThat(result.workedIntensively).isFalse
       assertThat(result.penaltyMinutes).isEqualTo(105)
@@ -245,6 +255,13 @@ class AppointmentMappersTest {
     @Test
     fun `success with only mandatory fields`() {
       val priorDeliusVersion = UUID.randomUUID()
+
+      val existingAppointment = AppointmentDto.valid().copy(
+        date = LocalDate.of(2020, 1, 2),
+        startTime = LocalTime.of(3, 2, 1),
+        endTime = LocalTime.of(12, 11, 10),
+        pickUpData = null,
+      )
 
       val dto = ValidatedAppointment.validUpdateAppointment().copy(
         dto = UpdateAppointmentOutcomeDto.valid().copy(
@@ -263,12 +280,7 @@ class AppointmentMappersTest {
         contactOutcome = null,
       )
 
-      val result = dto.toNDUpdateAppointment(
-        existingAppointment = AppointmentDto.valid().copy(
-          date = LocalDate.of(2020, 1, 2),
-          pickUpData = null,
-        ),
-      )
+      val result = dto.toNDUpdateAppointment(existingAppointment)
 
       assertThat(result.version).isEqualTo(priorDeliusVersion)
       assertThat(result.date).isEqualTo(LocalDate.of(2020, 1, 2))
@@ -286,6 +298,115 @@ class AppointmentMappersTest {
       assertThat(result.alertActive).isNull()
       assertThat(result.sensitive).isNull()
       assertThat(result.pickUp).isNull()
+    }
+
+    @Test
+    fun `if date changes add to note before user provided note`() {
+      val existingAppointment = AppointmentDto.valid().copy(
+        date = LocalDate.of(2021, 2, 3),
+        startTime = LocalTime.of(0, 1),
+        endTime = LocalTime.of(12, 45),
+      )
+
+      val dto = ValidatedAppointment.validUpdateAppointment().copy(
+        dto = UpdateAppointmentOutcomeDto.valid().copy(
+          date = LocalDate.of(2020, 1, 2),
+          startTime = LocalTime.of(0, 1),
+          endTime = LocalTime.of(12, 45),
+          notes = "The user provided notes",
+        ),
+      )
+
+      val result = dto.toNDUpdateAppointment(existingAppointment)
+
+      assertThat(result.notes).isEqualTo(
+        """
+          |Appointment Date changed from 03/02/2021 to 02/01/2020
+          |The user provided notes
+        """.trimMargin(),
+      )
+    }
+
+    @Test
+    fun `if start time changes add to note before user provided note`() {
+      val existingAppointment = AppointmentDto.valid().copy(
+        date = LocalDate.of(2021, 2, 3),
+        startTime = LocalTime.of(1, 2),
+        endTime = LocalTime.of(12, 45),
+      )
+
+      val dto = ValidatedAppointment.validUpdateAppointment().copy(
+        dto = UpdateAppointmentOutcomeDto.valid().copy(
+          date = LocalDate.of(2021, 2, 3),
+          startTime = LocalTime.of(0, 1),
+          endTime = LocalTime.of(12, 45),
+          notes = "The user provided notes",
+        ),
+      )
+
+      val result = dto.toNDUpdateAppointment(existingAppointment)
+
+      assertThat(result.notes).isEqualTo(
+        """
+          |Appointment Start Time changed from 01:02 to 00:01
+          |The user provided notes
+        """.trimMargin(),
+      )
+    }
+
+    @Test
+    fun `if end time changes add to note before user provided note`() {
+      val existingAppointment = AppointmentDto.valid().copy(
+        date = LocalDate.of(2021, 2, 3),
+        startTime = LocalTime.of(1, 2),
+        endTime = LocalTime.of(12, 45),
+      )
+
+      val dto = ValidatedAppointment.validUpdateAppointment().copy(
+        dto = UpdateAppointmentOutcomeDto.valid().copy(
+          date = LocalDate.of(2021, 2, 3),
+          startTime = LocalTime.of(1, 2),
+          endTime = LocalTime.of(13, 50),
+          notes = "The user provided notes",
+        ),
+      )
+
+      val result = dto.toNDUpdateAppointment(existingAppointment)
+
+      assertThat(result.notes).isEqualTo(
+        """
+          |Appointment End Time changed from 12:45 to 13:50
+          |The user provided notes
+        """.trimMargin(),
+      )
+    }
+
+    @Test
+    fun `all date time fields change without user provided note`() {
+      val existingAppointment = AppointmentDto.valid().copy(
+        date = LocalDate.of(2020, 1, 2),
+        startTime = LocalTime.of(2, 2, 1),
+        endTime = LocalTime.of(11, 11, 10),
+      )
+
+      val dto = ValidatedAppointment.validUpdateAppointment().copy(
+        dto = UpdateAppointmentOutcomeDto.valid().copy(
+          date = LocalDate.of(2018, 12, 9),
+          startTime = LocalTime.of(3, 2, 1),
+          endTime = LocalTime.of(12, 11, 10),
+          notes = " ",
+        ),
+      )
+
+      val result = dto.toNDUpdateAppointment(existingAppointment)
+
+      assertThat(result.notes).isEqualTo(
+        """
+          |Appointment Date changed from 02/01/2020 to 09/12/2018
+          |Appointment Start Time changed from 02:02:01 to 03:02:01
+          |Appointment End Time changed from 11:11:10 to 12:11:10
+        """.trimMargin(),
+      )
     }
   }
 


### PR DESCRIPTION
Example note when changing start/end time for a group session:

<img width="1382" height="227" alt="image" src="https://github.com/user-attachments/assets/e9431c83-b321-4829-9b93-807e78ece25a" />

Example note when recording course completion outcome and modifying the date and end time (start time was already set to 00:00)

<img width="1371" height="222" alt="image" src="https://github.com/user-attachments/assets/7aaa1833-4fb7-4768-b5f5-e2b081b44e28" />