### PR TITLE
Remove `CreateAppointmentDto.id`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CreateAppointmentDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CreateAppointmentDto.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalTime
-import java.util.UUID
 
 data class CreateAppointmentsDto(
   val projectCode: String,
@@ -11,7 +10,6 @@ data class CreateAppointmentsDto(
 )
 
 data class CreateAppointmentDto(
-  val id: UUID,
   val crn: String,
   val deliusEventNumber: Int,
   val allocationId: Long?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentCreationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentCreationService.kt
@@ -7,7 +7,9 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCreateAppointme
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCreatedAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentsDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService.ValidatedAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.ToAppointmentEntity.toAppointmentEntity
@@ -20,6 +22,7 @@ class AppointmentCreationService(
   private val communityPaybackAndDeliusClient: CommunityPaybackAndDeliusClient,
   private val appointmentEntityRepository: AppointmentEntityRepository,
   private val springEventPublisher: SpringEventPublisher,
+  private val appointmentIdGenerator: AppointmentIdGenerator,
 ) {
 
   @Transactional
@@ -45,27 +48,33 @@ class AppointmentCreationService(
     require(createAppointmentsDto.appointments.isNotEmpty()) { "At least one appointment must be provided" }
     require(createAppointmentsDto.appointments.count { it.projectCode != createAppointmentsDto.projectCode } == 0) { "All appointments must be for the same project code" }
 
-    val validatedAppointments = appointments.map { appointmentValidationService.validateCreate(it) }
+    val appointmentsToCreate = appointments.map {
+      AppointmentToCreate(
+        id = appointmentIdGenerator.generateId(),
+        validatedAppointment = appointmentValidationService.validateCreate(it),
+      )
+    }
 
     val creationResponse = communityPaybackAndDeliusClient.createAppointments(
       projectCode = projectCode,
-      appointments = NDCreateAppointments(validatedAppointments.map { it.toNDCreateAppointment() }),
+      appointments = NDCreateAppointments(appointmentsToCreate.map { it.validatedAppointment.toNDCreateAppointment(it.id) }),
     )
 
     val appointmentEntities = appointmentEntityRepository.saveAll(
-      validatedAppointments.map {
-        it.dto.toAppointmentEntity(
-          deliusAppointmentId = creationResponse.findDeliusId(communityPaybackId = it.dto.id),
-          providerCode = it.project.providerCode,
+      appointmentsToCreate.map {
+        it.validatedAppointment.dto.toAppointmentEntity(
+          id = it.id,
+          deliusAppointmentId = creationResponse.findDeliusId(communityPaybackId = it.id),
+          providerCode = it.validatedAppointment.project.providerCode,
         )
       },
     )
 
-    validatedAppointments.forEach { validatedCreateAppointment ->
+    appointmentsToCreate.forEach { appointmentToCreate ->
       springEventPublisher.publishEvent(
         CommunityPaybackSpringEvent.AppointmentCreatedEvent(
-          createDto = validatedCreateAppointment,
-          appointmentEntity = appointmentEntities.first { it.id == validatedCreateAppointment.dto.id },
+          createDto = appointmentToCreate.validatedAppointment,
+          appointmentEntity = appointmentEntities.first { it.id == appointmentToCreate.id },
           trigger = trigger,
         ),
       )
@@ -74,5 +83,19 @@ class AppointmentCreationService(
     return creationResponse.map { it.id }
   }
 
+  data class AppointmentToCreate(
+    val id: UUID,
+    val validatedAppointment: ValidatedAppointment<CreateAppointmentDto>,
+  )
+
   private fun List<NDCreatedAppointment>.findDeliusId(communityPaybackId: UUID) = first { it.reference == communityPaybackId }.id
+}
+
+interface AppointmentIdGenerator {
+  fun generateId(): UUID
+}
+
+@Service
+class DefaultAppointmentIdGenerator : AppointmentIdGenerator {
+  override fun generateId() = AppointmentEntity.generateId()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentEventEntityFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentEventEntityFactory.kt
@@ -26,7 +26,7 @@ class AppointmentEventEntityFactory(
     val supervisorCode = createAppointmentDto.supervisorOfficerCode ?: providerService.getTeamUnallocatedSupervisor(project.getTeamId()).code
 
     return AppointmentEventEntity(
-      id = createAppointmentDto.id,
+      id = appointment.id,
       appointment = appointment,
       eventType = AppointmentEventType.CREATE,
       priorDeliusVersion = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EnforcementAction
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.WorkQuality
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService.ValidatedAppointment
+import java.util.UUID
 
 @Service
 class AppointmentMappers(
@@ -200,10 +201,12 @@ private fun ValidatedAppointment<UpdateAppointmentOutcomeDto>.buildUpdateNote(
   }
 }.trimEnd().ifBlank { null }
 
-fun ValidatedAppointment<CreateAppointmentDto>.toNDCreateAppointment(): NDCreateAppointment {
+fun ValidatedAppointment<CreateAppointmentDto>.toNDCreateAppointment(
+  id: UUID,
+): NDCreateAppointment {
   val createDto = this.dto
   return NDCreateAppointment(
-    reference = createDto.id,
+    reference = id,
     crn = createDto.crn,
     eventNumber = createDto.deliusEventNumber,
     date = createDto.date,
@@ -231,10 +234,11 @@ fun ValidatedAppointment<CreateAppointmentDto>.toNDCreateAppointment(): NDCreate
 object ToAppointmentEntity {
 
   fun CreateAppointmentDto.toAppointmentEntity(
+    id: UUID,
     deliusAppointmentId: Long,
     providerCode: String,
   ): AppointmentEntity = AppointmentEntity(
-    id = this.id,
+    id = id,
     deliusId = deliusAppointmentId,
     crn = this.crn,
     deliusEventNumber = this.deliusEventNumber,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/EteMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/EteMappers.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionReso
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionEventDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.CommunityCampusPduEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
@@ -39,7 +38,6 @@ class EteMappers(
   ): CreateAppointmentDto {
     val creditTime = courseCompletionResolution.creditTimeDetails!!
     return CreateAppointmentDto(
-      id = AppointmentEntity.generateId(),
       crn = courseCompletionResolution.crn!!,
       deliusEventNumber = creditTime.deliusEventNumber,
       allocationId = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/SchedulingDataModels.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/SchedulingDataModels.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.service.scheduling.internal
 
-import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import java.time.DayOfWeek
 import java.time.Duration
 import java.time.LocalDate
@@ -125,7 +124,6 @@ data class SchedulingExistingAppointment(
 }
 
 data class SchedulingRequiredAppointment(
-  val id: UUID = AppointmentEntity.generateId(),
   val date: LocalDate,
   val startTime: LocalTime,
   val endTime: LocalTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/SchedulingMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/SchedulingMappers.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSchedulingExist
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSchedulingFrequency
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSchedulingProject
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import java.time.DayOfWeek
 import java.time.Duration
 
@@ -75,7 +76,7 @@ fun SchedulingRequiredAppointment.toCreateAppointmentDto(
   crn: String,
   eventNumber: Int,
 ) = CreateAppointmentDto(
-  id = id,
+  id = AppointmentEntity.generateId(),
   crn = crn,
   deliusEventNumber = eventNumber,
   allocationId = allocation.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/SchedulingMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/SchedulingMappers.kt
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSchedulingExist
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSchedulingFrequency
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSchedulingProject
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import java.time.DayOfWeek
 import java.time.Duration
 
@@ -76,7 +75,6 @@ fun SchedulingRequiredAppointment.toCreateAppointmentDto(
   crn: String,
   eventNumber: Int,
 ) = CreateAppointmentDto(
-  id = AppointmentEntity.generateId(),
   crn = crn,
   deliusEventNumber = eventNumber,
   allocationId = allocation.id,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/SchedulingRenderer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/SchedulingRenderer.kt
@@ -163,10 +163,8 @@ object SchedulingRenderer {
     }
   }
 
-  // "28f0, Today+6, ALLOC1, 16:00-20:00"
+  // "Today+6, ALLOC1, 16:00-20:00"
   private fun SchedulingRequiredAppointment.render(today: LocalDate) = buildString {
-    append(id.toString().substring(0, 4))
-    append(", ")
     append(dayAsDelta(today, date))
     append(", ")
     append(project.code)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/CreateAppointmentDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/CreateAppointmentDtoFactory.kt
@@ -6,10 +6,8 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomLocalDate
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomLocalTime
 import java.time.LocalTime
-import java.util.UUID
 
 fun CreateAppointmentDto.Companion.valid() = CreateAppointmentDto(
-  id = UUID.randomUUID(),
   crn = String.random(5),
   deliusEventNumber = Int.random(50),
   allocationId = Long.random(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentCreationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentCreationServiceTest.kt
@@ -22,12 +22,14 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.validCreateA
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentCreationService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentEventTrigger
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentIdGenerator
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService.ValidatedAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.ToAppointmentEntity.toAppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toNDCreateAppointment
+import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
 class AppointmentCreationServiceTest {
@@ -42,6 +44,9 @@ class AppointmentCreationServiceTest {
 
   @RelaxedMockK
   lateinit var springEventPublisher: SpringEventPublisher
+
+  @RelaxedMockK
+  lateinit var appointmentIdGenerator: AppointmentIdGenerator
 
   @InjectMockKs
   private lateinit var service: AppointmentCreationService
@@ -91,6 +96,10 @@ class AppointmentCreationServiceTest {
 
     @Test
     fun `create appointments persists data, sends to ND and raises a domain events`() {
+      val appointment1Id = UUID.randomUUID()
+      val appointment2Id = UUID.randomUUID()
+      every { appointmentIdGenerator.generateId() } returnsMany listOf(appointment1Id, appointment2Id)
+
       val createAppointment1Dto = CreateAppointmentDto.valid().copy(crn = CRN, deliusEventNumber = DELIUS_EVENT_NUMBER, projectCode = PROJECT_CODE)
       val createAppointment2Dto = CreateAppointmentDto.valid().copy(crn = CRN, deliusEventNumber = DELIUS_EVENT_NUMBER, projectCode = PROJECT_CODE)
 
@@ -99,18 +108,23 @@ class AppointmentCreationServiceTest {
       val validatedCreateAppointment2 = ValidatedAppointment.validCreateAppointment().copy(dto = createAppointment2Dto, project = PROJECT)
       every { appointmentValidationService.validateCreate(createAppointment2Dto) } returns validatedCreateAppointment2
 
-      val appointmentEntity1 = createAppointment1Dto.toAppointmentEntity(ND_APPT1_ID, PROVIDER_CODE)
-      val appointmentEntity2 = createAppointment2Dto.toAppointmentEntity(ND_APPT2_ID, PROVIDER_CODE)
+      val appointmentEntity1 = createAppointment1Dto.toAppointmentEntity(appointment1Id, ND_APPT1_ID, PROVIDER_CODE)
+      val appointmentEntity2 = createAppointment2Dto.toAppointmentEntity(appointment2Id, ND_APPT2_ID, PROVIDER_CODE)
       every { appointmentEntityRepository.saveAll(listOf(appointmentEntity1, appointmentEntity2)) } returnsArgument 0
 
       every {
         communityPaybackAndDeliusClient.createAppointments(
           projectCode = PROJECT_CODE,
-          NDCreateAppointments(listOf(validatedCreateAppointment1.toNDCreateAppointment(), validatedCreateAppointment2.toNDCreateAppointment())),
+          NDCreateAppointments(
+            listOf(
+              validatedCreateAppointment1.toNDCreateAppointment(appointment1Id),
+              validatedCreateAppointment2.toNDCreateAppointment(appointment2Id),
+            ),
+          ),
         )
       } returns listOf(
-        NDCreatedAppointment(id = ND_APPT1_ID, reference = createAppointment1Dto.id),
-        NDCreatedAppointment(id = ND_APPT2_ID, reference = createAppointment2Dto.id),
+        NDCreatedAppointment(id = ND_APPT1_ID, reference = appointment1Id),
+        NDCreatedAppointment(id = ND_APPT2_ID, reference = appointment2Id),
       )
 
       val result = service.createAppointmentsForProject(
@@ -126,8 +140,8 @@ class AppointmentCreationServiceTest {
       verify {
         appointmentEntityRepository.saveAll(
           listOf(
-            createAppointment1Dto.toAppointmentEntity(ND_APPT1_ID, PROVIDER_CODE),
-            createAppointment2Dto.toAppointmentEntity(ND_APPT2_ID, PROVIDER_CODE),
+            createAppointment1Dto.toAppointmentEntity(appointment1Id, ND_APPT1_ID, PROVIDER_CODE),
+            createAppointment2Dto.toAppointmentEntity(appointment2Id, ND_APPT2_ID, PROVIDER_CODE),
           ),
         )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentEventEntityFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentEventEntityFactoryTest.kt
@@ -98,7 +98,6 @@ class AppointmentEventEntityFactoryTest {
           ),
           createDto = ValidatedAppointment.validCreateAppointment().copy(
             dto = CreateAppointmentDto(
-              id = ID,
               crn = "X12345",
               deliusEventNumber = 48,
               allocationId = 22,
@@ -170,7 +169,6 @@ class AppointmentEventEntityFactoryTest {
           ),
           createDto = ValidatedAppointment.validCreateAppointment().copy(
             dto = CreateAppointmentDto(
-              id = ID,
               crn = "X12345",
               deliusEventNumber = 48,
               allocationId = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
@@ -87,7 +87,6 @@ class AppointmentMappersTest {
 
       val dto = ValidatedAppointment(
         dto = CreateAppointmentDto.valid().copy(
-          id = appointmentId,
           crn = "CRN123",
           deliusEventNumber = 5,
           date = LocalDate.of(2028, 7, 6),
@@ -112,7 +111,7 @@ class AppointmentMappersTest {
         project = ProjectDto.valid(),
       )
 
-      val result = dto.toNDCreateAppointment()
+      val result = dto.toNDCreateAppointment(appointmentId)
 
       assertThat(result.reference).isEqualTo(appointmentId)
       assertThat(result.crn).isEqualTo("CRN123")
@@ -141,7 +140,6 @@ class AppointmentMappersTest {
 
       val dto = ValidatedAppointment(
         dto = CreateAppointmentDto.valid().copy(
-          id = appointmentId,
           crn = "CRN123",
           deliusEventNumber = 5,
           date = LocalDate.of(2028, 7, 6),
@@ -160,7 +158,7 @@ class AppointmentMappersTest {
         project = ProjectDto.valid(),
       )
 
-      val result = dto.toNDCreateAppointment()
+      val result = dto.toNDCreateAppointment(appointmentId)
 
       assertThat(result.reference).isEqualTo(appointmentId)
       assertThat(result.crn).isEqualTo("CRN123")
@@ -694,11 +692,11 @@ class AppointmentMappersTest {
     fun success() {
       val communityPaybackId = UUID.randomUUID()
       val result = CreateAppointmentDto.valid().copy(
-        id = communityPaybackId,
         crn = "CRN777",
         deliusEventNumber = 90,
         date = LocalDate.of(2009, 8, 7),
       ).toAppointmentEntity(
+        id = communityPaybackId,
         deliusAppointmentId = 91283,
         providerCode = "PROV1",
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/EteMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/EteMappersTest.kt
@@ -103,7 +103,6 @@ class EteMappersTest {
       )
 
       assertThat(result).isNotNull
-      assertThat(result.id).isNotNull()
       assertThat(result.crn).isEqualTo(CRN)
       assertThat(result.deliusEventNumber).isEqualTo(DELIUS_EVENT_NUMBER)
       assertThat(result.allocationId).isNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/scheduling/SchedulingMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/scheduling/SchedulingMappersTest.kt
@@ -32,7 +32,6 @@ import java.time.DayOfWeek
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
-import java.util.UUID
 
 class SchedulingMappersTest {
 
@@ -305,7 +304,6 @@ class SchedulingMappersTest {
     @Test
     fun `map all fields`() {
       val result = SchedulingRequiredAppointment(
-        id = UUID.randomUUID(),
         date = LocalDate.of(2021, 9, 8),
         startTime = LocalTime.of(1, 2),
         endTime = LocalTime.of(11, 12),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/scheduling/scenarios/SchedulingScenarioDsl.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/scheduling/scenarios/SchedulingScenarioDsl.kt
@@ -23,7 +23,6 @@ import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.temporal.TemporalAdjusters
-import java.util.UUID
 
 @DslMarker
 annotation class SchedulingScenarioDslMarker
@@ -139,27 +138,13 @@ class SchedulingScenarioBuilder {
       )
       expectedActions.apply(init)
 
-      val testReference = UUID.randomUUID()
+      val actualCreations = insufficient.plan.actions.filterIsInstance<SchedulingAction.CreateAppointment>()
 
-      val actualCreations = insufficient.plan.actions.filterIsInstance<SchedulingAction.CreateAppointment>().allWithSameReference(testReference)
-
-      assertThat(actualCreations).containsExactlyInAnyOrderElementsOf(expectedActions.actions.allWithSameReference(testReference))
+      assertThat(actualCreations).containsExactlyInAnyOrderElementsOf(expectedActions.actions)
 
       toAddressShortfall?.let {
         assertThat(insufficient.plan.shortfall).isEqualTo(it)
       }
-    }
-
-    /*
-    Because reference is a random UUID we can't know its value before running the test
-
-    Attempts to ignore this field when checking lists in assertj using `usingRecursiveFieldByFieldElementComparator`
-    failed, so instead we set the reference to the same value for all entries before doing a comparison
-     */
-    private fun List<SchedulingAction.CreateAppointment>.allWithSameReference(reference: UUID) = map {
-      SchedulingAction.CreateAppointment(
-        toCreate = it.toCreate.copy(id = reference),
-      )
     }
 
     fun noActionsExpected(toAddressShortfall: Duration? = null) {


### PR DESCRIPTION
IDs should be managed within service code and not by clients of the API