### PR TITLE
Enable `retry-all-dlqs` endpoint

### DIFF
--- a/helm_deploy/hmpps-community-payback-api/values.yaml
+++ b/helm_deploy/hmpps-community-payback-api/values.yaml
@@ -81,3 +81,8 @@ generic-prometheus-alerts:
 # Override in values-dev.yaml
 # Also update the environment variables to point the application to the mocked services (on port 80)
 deploy_stubs: false
+
+# see https://github.com/ministryofjustice/hmpps-spring-boot-sqs?tab=readme-ov-file#usage
+retryDlqCronjob:
+  enabled: false
+  retryDlqSchedule: "*/20 * * * *"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/OpenApiConfiguration.kt
@@ -28,7 +28,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
   }
 
   @Bean
-  fun customOpenAPI() = OpenAPI()
+  fun customOpenAPI(): OpenAPI = OpenAPI()
     .servers(
       listOf(
         Server().url("https://community-payback-api-dev.hmpps.service.justice.gov.uk").description("Development"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/SecurityConfiguration.kt
@@ -1,5 +1,9 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.config
 
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import uk.gov.justice.hmpps.kotlin.auth.dsl.ResourceServerConfigurationCustomizer
+
 /**
  * Baseline configuration is provided by the hmpps kotlin library, see https://github.com/ministryofjustice/hmpps-kotlin-lib/blob/main/readme-contents/SpringResourceServer.md
  */
@@ -7,4 +11,35 @@ object SecurityConfiguration {
   const val ROLE_ADMIN_UI = "ROLE_COMMUNITY_PAYBACK__COMMUNITY_PAYBACK_UI"
   const val ROLE_DOMAIN_EVENT_DETAILS = "ROLE_COMMUNITY_PAYBACK__DOMAIN_EVENT_DETAILS__ALL__RO"
   const val ROLE_SUPERVISOR_UI = "ROLE_COMMUNITY_PAYBACK__SUPERVISOR"
+}
+
+@Configuration
+class ResourceServerConfiguration {
+
+  /**
+   * This modifies the baseline security configuration](https://github.com/ministryofjustice/hmpps-kotlin-lib/blob/main/readme-contents/SpringResourceServer.md)
+   * provided by hmpps-kotlin-lib to exclude the 'retry-all-dlqs' endpoint from security checks,
+   * required to enable the [retry cronjob](https://github.com/ministryofjustice/hmpps-helm-charts/tree/main/charts/generic-service#retrying-messages-on-a-dead-letter-queue)
+   *
+   * The configuration follows the example in the [sqs test app](https://github.com/ministryofjustice/hmpps-spring-boot-sqs/blob/main/test-app/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/config/ResourceServerConfiguration.kt)
+   *
+   * This endpoint _is_ protected at the ingress level (see values.yaml), so the only allows calls must
+   * originate from within k8s itself
+   */
+  @Bean
+  fun resourceServerCustomizer() = ResourceServerConfigurationCustomizer {
+    authorizeHttpRequests {
+      listOf(
+        "/webjars/**",
+        "/favicon.ico",
+        "/health/**",
+        "/info",
+        "/v3/api-docs/**",
+        "/swagger-ui/**",
+        "/swagger-ui.html",
+        "/queue-admin/retry-all-dlqs",
+      ).forEach { authorize(it, permitAll) }
+      authorize(anyRequest, authenticated)
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/ResourceSecurityIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/ResourceSecurityIT.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.integration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.getBeansOfType
 import org.springframework.context.ApplicationContext
 import org.springframework.core.annotation.AnnotationUtils
 import org.springframework.security.access.prepost.PreAuthorize
@@ -19,7 +20,7 @@ class ResourceSecurityIT : IntegrationTestBase() {
     "GET /swagger-ui.html",
     "GET /v3/api-docs",
     "GET /v3/api-docs/swagger-config",
-    "GET /queue-admin/retry-all-dlqs",
+    "PUT /queue-admin/retry-all-dlqs",
     " /error",
     "GET /mocks/community-payback-and-delius",
     "POST /mocks/community-payback-and-delius",
@@ -36,11 +37,11 @@ class ResourceSecurityIT : IntegrationTestBase() {
         }
       }
       .filterNotNull()
-      .flatMap { path -> listOf("GET", "POST", "PUT", "DELETE").map { method -> "$method $path" } }
+      .flatMap { path -> listOf("GET", "POST", "PUT", "DELETE", "PUT").map { method -> "$method $path" } }
       .toMutableSet()
       .also { it.addAll(unprotectedDefaultMethods) }
 
-    val beans = context.getBeansOfType(RequestMappingHandlerMapping::class.java)
+    val beans = context.getBeansOfType<RequestMappingHandlerMapping>()
 
     val unprotected = beans.values.asSequence()
       .flatMap { mapping -> mapping.handlerMethods.asSequence() }


### PR DESCRIPTION
The hmpps-sqs project provides a mechanism to automatically retry messages on the DLQ, leveraging a k8s managed retry cron job.

For this functionality to work we need to remove security checks on the `/queue-admin/retry-all-dlqs` endpoint, allowing k8s to call it without authorisation.

Note that we have already blocked access outside of k8s to this endpoint via [this ingress config](https://github.com/ministryofjustice/hmpps-community-payback-api/blob/282a35d26b66187195e9e14be641d4ecd080bf08/helm_deploy/hmpps-community-payback-api/values.yaml#L18) in helm.

The k8s cron job is explicitly disabled in this commit via a change to `values.yaml`. It can be enabled once support requirements are understood.