### PR TITLE
Add a ‘clean’ log for course completion messages

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/listener/EducationCourseCompletionListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/listener/EducationCourseCompletionListener.kt
@@ -20,7 +20,7 @@ class EducationCourseCompletionListener(
   @param:Value("\${community-payback.education-course-integration.log-messages:false}") private val logMessages: Boolean,
 ) {
   private companion object {
-    val log: Logger = LoggerFactory.getLogger(this::class.java)
+    val log: Logger = LoggerFactory.getLogger(this::class.java.name + ".message")
   }
 
   @SqsListener(
@@ -33,7 +33,7 @@ class EducationCourseCompletionListener(
     @Headers headers: MessageHeaders,
   ) {
     if (logMessages) {
-      log.debug("Have received education course course completion message '$messageString'")
+      log.info(messageString)
     }
     sqsListenerErrorHandler.withErrorHandler(headers) {
       val message = jsonMapper.readValue(messageString, EducationCourseCompletionMessage::class.java)


### PR DESCRIPTION
This commit tweaks the course completion message logging to make it easy to extract and replay messages from logs to support replaying messages into the test environment

Note that these logs are only enabled locally and in dev/test