### PR TITLE
Remove `CreateAppointmentDto.pickUpLocationDescription`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.format.annotation.DateTimeFormat
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
@@ -89,7 +88,7 @@ interface CommunityPaybackAndDeliusClient {
   ): NDSupervisorSummaries
 
   @Cacheable(CacheKey.Delius.GET_TEAM_LOCATIONS)
-  @GetMapping("/providers/team/{teamCode}/locations")
+  @GetExchange("/providers/team/{teamCode}/locations")
   fun getTeamLocations(@PathVariable teamCode: String): NDPickUpLocationsResponse
 
   @GetExchange("/case/{crn}/event/{eventNumber}/appointments/schedule")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
@@ -86,6 +87,10 @@ interface CommunityPaybackAndDeliusClient {
     @PathVariable providerCode: String,
     @PathVariable teamCode: String,
   ): NDSupervisorSummaries
+
+  @Cacheable(CacheKey.Delius.GET_TEAM_LOCATIONS)
+  @GetMapping("/providers/team/{teamCode}/locations")
+  fun getTeamLocations(@PathVariable teamCode: String): NDPickUpLocationsResponse
 
   @GetExchange("/case/{crn}/event/{eventNumber}/appointments/schedule")
   fun getUnpaidWorkRequirement(
@@ -618,4 +623,8 @@ enum class NDAdjustmentType(val code: String) {
 
 data class NDAdjustmentPostResponse(
   val id: Long,
+)
+
+data class NDPickUpLocationsResponse(
+  val locations: List<NDPickUpLocation> = emptyList(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CacheConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CacheConfig.kt
@@ -37,6 +37,7 @@ class CacheConfig {
         const val GET_PROVIDERS = "cpAndDelius.getProviders"
         const val GET_PROVIDER_TEAMS = "cpAndDelius.getProviderTeams"
         const val GET_SUPERVISORS = "cpAndDelius.getSupervisors"
+        const val GET_TEAM_LOCATIONS = "cpAndDelius.getTeamLocations"
         const val GET_TEAM_SUPERVISORS = "cpAndDelius.getTeamSupervisors"
         const val GET_NON_WORKING_DAYS = "cpAndDelius.getNonWorkingDays"
       }
@@ -72,6 +73,7 @@ class CacheConfig {
     caffeineCacheManager.registerCustomCache(CacheKey.Delius.GET_PROVIDERS, builder().expireAfterWrite(Duration.ofMinutes(10)).build())
     caffeineCacheManager.registerCustomCache(CacheKey.Delius.GET_PROVIDER_TEAMS, builder().expireAfterWrite(Duration.ofMinutes(5)).build())
     caffeineCacheManager.registerCustomCache(CacheKey.Delius.GET_SUPERVISORS, builder().expireAfterWrite(Duration.ofMinutes(5)).build())
+    caffeineCacheManager.registerCustomCache(CacheKey.Delius.GET_TEAM_LOCATIONS, builder().expireAfterWrite(Duration.ofMinutes(5)).build())
     caffeineCacheManager.registerCustomCache(CacheKey.Delius.GET_TEAM_SUPERVISORS, builder().expireAfterWrite(Duration.ofMinutes(5)).build())
 
     return caffeineCacheManager

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CreateAppointmentDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CreateAppointmentDto.kt
@@ -20,7 +20,6 @@ data class CreateAppointmentDto(
   @param:Schema(example = "14:00", description = "The end local time of the appointment", pattern = "^([0-1][0-9]|2[0-3]):[0-5][0-9]$")
   override val endTime: LocalTime,
   val pickUpLocationCode: String?,
-  val pickUpLocationDescription: String?,
   val pickUpTime: LocalTime?,
   override val contactOutcomeCode: String? = null,
   override val attendanceData: AttendanceDataDto? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/PickUpDataDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/PickUpDataDto.kt
@@ -1,11 +1,19 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
 
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalTime
 
 data class PickUpDataDto(
+  @Deprecated("Use pickupLocation instead")
+  @param:Schema(description = "Use pickupLocation instead", deprecated = true)
   val location: LocationDto?,
+  @Deprecated("Use pickupLocation.deliusCode instead")
+  @param:Schema(description = "Use pickupLocation.deliusCode instead", deprecated = true)
   val locationCode: String?,
+  @Deprecated("Use pickupLocation.description instead")
+  @param:Schema(description = "Use pickupLocation.description instead", deprecated = true)
   val locationDescription: String?,
+  val pickupLocation: PickUpLocationDto?,
   val time: LocalTime?,
 ) {
   companion object

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/PickUpLocationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/PickUpLocationDto.kt
@@ -9,4 +9,6 @@ data class PickUpLocationDto(
   val townCity: String?,
   val county: String?,
   val postCode: String?,
-)
+) {
+  companion object
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/PickUpLocationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/PickUpLocationDto.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
+
+data class PickUpLocationDto(
+  val deliusCode: String,
+  val description: String,
+  val buildingName: String?,
+  val buildingNumber: String?,
+  val streetName: String?,
+  val townCity: String?,
+  val county: String?,
+  val postCode: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentEventEntityFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentEventEntityFactory.kt
@@ -23,6 +23,7 @@ class AppointmentEventEntityFactory(
     val appointment = details.appointmentEntity
     val createAppointmentDto = details.createDto.dto
     val project = details.createDto.project
+    val pickUpLocation = details.createDto.pickUpLocation
     val supervisorCode = createAppointmentDto.supervisorOfficerCode ?: providerService.getTeamUnallocatedSupervisor(project.getTeamId()).code
 
     return AppointmentEventEntity(
@@ -35,8 +36,8 @@ class AppointmentEventEntityFactory(
       date = createAppointmentDto.date,
       startTime = createAppointmentDto.startTime,
       endTime = createAppointmentDto.endTime,
-      pickupLocationCode = createAppointmentDto.pickUpLocationCode,
-      pickupLocationDescription = createAppointmentDto.pickUpLocationDescription,
+      pickupLocationCode = pickUpLocation?.deliusCode,
+      pickupLocationDescription = pickUpLocation?.description,
       pickupTime = createAppointmentDto.pickUpTime,
       contactOutcome = details.createDto.contactOutcome,
       supervisorOfficerCode = supervisorCode,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentValidationService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.common.validateNotNull
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentCommandDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PickUpLocationDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UnpaidWorkDetailsDto
@@ -29,16 +30,20 @@ class AppointmentValidationService(
   private val contactOutcomeEntityRepository: ContactOutcomeEntityRepository,
   private val offenderService: OffenderService,
   private val projectService: ProjectService,
+  private val providerService: ProviderService,
   private val appointmentCalculationService: AppointmentCalculationService,
 ) {
 
   fun validateCreate(
     create: CreateAppointmentDto,
   ): ValidatedAppointment<CreateAppointmentDto> {
+    val project = projectService.getProject(create.projectCode) ?: badRequestReferenceNotFound("Project", create.projectCode)
+
     val ctx = ValidationContext(
       command = create,
-      project = projectService.getProject(create.projectCode) ?: badRequestReferenceNotFound("Project", create.projectCode),
+      project = project,
       contactOutcome = loadContactOutcome(create.contactOutcomeCode),
+      pickUpLocation = loadPickUpLocation(project, create.pickUpLocationCode),
       unpaidWorkDetails = offenderService.getUnpaidWorkDetails(create.crn, create.deliusEventNumber),
       appointmentDate = create.date,
     )
@@ -57,10 +62,13 @@ class AppointmentValidationService(
     existingAppointment: AppointmentDto,
     update: UpdateAppointmentOutcomeDto,
   ): ValidatedAppointment<UpdateAppointmentOutcomeDto> {
+    val project = projectService.getProject(existingAppointment.projectCode) ?: error("Can't retrieve project ${existingAppointment.projectCode}")
+
     val ctx = ValidationContext(
       command = update,
-      project = projectService.getProject(existingAppointment.projectCode) ?: error("Can't retrieve project ${existingAppointment.projectCode}"),
+      project = project,
       contactOutcome = loadContactOutcome(update.contactOutcomeCode),
+      pickUpLocation = loadPickUpLocation(project, existingAppointment.pickUpData?.pickupLocation?.deliusCode),
       unpaidWorkDetails = offenderService.getUnpaidWorkDetails(existingAppointment.offender.crn, existingAppointment.deliusEventNumber),
       appointmentDate = update.resolveDate(existingAppointment),
       appointmentMinutesAlreadyCredited = existingAppointment.minutesCredited?.let { Duration.ofMinutes(it) } ?: Duration.ZERO,
@@ -188,10 +196,15 @@ class AppointmentValidationService(
     contactOutcomeEntityRepository.findByCode(it) ?: badRequest("Contact outcome not found for code '$code'")
   }
 
+  private fun loadPickUpLocation(project: ProjectDto, locationCode: String?) = locationCode?.let {
+    providerService.getPickupLocation(project.getTeamId(), locationCode) ?: badRequest("Pick Up Location not found for team '${project.teamCode}' and code '$locationCode'")
+  }
+
   private data class ValidationContext(
     val project: ProjectDto,
     val command: AppointmentCommandDto,
     val contactOutcome: ContactOutcomeEntity?,
+    val pickUpLocation: PickUpLocationDto?,
     val unpaidWorkDetails: UnpaidWorkDetailsDto,
     val appointmentDate: LocalDate,
     val appointmentMinutesAlreadyCredited: Duration = Duration.ZERO,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentValidationService.kt
@@ -54,6 +54,7 @@ class AppointmentValidationService(
       dto = create,
       minutesToCredit = ctx.calculateMinutesToCredit(),
       contactOutcome = ctx.contactOutcome,
+      pickUpLocation = ctx.pickUpLocation,
       project = ctx.project,
     )
   }
@@ -83,6 +84,7 @@ class AppointmentValidationService(
       dto = update,
       minutesToCredit = ctx.calculateMinutesToCredit(),
       contactOutcome = ctx.contactOutcome,
+      pickUpLocation = ctx.pickUpLocation,
       project = ctx.project,
     )
   }
@@ -220,6 +222,7 @@ class AppointmentValidationService(
     val dto: T,
     val minutesToCredit: Duration? = null,
     val contactOutcome: ContactOutcomeEntity? = null,
+    val pickUpLocation: PickUpLocationDto?,
     val project: ProjectDto,
   ) {
     companion object

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/ProviderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/ProviderService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 
 import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
@@ -16,6 +17,16 @@ class ProviderService(
   fun getTeamSupervisors(teamId: TeamId) = communityPaybackAndDeliusClient.getTeamSupervisors(teamId.providerCode, teamId.teamCode).toDto()
 
   fun getTeamUnallocatedSupervisor(teamId: TeamId) = getTeamSupervisors(teamId).supervisors.firstOrNull { it.unallocated } ?: error("Can't find unallocated supervisor for team '$teamId'")
+
+  fun getPickupLocations(teamId: TeamId) = try {
+    communityPaybackAndDeliusClient.getTeamLocations(teamId.teamCode).locations.map { it.toDto() }
+  } catch (_: WebClientResponseException.NotFound) {
+    null
+  }
+
+  fun getPickupLocation(teamId: TeamId, pickupLocationCode: String) = getPickupLocations(teamId)?.firstOrNull {
+    it.deliusCode == pickupLocationCode
+  }
 }
 
 data class TeamId(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
@@ -262,9 +262,10 @@ fun WorkQuality.Companion.fromDto(dto: AppointmentWorkQualityDto) = WorkQuality.
 fun Behaviour.Companion.fromDto(dto: AppointmentBehaviourDto) = Behaviour.entries.first { it.dtoType == dto }
 
 fun NDAppointmentPickUp.toDto() = PickUpDataDto(
-  location = location?.toDto(),
+  location = location?.toLocationDto(),
   locationCode = location?.code,
   locationDescription = location?.description,
+  pickupLocation = location?.toDto(),
   time = time,
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/EteMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/EteMappers.kt
@@ -46,7 +46,6 @@ class EteMappers(
       startTime = APPOINTMENT_START_TIME,
       endTime = calculateEndTime(creditTime.minutesToCredit),
       pickUpLocationCode = null,
-      pickUpLocationDescription = null,
       pickUpTime = null,
       contactOutcomeCode = creditTime.contactOutcomeCode,
       attendanceData = createAttendanceData(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/PickupLocationMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/PickupLocationMapper.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers
+
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPickUpLocation
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.LocationDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PickUpLocationDto
+
+fun NDPickUpLocation.toLocationDto() = LocationDto(
+  buildingName = this.buildingName,
+  buildingNumber = this.addressNumber,
+  streetName = this.streetName,
+  townCity = this.townCity,
+  county = this.county,
+  postCode = this.postCode,
+)
+
+fun NDPickUpLocation.toDto() = PickUpLocationDto(
+  deliusCode = this.code,
+  description = this.description,
+  buildingName = this.buildingName,
+  buildingNumber = this.addressNumber,
+  streetName = this.streetName,
+  townCity = this.townCity,
+  county = this.county,
+  postCode = this.postCode,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/ProjectLocationMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/ProjectLocationMapper.kt
@@ -1,19 +1,9 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers
 
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAddress
-import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPickUpLocation
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.LocationDto
 
 fun NDAddress.toDto() = LocationDto(
-  buildingName = this.buildingName,
-  buildingNumber = this.addressNumber,
-  streetName = this.streetName,
-  townCity = this.townCity,
-  county = this.county,
-  postCode = this.postCode,
-)
-
-fun NDPickUpLocation.toDto() = LocationDto(
   buildingName = this.buildingName,
   buildingNumber = this.addressNumber,
   streetName = this.streetName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/SchedulingMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/SchedulingMappers.kt
@@ -83,7 +83,6 @@ fun SchedulingRequiredAppointment.toCreateAppointmentDto(
   startTime = this.startTime,
   endTime = this.endTime,
   pickUpLocationCode = this.allocation.pickUpLocationCode,
-  pickUpLocationDescription = this.allocation.pickUpLocationDescription,
   pickUpTime = this.allocation.pickUpTime,
   notes = "[System scheduled appointment]",
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/CreateAppointmentDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/CreateAppointmentDtoFactory.kt
@@ -16,7 +16,6 @@ fun CreateAppointmentDto.Companion.valid() = CreateAppointmentDto(
   startTime = LocalTime.of(10, 0),
   endTime = LocalTime.of(16, 0),
   pickUpLocationCode = String.random(5),
-  pickUpLocationDescription = String.random(50),
   pickUpTime = randomLocalTime(),
   contactOutcomeCode = String.random(5),
   supervisorOfficerCode = String.random(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/PickUpDataDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/PickUpDataDtoFactory.kt
@@ -17,15 +17,6 @@ fun PickUpDataDto.Companion.valid() = PickUpDataDto(
   ),
   locationCode = String.random(5),
   locationDescription = String.random(50),
-  pickupLocation = PickUpLocationDto(
-    deliusCode = String.random(5),
-    description = String.random(50),
-    buildingName = String.random(),
-    buildingNumber = String.random(),
-    streetName = String.random(),
-    townCity = String.random(),
-    county = String.random(),
-    postCode = String.random(),
-  ),
+  pickupLocation = PickUpLocationDto.valid(),
   time = randomLocalTime(),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/PickUpDataDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/PickUpDataDtoFactory.kt
@@ -2,12 +2,13 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto
 
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.LocationDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PickUpDataDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PickUpLocationDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomLocalTime
 
 fun PickUpDataDto.Companion.valid() = PickUpDataDto(
   location = LocationDto(
-    buildingName = String.Companion.random(),
+    buildingName = String.random(),
     buildingNumber = String.random(),
     streetName = String.random(),
     townCity = String.random(),
@@ -16,5 +17,15 @@ fun PickUpDataDto.Companion.valid() = PickUpDataDto(
   ),
   locationCode = String.random(5),
   locationDescription = String.random(50),
+  pickupLocation = PickUpLocationDto(
+    deliusCode = String.random(5),
+    description = String.random(50),
+    buildingName = String.random(),
+    buildingNumber = String.random(),
+    streetName = String.random(),
+    townCity = String.random(),
+    county = String.random(),
+    postCode = String.random(),
+  ),
   time = randomLocalTime(),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/PickUpLocationDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/PickUpLocationDtoFactory.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto
+
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PickUpLocationDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
+
+fun PickUpLocationDto.Companion.valid() = PickUpLocationDto(
+  deliusCode = String.random(5),
+  description = String.random(50),
+  buildingName = String.random(),
+  buildingNumber = String.random(),
+  streetName = String.random(),
+  townCity = String.random(),
+  county = String.random(),
+  postCode = String.random(),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/ValidatedFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/ValidatedFactory.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto
 
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PickUpLocationDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntity
@@ -12,6 +13,7 @@ fun ValidatedAppointment.Companion.validCreateAppointment() = ValidatedAppointme
   dto = CreateAppointmentDto.valid(),
   minutesToCredit = randomDuration(),
   contactOutcome = ContactOutcomeEntity.valid(),
+  pickUpLocation = PickUpLocationDto.valid(),
   project = ProjectDto.valid(),
 )
 
@@ -19,5 +21,6 @@ fun ValidatedAppointment.Companion.validUpdateAppointment() = ValidatedAppointme
   dto = UpdateAppointmentOutcomeDto.valid(),
   minutesToCredit = randomDuration(),
   contactOutcome = ContactOutcomeEntity.valid(),
+  pickUpLocation = PickUpLocationDto.valid(),
   project = ProjectDto.valid(),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
@@ -695,7 +695,7 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
           case = NDCaseSummary.valid().copy(crn = SchedulingIT.CRN),
         ),
         username = "theusername",
-        project = NDProject.valid(ctx).copy(code = "proj123"),
+        project = NDProject.valid(ctx).copy(code = PROJECT_CODE),
       )
 
       CommunityPaybackAndDeliusMockServer.setupPutAppointmentResponse(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/SchedulingIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/SchedulingIT.kt
@@ -302,6 +302,7 @@ class SchedulingIT : IntegrationTestBase() {
       dayOfWeek = NDSchedulingDayOfWeek.Saturday,
       startTime = LocalTime.of(10, 0),
       endTime = LocalTime.of(14, 0),
+      pickUp = null,
     )
 
     // ALLOC2-PROJ1-FN-SUN-12:00-18:00, Started Today-365
@@ -315,6 +316,7 @@ class SchedulingIT : IntegrationTestBase() {
       dayOfWeek = NDSchedulingDayOfWeek.Sunday,
       startTime = LocalTime.of(12, 0),
       endTime = LocalTime.of(18, 0),
+      pickUp = null,
     )
 
     CommunityPaybackAndDeliusMockServer.setupGetUnpaidWorkRequirementResponse(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/SupervisorAppointmentsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/SupervisorAppointmentsIT.kt
@@ -7,13 +7,13 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointment
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointmentPickUp
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDContactOutcome
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDEnforcementAction
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProject
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProjectAndLocation
-import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDUpwDetails
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AttendanceDataDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
@@ -266,44 +266,42 @@ class SupervisorAppointmentsIT : IntegrationTestBase() {
     }
 
     @Test
-    fun `succeeds and calls upstream endpoint`() {
-      CommunityPaybackAndDeliusMockServer.setupGetUpwDetailsSummaryResponse(
-        crn = CRN,
-        case = NDCaseSummary.valid(),
-        unpaidWorkDetails = listOf(
-          NDUpwDetails.valid().copy(
-            eventNumber = EVENT_NUMBER,
-            sentenceDate = LocalDate.now().minusYears(1),
-          ),
-        ),
-      )
+    fun `succeeds and calls upstream endpoint to update the appointment`() {
+      val projectAndLocation = NDProjectAndLocation.valid().copy(code = "PC01")
+      val project = NDProject.valid(ctx).copy(code = "PC01")
+      val pickup = NDAppointmentPickUp.valid()
 
-      CommunityPaybackAndDeliusMockServer.setupGetAppointmentResponse(
-        appointment = NDAppointment.validNoOutcome(ctx).copy(
+      CommunityPaybackAndDeliusMockServer.Aggregates.setupGetDataMocksForUpdateAppointment(
+        existingAppointment = NDAppointment.validNoOutcome(ctx).copy(
           id = 1234L,
-          project = NDProjectAndLocation.valid().copy(code = "PC01"),
+          project = projectAndLocation,
           date = LocalDate.now(),
           event = NDEvent.valid().copy(number = EVENT_NUMBER),
           case = NDCaseSummary.valid().copy(crn = CRN),
+          pickUpData = pickup,
         ),
+        project = project,
         username = "theusername",
       )
-      CommunityPaybackAndDeliusMockServer.setupGetProjectResponse(NDProject.valid(ctx).copy(code = "PC01"))
+
       CommunityPaybackAndDeliusMockServer.setupPutAppointmentResponse(
         projectCode = "PC01",
         appointmentId = 1234L,
       )
 
-      CommunityPaybackAndDeliusMockServer.setupGetAppointmentResponse(
-        appointment = NDAppointment.validNoOutcome(ctx).copy(
+      CommunityPaybackAndDeliusMockServer.Aggregates.setupGetDataMocksForUpdateAppointment(
+        existingAppointment = NDAppointment.validNoOutcome(ctx).copy(
           id = 5678L,
-          project = NDProjectAndLocation.valid().copy(code = "PC01"),
+          project = projectAndLocation,
           date = LocalDate.now(),
           event = NDEvent.valid().copy(number = EVENT_NUMBER),
           case = NDCaseSummary.valid().copy(crn = CRN),
+          pickUpData = pickup,
         ),
+        project = project,
         username = "theusername",
       )
+
       CommunityPaybackAndDeliusMockServer.setupPutAppointmentResponse(
         projectCode = "PC01",
         appointmentId = 5678L,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
@@ -20,6 +20,8 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointmentSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseDetailsSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseSummary
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPickUpLocation
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPickUpLocationsResponse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProject
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProjectOutcomeStats
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProviderSummaries
@@ -278,6 +280,17 @@ object CommunityPaybackAndDeliusMockServer {
     )
   }
 
+  fun setupGetTeamLocations(teamCode: String, locations: NDPickUpLocationsResponse) {
+    WireMock.stubFor(
+      get("/community-payback-and-delius/providers/team/$teamCode/locations")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(jsonMapper.writer().writeValueAsString(locations)),
+        ),
+    )
+  }
+
   fun setupGetTeamSupervisorsResponse(forProject: NDProject, supervisorSummaries: NDSupervisorSummaries) = setupGetTeamSupervisorsResponse(
     providerCode = forProject.provider.code,
     teamCode = forProject.team.code,
@@ -480,6 +493,9 @@ object CommunityPaybackAndDeliusMockServer {
         crn = existingAppointment.case.crn,
         eventNumber = existingAppointment.event.number,
         project = project,
+        pickUpLocation = existingAppointment.pickUpData?.location?.code?.let {
+          NDPickUpLocation.valid().copy(code = existingAppointment.pickUpData.location.code)
+        },
       )
     }
 
@@ -487,6 +503,7 @@ object CommunityPaybackAndDeliusMockServer {
       crn: String,
       eventNumber: Int,
       project: NDProject,
+      pickUpLocation: NDPickUpLocation? = null,
     ) {
       setupGetProjectResponse(project)
       setupGetTeamSupervisorsResponse(
@@ -501,6 +518,12 @@ object CommunityPaybackAndDeliusMockServer {
             eventNumber = eventNumber,
             sentenceDate = LocalDate.now().minusYears(10),
           ),
+        ),
+      )
+      setupGetTeamLocations(
+        teamCode = project.team.code,
+        locations = NDPickUpLocationsResponse(
+          locations = listOfNotNull(pickUpLocation),
         ),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentEventEntityFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentEventEntityFactoryTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.description
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.HourMinuteDuration
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentBehaviourDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
@@ -18,6 +19,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EnforcementDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PickUpDataDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PickUpLocationDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SupervisorSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
@@ -63,6 +65,8 @@ class AppointmentEventEntityFactoryTest {
     const val PROVIDER_CODE: String = "PRIV1"
     const val TEAM_CODE: String = "TEAM1"
     const val UNALLOCATED_SUPERVISOR_CODE: String = "SUPCODE1"
+    const val PICK_UP_LOCATION_CODE: String = "Pickup 1"
+    const val PICK_UP_LOCATION_DESCRIPTION: String = "Pickup Desc"
     val PROJECT = ProjectDto.valid().copy(
       projectCode = PROJECT_CODE,
       projectName = "The project name",
@@ -88,6 +92,11 @@ class AppointmentEventEntityFactoryTest {
         attended = true,
       )
 
+      val pickUpLocationDto = PickUpLocationDto.valid().copy(
+        deliusCode = PICK_UP_LOCATION_CODE,
+        description = PICK_UP_LOCATION_DESCRIPTION,
+      )
+
       val result = factory.buildCreatedEvent(
         AppointmentCreatedEvent(
           appointmentEntity = AppointmentEntity.valid().copy(deliusId = 101L, id = ID),
@@ -106,7 +115,6 @@ class AppointmentEventEntityFactoryTest {
               startTime = LocalTime.of(10, 1),
               endTime = LocalTime.of(16, 3),
               pickUpLocationCode = "PICKUPLOC1",
-              pickUpLocationDescription = "Pickup Description",
               pickUpTime = LocalTime.of(20, 5),
               contactOutcomeCode = CONTACT_OUTCOME_CODE,
               supervisorOfficerCode = "N45",
@@ -125,6 +133,7 @@ class AppointmentEventEntityFactoryTest {
             minutesToCredit = Duration.ofMinutes(66),
             project = PROJECT,
             contactOutcome = contactOutcomeEntity,
+            pickUpLocation = pickUpLocationDto,
           ),
         ),
       )
@@ -137,8 +146,8 @@ class AppointmentEventEntityFactoryTest {
       assertThat(result.date).isEqualTo(LocalDate.of(2014, 6, 7))
       assertThat(result.startTime).isEqualTo(LocalTime.of(10, 1))
       assertThat(result.endTime).isEqualTo(LocalTime.of(16, 3))
-      assertThat(result.pickupLocationCode).isEqualTo("PICKUPLOC1")
-      assertThat(result.pickupLocationDescription).isEqualTo("Pickup Description")
+      assertThat(result.pickupLocationCode).isEqualTo(PICK_UP_LOCATION_CODE)
+      assertThat(result.pickupLocationDescription).isEqualTo(PICK_UP_LOCATION_DESCRIPTION)
       assertThat(result.pickupTime).isEqualTo(LocalTime.of(20, 5))
       assertThat(result.contactOutcome).isEqualTo(contactOutcomeEntity)
       assertThat(result.supervisorOfficerCode).isEqualTo("N45")
@@ -177,7 +186,6 @@ class AppointmentEventEntityFactoryTest {
               startTime = LocalTime.of(10, 1),
               endTime = LocalTime.of(16, 3),
               pickUpLocationCode = null,
-              pickUpLocationDescription = null,
               pickUpTime = null,
               contactOutcomeCode = null,
               supervisorOfficerCode = null,
@@ -189,6 +197,7 @@ class AppointmentEventEntityFactoryTest {
             minutesToCredit = null,
             project = PROJECT,
             contactOutcome = null,
+            pickUpLocation = null,
           ),
         ),
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentValidationServiceTest.kt
@@ -123,6 +123,7 @@ class AppointmentValidationServiceTest {
             dto = baselineCreate,
             minutesToCredit = Duration.ofMinutes(60),
             contactOutcome = baselineOutcome,
+            pickUpLocation = baselinePickUpLocation,
             project = baselineProject,
           ),
         )
@@ -149,6 +150,7 @@ class AppointmentValidationServiceTest {
             dto = create,
             minutesToCredit = Duration.ofMinutes(125),
             contactOutcome = baselineOutcome,
+            pickUpLocation = baselinePickUpLocation,
             project = baselineProject,
           ),
         )
@@ -713,6 +715,7 @@ class AppointmentValidationServiceTest {
             dto = baselineUpdate,
             minutesToCredit = Duration.ofMinutes(60),
             contactOutcome = baselineOutcome,
+            pickUpLocation = baselinePickUpLocation,
             project = baselineProject,
           ),
         )
@@ -743,6 +746,7 @@ class AppointmentValidationServiceTest {
             dto = update,
             minutesToCredit = Duration.ofMinutes(125),
             contactOutcome = baselineOutcome,
+            pickUpLocation = baselinePickUpLocation,
             project = baselineProject,
           ),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentValidationServiceTest.kt
@@ -16,6 +16,8 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AttendanceDataDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PickUpDataDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PickUpLocationDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectAvailabilityDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeDto
@@ -34,6 +36,8 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService.ValidatedAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ProjectService
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ProviderService
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.TeamId
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
@@ -53,6 +57,9 @@ class AppointmentValidationServiceTest {
   @MockK
   lateinit var appointmentCalculationService: AppointmentCalculationService
 
+  @MockK
+  lateinit var providerService: ProviderService
+
   @InjectMockKs
   lateinit var service: AppointmentValidationService
 
@@ -60,7 +67,10 @@ class AppointmentValidationServiceTest {
     const val CRN = "CRN123"
     const val EVENT_NUMBER = 1234321
     const val OUTCOME_CODE = "OUTCOME1"
+    const val PICK_UP_LOCATION_CODE = "PICKUP1"
     const val PROJECT_CODE = "PROJ123"
+    const val PROVIDER_CODE = "PROV1"
+    const val TEAM_CODE = "TEAM1"
   }
 
   @Nested
@@ -74,14 +84,18 @@ class AppointmentValidationServiceTest {
       contactOutcomeCode = OUTCOME_CODE,
       startTime = LocalTime.MIN,
       endTime = LocalTime.MAX,
+      pickUpLocationCode = PICK_UP_LOCATION_CODE,
     )
     val baselineOutcome = ContactOutcomeEntity.valid().copy(code = OUTCOME_CODE)
+    val baselinePickUpLocation = PickUpLocationDto.valid()
     val baselineProject = ProjectDto.valid().copy(
       actualEndDateExclusive = null,
       availability = SchedulingDayOfWeekDto.entries.map { dayOfWeek ->
         ProjectAvailabilityDto.valid().copy(dayOfWeek = dayOfWeek)
       },
       projectType = ProjectTypeDto.valid().copy(group = ProjectTypeGroupDto.INDIVIDUAL),
+      providerCode = PROVIDER_CODE,
+      teamCode = TEAM_CODE,
     )
     val baselineUnpaidWorkDetails = UnpaidWorkDetailsDto.valid().copy(
       eventNumber = EVENT_NUMBER,
@@ -92,6 +106,7 @@ class AppointmentValidationServiceTest {
     fun setupBaselineMockResponses() {
       every { projectService.getProject(PROJECT_CODE) } returns baselineProject
       every { contactOutcomeEntityRepository.findByCode(baselineOutcome.code) } returns baselineOutcome
+      every { providerService.getPickupLocation(TeamId(PROVIDER_CODE, TEAM_CODE), PICK_UP_LOCATION_CODE) } returns baselinePickUpLocation
       every { offenderService.getUnpaidWorkDetails(CRN, EVENT_NUMBER) } returns baselineUnpaidWorkDetails
       every { appointmentCalculationService.minutesToCredit(any(), any(), any(), any()) } returns Duration.ofMinutes(60)
     }
@@ -624,6 +639,19 @@ class AppointmentValidationServiceTest {
           .hasMessage("Credited minutes of '1 hours 1 minutes' exceeds remaining allowed ETE time of '1 hours 0 minutes'")
       }
     }
+
+    @Nested
+    inner class PickUpLocation {
+      @Test
+      fun `throws BadRequestException when pickup location not found`() {
+        every { providerService.getPickupLocation(TeamId(PROVIDER_CODE, TEAM_CODE), PICK_UP_LOCATION_CODE) } returns null
+
+        assertThatThrownBy {
+          service.validateCreate(baselineCreate)
+        }.isInstanceOf(BadRequestException::class.java)
+          .hasMessage("Pick Up Location not found for team 'TEAM1' and code 'PICKUP1'")
+      }
+    }
   }
 
   @Nested
@@ -634,6 +662,11 @@ class AppointmentValidationServiceTest {
       deliusEventNumber = EVENT_NUMBER,
       offender = OffenderDto.validFull().copy(crn = CRN),
       contactOutcomeCode = null,
+      pickUpData = PickUpDataDto.valid().copy(
+        pickupLocation = PickUpLocationDto.valid().copy(
+          deliusCode = PICK_UP_LOCATION_CODE,
+        ),
+      ),
     )
     val baselineUpdate = UpdateAppointmentOutcomeDto.valid().copy(
       contactOutcomeCode = OUTCOME_CODE,
@@ -642,11 +675,14 @@ class AppointmentValidationServiceTest {
       endTime = LocalTime.MAX,
     )
     val baselineOutcome = ContactOutcomeEntity.valid().copy(code = OUTCOME_CODE)
+    val baselinePickUpLocation = PickUpLocationDto.valid()
     val baselineProject = ProjectDto.valid().copy(
       projectType = ProjectTypeDto.valid().copy(group = ProjectTypeGroupDto.INDIVIDUAL),
       availability = SchedulingDayOfWeekDto.entries.map { dayOfWeek ->
         ProjectAvailabilityDto.valid().copy(dayOfWeek = dayOfWeek)
       },
+      providerCode = PROVIDER_CODE,
+      teamCode = TEAM_CODE,
     )
     val baselineUnpaidWorkDetails = UnpaidWorkDetailsDto.valid().copy(
       eventNumber = EVENT_NUMBER,
@@ -657,6 +693,7 @@ class AppointmentValidationServiceTest {
     fun setupBaselineMockResponses() {
       every { projectService.getProject(PROJECT_CODE) } returns baselineProject
       every { contactOutcomeEntityRepository.findByCode(OUTCOME_CODE) } returns baselineOutcome
+      every { providerService.getPickupLocation(TeamId(PROVIDER_CODE, TEAM_CODE), PICK_UP_LOCATION_CODE) } returns baselinePickUpLocation
       every { offenderService.getUnpaidWorkDetails(CRN, EVENT_NUMBER) } returns baselineUnpaidWorkDetails
       every { appointmentCalculationService.minutesToCredit(any(), any(), any(), any()) } returns Duration.ofMinutes(60)
     }
@@ -1407,6 +1444,22 @@ class AppointmentValidationServiceTest {
           ),
           update = baselineUpdate,
         )
+      }
+
+      @Nested
+      inner class PickUpLocation {
+        @Test
+        fun `throws BadRequestException when pickup location not found`() {
+          every { providerService.getPickupLocation(TeamId(PROVIDER_CODE, TEAM_CODE), PICK_UP_LOCATION_CODE) } returns null
+
+          assertThatThrownBy {
+            service.validateUpdate(
+              existingAppointment = baselineExistingAppointment,
+              update = baselineUpdate,
+            )
+          }.isInstanceOf(BadRequestException::class.java)
+            .hasMessage("Pick Up Location not found for team 'TEAM1' and code 'PICKUP1'")
+        }
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/ProviderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/ProviderServiceTest.kt
@@ -10,12 +10,15 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPickUpLocation
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPickUpLocationsResponse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSupervisorSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSupervisorSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ProviderService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.TeamId
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.unit.util.WebClientResponseExceptionFactory
 
 @ExtendWith(MockKExtension::class)
 class ProviderServiceTest {
@@ -29,6 +32,7 @@ class ProviderServiceTest {
   companion object {
     const val PROVIDER_CODE = "PROV1"
     const val TEAM_CODE = "TEAM1"
+    val TEAM_ID = TeamId(PROVIDER_CODE, TEAM_CODE)
   }
 
   @Nested
@@ -62,6 +66,38 @@ class ProviderServiceTest {
       assertThatThrownBy {
         service.getTeamUnallocatedSupervisor(TeamId(PROVIDER_CODE, TEAM_CODE))
       }.hasMessage("Can't find unallocated supervisor for team 'TeamId(providerCode=PROV1, teamCode=TEAM1)'")
+    }
+  }
+
+  @Nested
+  inner class GetPickupLocations {
+
+    @Test
+    fun success() {
+      val location = NDPickUpLocation.valid()
+
+      every {
+        communityPaybackAndDeliusClient.getTeamLocations(TEAM_CODE)
+      } returns NDPickUpLocationsResponse(
+        locations = listOf(location),
+      )
+
+      val result = service.getPickupLocations(TEAM_ID)
+
+      assertThat(result).containsExactly(
+        location.toDto(),
+      )
+    }
+
+    @Test
+    fun `return null if team locations not found`() {
+      every {
+        communityPaybackAndDeliusClient.getTeamLocations(TEAM_CODE)
+      } throws WebClientResponseExceptionFactory.notFound()
+
+      val result = service.getPickupLocations(TEAM_ID)
+
+      assertThat(result).isNull()
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
@@ -51,6 +51,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.WorkQuality
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.valid
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.validCreateAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.validFull
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.validUpdateAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
@@ -85,7 +86,7 @@ class AppointmentMappersTest {
     fun success() {
       val appointmentId = UUID.randomUUID()
 
-      val dto = ValidatedAppointment(
+      val dto = ValidatedAppointment.validCreateAppointment().copy(
         dto = CreateAppointmentDto.valid().copy(
           crn = "CRN123",
           deliusEventNumber = 5,
@@ -108,7 +109,6 @@ class AppointmentMappersTest {
         ),
         minutesToCredit = Duration.ofMinutes(35),
         contactOutcome = ContactOutcomeEntity.valid().copy(code = "COE1"),
-        project = ProjectDto.valid(),
       )
 
       val result = dto.toNDCreateAppointment(appointmentId)
@@ -138,7 +138,7 @@ class AppointmentMappersTest {
     fun `success only mandatory fields`() {
       val appointmentId = UUID.randomUUID()
 
-      val dto = ValidatedAppointment(
+      val dto = ValidatedAppointment.validCreateAppointment().copy(
         dto = CreateAppointmentDto.valid().copy(
           crn = "CRN123",
           deliusEventNumber = 5,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/PickupLocationMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/PickupLocationMappersTest.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.mappers
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPickUpLocation
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toLocationDto
+
+class PickupLocationMappersTest {
+
+  @Nested
+  inner class NDPickUpLocationToLocationDto {
+
+    @Test
+    fun success() {
+      val result = NDPickUpLocation(
+        code = "CD123",
+        description = "A location",
+        buildingName = "build 1",
+        addressNumber = "15a",
+        streetName = "bracklow close",
+        townCity = "madeupville",
+        county = "fakeorton",
+        postCode = "AB12 123",
+      ).toLocationDto()
+
+      assertThat(result.buildingName).isEqualTo("build 1")
+      assertThat(result.buildingNumber).isEqualTo("15a")
+      assertThat(result.streetName).isEqualTo("bracklow close")
+      assertThat(result.townCity).isEqualTo("madeupville")
+      assertThat(result.county).isEqualTo("fakeorton")
+      assertThat(result.postCode).isEqualTo("AB12 123")
+    }
+  }
+
+  @Nested
+  inner class NDPickUpLocationToPickUpLocationDto {
+
+    @Test
+    fun success() {
+      val result = NDPickUpLocation(
+        code = "CD123",
+        description = "A location",
+        buildingName = "build 1",
+        addressNumber = "15a",
+        streetName = "bracklow close",
+        townCity = "madeupville",
+        county = "fakeorton",
+        postCode = "AB12 123",
+      ).toDto()
+
+      assertThat(result.deliusCode).isEqualTo("CD123")
+      assertThat(result.description).isEqualTo("A location")
+      assertThat(result.buildingName).isEqualTo("build 1")
+      assertThat(result.buildingNumber).isEqualTo("15a")
+      assertThat(result.streetName).isEqualTo("bracklow close")
+      assertThat(result.townCity).isEqualTo("madeupville")
+      assertThat(result.county).isEqualTo("fakeorton")
+      assertThat(result.postCode).isEqualTo("AB12 123")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/ProjectLocationMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/ProjectLocationMappersTest.kt
@@ -4,7 +4,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAddress
-import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPickUpLocation
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
 
 class ProjectLocationMappersTest {
@@ -15,31 +14,6 @@ class ProjectLocationMappersTest {
     @Test
     fun success() {
       val result = NDAddress(
-        buildingName = "build 1",
-        addressNumber = "15a",
-        streetName = "bracklow close",
-        townCity = "madeupville",
-        county = "fakeorton",
-        postCode = "AB12 123",
-      ).toDto()
-
-      assertThat(result.buildingName).isEqualTo("build 1")
-      assertThat(result.buildingNumber).isEqualTo("15a")
-      assertThat(result.streetName).isEqualTo("bracklow close")
-      assertThat(result.townCity).isEqualTo("madeupville")
-      assertThat(result.county).isEqualTo("fakeorton")
-      assertThat(result.postCode).isEqualTo("AB12 123")
-    }
-  }
-
-  @Nested
-  inner class NDPickUpLocationToDto {
-
-    @Test
-    fun success() {
-      val result = NDPickUpLocation(
-        code = "CD123",
-        description = "A location",
         buildingName = "build 1",
         addressNumber = "15a",
         streetName = "bracklow close",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/scheduling/SchedulingMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/scheduling/SchedulingMappersTest.kt
@@ -328,7 +328,6 @@ class SchedulingMappersTest {
       assertThat(result.startTime).isEqualTo(LocalTime.of(1, 2))
       assertThat(result.endTime).isEqualTo(LocalTime.of(11, 12))
       assertThat(result.pickUpLocationCode).isEqualTo("PICKUP1")
-      assertThat(result.pickUpLocationDescription).isEqualTo("Pickup Description")
       assertThat(result.pickUpTime).isEqualTo(LocalTime.of(13, 14))
       assertThat(result.contactOutcomeCode).isNull()
       assertThat(result.attendanceData).isNull()


### PR DESCRIPTION
The description is now resolved dynamically by retrieving pick up location details from NDelius, simplifying appointment creation.

To enable this quite a bit of change was required, adding validation of an appointments pickup location on create and update using the new 'get pickup locations for team' endpoint