### PR TITLE
CPB-825 Add update appointment endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
@@ -16,12 +16,14 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.badRequest
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEventTriggerType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentEventTrigger
@@ -71,13 +73,52 @@ class AdminAppointmentController(
     deliusAppointmentId = deliusAppointmentId,
   )
 
+  @PutMapping(
+    path = ["/projects/{projectCode}/appointments/{deliusAppointmentId}"],
+    consumes = [MediaType.APPLICATION_JSON_VALUE],
+  )
+  @Operation(
+    description = "Record an appointment's outcome",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Appointment update is (or has already) been recorded",
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Invalid appointment ID provided",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "409",
+        description = "A newer version of the appointment exists in Delius",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun updateAppointment(
+    @PathVariable projectCode: String,
+    @PathVariable deliusAppointmentId: Long,
+    @RequestBody update: UpdateAppointmentDto,
+  ) = updateAppointmentOutcome(projectCode, deliusAppointmentId, update.toUpdateAppointmentOutcomeDto())
+
   @PostMapping(
     path = ["/projects/{projectCode}/appointments/{deliusAppointmentId}/outcome"],
     consumes = [MediaType.APPLICATION_JSON_VALUE],
   )
   @Operation(
-    description = """Record an appointment's outcome. This endpoint is idempotent -  
-      If the most recent recorded outcome matches the values in the request nothing will be done and a 200 will be returned.""",
+    deprecated = true,
+    description = """Deprecated, instead use PUT /admin/projects/{projectCode}/appointments/{deliusAppointmentId}""",
     responses = [
       ApiResponse(
         responseCode = "200",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorAppointmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorAppointmentsController.kt
@@ -8,11 +8,13 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.badRequest
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomesDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEventTriggerType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentEventTrigger
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentService
@@ -60,13 +62,52 @@ class SupervisorAppointmentsController(
     deliusAppointmentId = deliusAppointmentId,
   )
 
+  @PutMapping(
+    path = ["/{deliusAppointmentId}"],
+    consumes = [MediaType.APPLICATION_JSON_VALUE],
+  )
+  @Operation(
+    description = "Record an appointment's outcome",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Appointment update is (or has already) been recorded",
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Invalid appointment ID provided",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "409",
+        description = "A newer version of the appointment exists in Delius",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun updateAppointment(
+    @PathVariable projectCode: String,
+    @PathVariable deliusAppointmentId: Long,
+    @RequestBody outcome: UpdateAppointmentDto,
+  ) = updateAppointmentOutcome(projectCode, deliusAppointmentId, outcome.toUpdateAppointmentOutcomeDto())
+
   @PostMapping(
     path = ["/{deliusAppointmentId}/outcome"],
     consumes = [MediaType.APPLICATION_JSON_VALUE],
   )
   @Operation(
-    description = """Record an appointment's outcome. This endpoint is idempotent -  
-      If the most recent recorded outcome matches the values in the request nothing will be done and a 200 will be returned""",
+    deprecated = true,
+    description = """Deprecated, instead use PUT /supervisor/projects/{projectCode}/appointments/{deliusAppointmentId}""",
     responses = [
       ApiResponse(
         responseCode = "200",
@@ -136,13 +177,12 @@ class SupervisorAppointmentsController(
       ),
     ],
   )
-  @SuppressWarnings("UnusedParameter")
-  fun updateAppointmentOutcomes(
+  fun updateAppointments(
     @PathVariable projectCode: String,
-    @RequestBody request: UpdateAppointmentOutcomesDto,
+    @RequestBody request: UpdateAppointmentsDto,
   ) = appointmentService.updateAppointmentOutcomes(
     projectCode = projectCode,
-    request = request,
+    request = request.toUpdateAppointmentOutcomesDto(),
     trigger = AppointmentEventTrigger(
       triggeredAt = OffsetDateTime.now(),
       triggerType = AppointmentEventTriggerType.USER,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/UpdateAppointmentDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/UpdateAppointmentDto.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.UUID
+
+data class UpdateAppointmentsDto(
+  val updates: List<UpdateAppointmentDto>,
+) {
+  companion object
+
+  fun toUpdateAppointmentOutcomesDto() = UpdateAppointmentOutcomesDto(
+    updates.map { it.toUpdateAppointmentOutcomeDto() },
+  )
+}
+
+data class UpdateAppointmentDto(
+  @param:Schema(description = "Delius ID of the appointment to update")
+  val deliusId: Long,
+  @param:Schema(description = "The version of the appointment retrieved from delius this update is being applied to")
+  val deliusVersionToUpdate: UUID,
+  val date: LocalDate,
+  @param:Schema(example = "09:00", description = "The start local time of the appointment", pattern = "^([0-1][0-9]|2[0-3]):[0-5][0-9]$")
+  override val startTime: LocalTime,
+  @param:Schema(example = "14:00", description = "The end local time of the appointment", pattern = "^([0-1][0-9]|2[0-3]):[0-5][0-9]$")
+  override val endTime: LocalTime,
+  override val contactOutcomeCode: String?,
+  override val attendanceData: AttendanceDataDto?,
+  val supervisorOfficerCode: String,
+  override val notes: String? = null,
+  val alertActive: Boolean?,
+  @param:Schema(description = "If the corresponding delius contact should be marked as sensitive")
+  val sensitive: Boolean?,
+) : AppointmentCommandDto {
+  companion object
+
+  fun toUpdateAppointmentOutcomeDto() = UpdateAppointmentOutcomeDto(
+    deliusId = deliusId,
+    deliusVersionToUpdate = deliusVersionToUpdate,
+    date = date,
+    startTime = startTime,
+    endTime = endTime,
+    contactOutcomeCode = contactOutcomeCode,
+    attendanceData = attendanceData,
+    enforcementData = null,
+    supervisorOfficerCode = supervisorOfficerCode,
+    alertActive = alertActive,
+    sensitive = sensitive,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/UpdateAppointmentDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/UpdateAppointmentDtoFactory.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto
+
+import org.springframework.beans.factory.getBean
+import org.springframework.context.ApplicationContext
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AttendanceDataDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentsDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.UUID
+
+fun UpdateAppointmentsDto.Companion.valid() = UpdateAppointmentsDto(
+  updates = listOf(UpdateAppointmentDto.valid()),
+)
+
+fun UpdateAppointmentDto.Companion.valid() = UpdateAppointmentDto(
+  deliusId = Long.random(),
+  deliusVersionToUpdate = UUID.randomUUID(),
+  date = LocalDate.now(),
+  startTime = LocalTime.of(10, 0),
+  endTime = LocalTime.of(16, 0),
+  contactOutcomeCode = String.random(5),
+  supervisorOfficerCode = String.random(),
+  notes = String.random(400),
+  attendanceData = AttendanceDataDto.valid(),
+  alertActive = Boolean.random(),
+  sensitive = Boolean.random(),
+)
+
+fun UpdateAppointmentDto.Companion.valid(ctx: ApplicationContext) = UpdateAppointmentDto.valid().copy(
+  contactOutcomeCode = ctx.getBean<ContactOutcomeEntityRepository>().findAll().first().code,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AttendanceDataDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEventEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskEntityRepository
@@ -126,6 +127,120 @@ class AdminAppointmentIT : IntegrationTestBase() {
 
       assertThat(response.id).isEqualTo(id)
       assertThat(response.projectName).isEqualTo(projectName)
+    }
+  }
+
+  @Nested
+  @DisplayName("PUT /admin/projects/{projectCode}/appointments/{deliusAppointmentId}")
+  inner class PutAppointmentEndpoint {
+
+    @BeforeEach
+    fun setUp() {
+      appointmentOutcomeEntityRepository.deleteAll()
+    }
+
+    @Test
+    fun `should return unauthorized if no token`() {
+      webTestClient.put()
+        .uri("/admin/projects/proj123/appointments/1234")
+        .bodyValue(UpdateAppointmentDto.valid())
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden if no role`() {
+      webTestClient.put()
+        .uri("/admin/projects/proj123/appointments/1234")
+        .bodyValue(UpdateAppointmentDto.valid())
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `should return forbidden if wrong role`() {
+      webTestClient.put()
+        .uri("/admin/projects/proj123/appointments/1234")
+        .bodyValue(UpdateAppointmentDto.valid())
+        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `Should return 404 if an appointment can't be found`() {
+      CommunityPaybackAndDeliusMockServer.setupGetAppointment404Response(
+        projectCode = "proj123",
+        appointmentId = 1234L,
+        username = "theusername",
+      )
+
+      val response = webTestClient.put()
+        .uri("/admin/projects/proj123/appointments/1234")
+        .addAdminUiAuthHeader("theusername")
+        .bodyValue(
+          UpdateAppointmentDto.valid(ctx).copy(
+            deliusId = 1234L,
+            attendanceData = AttendanceDataDto.valid(),
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+        .bodyAsObject<ErrorResponse>()
+
+      assertThat(response.userMessage).isEqualTo("No resource found failure: Appointment not found for ID 'Project proj123, NDelius ID 1234'")
+    }
+
+    @Test
+    fun `Should update upstream, raise domain event and create travel time task`() {
+      appointmentTaskEntityRepository.deleteAll()
+
+      CommunityPaybackAndDeliusMockServer.Aggregates.setupGetDataMocksForUpdateAppointment(
+        existingAppointment = NDAppointment.validNoOutcome(ctx).copy(
+          id = 1234L,
+          project = NDProjectAndLocation.valid().copy(code = "proj123"),
+          date = LocalDate.now(),
+          event = NDEvent.valid().copy(number = EVENT_NUMBER),
+          case = NDCaseSummary.valid().copy(crn = CRN),
+        ),
+        username = "theusername",
+        project = NDProject.valid(ctx).copy(code = "proj123", type = NDProjectType.valid().copy(code = GROUP_PLACEMENT_NATIONAL_PROJECT_CODE)),
+      )
+
+      CommunityPaybackAndDeliusMockServer.setupPutAppointmentResponse(
+        projectCode = "proj123",
+        appointmentId = 1234L,
+      )
+
+      webTestClient.put()
+        .uri("/admin/projects/proj123/appointments/1234")
+        .addAdminUiAuthHeader("theusername")
+        .bodyValue(
+          UpdateAppointmentDto.valid(ctx).copy(
+            deliusId = 1234L,
+            attendanceData = AttendanceDataDto.valid(),
+            contactOutcomeCode = CODE_ATTENDED_COMPLIED,
+            startTime = LocalTime.of(0, 0),
+            endTime = LocalTime.of(1, 0),
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isOk()
+
+      CommunityPaybackAndDeliusMockServer.verifyPutAppointmentRequest(
+        projectCode = "proj123",
+        appointmentId = 1234L,
+      )
+
+      domainEventAsserter.assertEventCount("community-payback.appointment.updated", 1)
+
+      assertThat(appointmentTaskEntityRepository.findAll()).hasSize(1)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/SupervisorAppointmentsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/SupervisorAppointmentsIT.kt
@@ -16,9 +16,10 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProject
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProjectAndLocation
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AttendanceDataDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeResultType
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomesDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentsOutcomesResultDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEventEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
@@ -115,6 +116,112 @@ class SupervisorAppointmentsIT : IntegrationTestBase() {
 
       assertThat(response.id).isEqualTo(id)
       assertThat(response.projectName).isEqualTo(projectName)
+    }
+  }
+
+  @Nested
+  @DisplayName("PUT /supervisor/projects/{projectCode}/appointments/{deliusAppointmentId}")
+  inner class PutAppointment {
+
+    @BeforeEach
+    fun setUp() {
+      appointmentOutcomeEntityRepository.deleteAll()
+    }
+
+    @Test
+    fun `should return unauthorized if no token`() {
+      webTestClient.put()
+        .uri("/supervisor/projects/PC01/appointments/1234")
+        .bodyValue(UpdateAppointmentDto.valid())
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden if no role`() {
+      webTestClient.put()
+        .uri("/supervisor/projects/PC01/appointments/1234")
+        .bodyValue(UpdateAppointmentDto.valid())
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `should return forbidden if wrong role`() {
+      webTestClient.put()
+        .uri("/supervisor/projects/PC01/appointments/1234")
+        .bodyValue(UpdateAppointmentDto.valid())
+        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `Should return 404 if an appointment can't be found`() {
+      CommunityPaybackAndDeliusMockServer.setupPutAppointment404Response(
+        projectCode = "PC01",
+        appointmentId = 1234L,
+      )
+
+      val response = webTestClient.put()
+        .uri("/supervisor/projects/PC01/appointments/1234")
+        .addSupervisorUiAuthHeader()
+        .bodyValue(
+          UpdateAppointmentDto.valid(ctx).copy(
+            deliusId = 1234L,
+            attendanceData = AttendanceDataDto.valid(),
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+        .bodyAsObject<ErrorResponse>()
+
+      assertThat(response.userMessage).isEqualTo("No resource found failure: Appointment not found for ID 'Project PC01, NDelius ID 1234'")
+    }
+
+    @Test
+    fun `Should send update upstream and delete corresponding form data`() {
+      CommunityPaybackAndDeliusMockServer.Aggregates.setupGetDataMocksForUpdateAppointment(
+        existingAppointment = NDAppointment.validNoOutcome(ctx).copy(
+          id = 1234L,
+          project = NDProjectAndLocation.valid().copy(code = "PC01"),
+          date = LocalDate.now(),
+          event = NDEvent.valid().copy(number = EVENT_NUMBER),
+          case = NDCaseSummary.valid().copy(crn = CRN),
+        ),
+        username = "theusername",
+        project = NDProject.valid(ctx).copy(code = "PC01"),
+      )
+
+      CommunityPaybackAndDeliusMockServer.setupPutAppointmentResponse(
+        projectCode = "PC01",
+        appointmentId = 1234L,
+      )
+
+      webTestClient.put()
+        .uri("/supervisor/projects/PC01/appointments/1234")
+        .addSupervisorUiAuthHeader("theusername")
+        .bodyValue(
+          UpdateAppointmentDto.valid(ctx).copy(
+            deliusId = 1234L,
+            attendanceData = AttendanceDataDto.valid(),
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isOk()
+
+      CommunityPaybackAndDeliusMockServer.verifyPutAppointmentRequest(
+        projectCode = "PC01",
+        appointmentId = 1234L,
+      )
+
+      domainEventAsserter.assertEventCount("community-payback.appointment.updated", 1)
     }
   }
 
@@ -226,7 +333,7 @@ class SupervisorAppointmentsIT : IntegrationTestBase() {
 
   @Nested
   @DisplayName("POST /supervisor/projects/{projectCode}/appointments/bulk")
-  inner class UpdateAppointmentOutcomes {
+  inner class BulkUpdate {
 
     @BeforeEach
     fun setUp() {
@@ -237,7 +344,7 @@ class SupervisorAppointmentsIT : IntegrationTestBase() {
     fun `should return unauthorized if no token`() {
       webTestClient.post()
         .uri("/supervisor/projects/PC01/appointments/bulk")
-        .bodyValue(UpdateAppointmentOutcomesDto.valid())
+        .bodyValue(UpdateAppointmentsDto.valid())
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -248,7 +355,7 @@ class SupervisorAppointmentsIT : IntegrationTestBase() {
       webTestClient.post()
         .uri("/supervisor/projects/PC01/appointments/bulk")
         .headers(setAuthorisation())
-        .bodyValue(UpdateAppointmentOutcomesDto.valid())
+        .bodyValue(UpdateAppointmentsDto.valid())
         .exchange()
         .expectStatus()
         .isForbidden
@@ -259,7 +366,7 @@ class SupervisorAppointmentsIT : IntegrationTestBase() {
       webTestClient.post()
         .uri("/supervisor/projects/PC01/appointments/bulk")
         .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
-        .bodyValue(UpdateAppointmentOutcomesDto.valid())
+        .bodyValue(UpdateAppointmentsDto.valid())
         .exchange()
         .expectStatus()
         .isForbidden
@@ -311,10 +418,10 @@ class SupervisorAppointmentsIT : IntegrationTestBase() {
         .uri("/supervisor/projects/PC01/appointments/bulk")
         .addSupervisorUiAuthHeader("theusername")
         .bodyValue(
-          UpdateAppointmentOutcomesDto(
+          UpdateAppointmentsDto(
             updates = listOf(
-              UpdateAppointmentOutcomeDto.valid(ctx).copy(deliusId = 1234L),
-              UpdateAppointmentOutcomeDto.valid(ctx).copy(deliusId = 5678L),
+              UpdateAppointmentDto.valid(ctx).copy(deliusId = 1234L),
+              UpdateAppointmentDto.valid(ctx).copy(deliusId = 5678L),
             ),
           ),
         )


### PR DESCRIPTION
Adds a new `UpdateAppointmentDto`, replacing `UpdateAppointmentOutcomeDto`

Deprecate the update appointment outcome endpoints and update the existing unused bulk update endpoint to instead use `UpdateAppointmentDto`.

Internally the code is still using `UpdateAppointmentOutcomeDto` to support the absence of an appointment date on the update request. Once the UI is using the new `UpdateAppointmentDto` we can remove `UpdateAppointmentOutcomeDto`