### PR TITLE
Move use in NotFoundException into controllers

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentTaskController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentTaskController.kt
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentTaskSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentTaskService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
@@ -84,6 +85,9 @@ class AdminAppointmentTaskController(
     ],
   )
   fun completeTask(@PathVariable taskId: UUID) {
+    if (!appointmentTaskService.taskExists(taskId)) {
+      notFound("Task", taskId)
+    }
     appointmentTaskService.completeTask(taskId)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminUpwDetailsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminUpwDetailsController.kt
@@ -11,9 +11,9 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UnpaidWorkDetailsIdDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.NotFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ContextService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.OffenderService
@@ -54,7 +54,7 @@ class AdminUpwDetailsController(
   fun getEvent(@PathVariable crn: String, @PathVariable deliusEventNumber: Int) = offenderService.getUnpaidWorkDetails(
     upwDetailsId = UnpaidWorkDetailsIdDto(crn, deliusEventNumber),
     userName = contextService.getUserName(),
-  ) ?: throw NotFoundException("Unpaid Work Details", "CRN $crn, Event Number $deliusEventNumber")
+  ) ?: notFound("Unpaid Work Details", "CRN $crn, Event Number $deliusEventNumber")
 
   @PostMapping(
     path = ["/offenders/{crn}/unpaid-work-details/{deliusEventNumber}/adjustments"],

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorInfoController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorInfoController.kt
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.SupervisorService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
@@ -43,5 +44,5 @@ class SupervisorInfoController(
   )
   fun getSupervisorInfo(
     @RequestParam username: String,
-  ) = supervisorService.getSupervisorInfo(username)
+  ) = supervisorService.getSupervisorInfo(username) ?: notFound("Supervisor", username)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentValidationService.kt
@@ -4,9 +4,9 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.badRequest
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.formatForUser
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UnpaidWorkDetailsIdDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.NotFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentReasonEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentReasonEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskEntity
@@ -27,9 +27,9 @@ class AdjustmentValidationService(
     username: String,
   ): ValidatedCreateAdjustment {
     val reason = adjustmentReasonEntityRepository.findByIdOrNull(createAdjustment.adjustmentReasonId)
-      ?: throw NotFoundException("Adjustment Reason", createAdjustment.adjustmentReasonId.toString())
+      ?: notFound("Adjustment Reason", createAdjustment.adjustmentReasonId.toString())
 
-    val task = appointmentTaskEntityRepository.findByIdOrNull(createAdjustment.taskId) ?: throw NotFoundException("Task", createAdjustment.taskId)
+    val task = appointmentTaskEntityRepository.findByIdOrNull(createAdjustment.taskId) ?: notFound("Task", createAdjustment.taskId)
 
     offenderService.ensureUnpaidWorkDetailsExist(upwDetailsId, username)
     val requestedMinutes = createAdjustment.minutes

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentValidationService.kt
@@ -27,7 +27,7 @@ class AdjustmentValidationService(
     username: String,
   ): ValidatedCreateAdjustment {
     val reason = adjustmentReasonEntityRepository.findByIdOrNull(createAdjustment.adjustmentReasonId)
-      ?: notFound("Adjustment Reason", createAdjustment.adjustmentReasonId.toString())
+      ?: badRequest("Adjustment Reason not found for ID '${createAdjustment.adjustmentReasonId}'")
 
     val task = appointmentTaskEntityRepository.findByIdOrNull(createAdjustment.taskId) ?: notFound("Task", createAdjustment.taskId)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentValidationService.kt
@@ -4,7 +4,6 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.badRequest
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.formatForUser
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UnpaidWorkDetailsIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentReasonEntity
@@ -29,7 +28,7 @@ class AdjustmentValidationService(
     val reason = adjustmentReasonEntityRepository.findByIdOrNull(createAdjustment.adjustmentReasonId)
       ?: badRequest("Adjustment Reason not found for ID '${createAdjustment.adjustmentReasonId}'")
 
-    val task = appointmentTaskEntityRepository.findByIdOrNull(createAdjustment.taskId) ?: notFound("Task", createAdjustment.taskId)
+    val task = appointmentTaskEntityRepository.findByIdOrNull(createAdjustment.taskId) ?: badRequest("Task not found for ID '${createAdjustment.taskId}'")
 
     offenderService.ensureUnpaidWorkDetailsExist(upwDetailsId, username)
     val requestedMinutes = createAdjustment.minutes

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentRetrievalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentRetrievalService.kt
@@ -6,10 +6,10 @@ import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.NotFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.toHttpParams
@@ -41,7 +41,7 @@ class AppointmentRetrievalService(
       appointmentMappers.toDto(appointment, projectType)
     }
   } catch (_: WebClientResponseException.NotFound) {
-    throw NotFoundException("Appointment", "Project $projectCode, NDelius ID $deliusAppointmentId")
+    notFound("Appointment", "Project $projectCode, NDelius ID $deliusAppointmentId")
   }
 
   fun getAppointments(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentTaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentTaskService.kt
@@ -9,7 +9,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.badRequest
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentTaskSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventTriggerType
@@ -75,11 +75,13 @@ class AppointmentTaskService(
     }
   }
 
+  fun taskExists(taskId: UUID) = appointmentTaskEntityRepository.existsById(taskId)
+
   @Transactional
   fun completeTask(
     taskId: UUID,
   ) {
-    val task = appointmentTaskEntityRepository.findByIdOrNull(taskId) ?: notFound("Task", taskId)
+    val task = appointmentTaskEntityRepository.findByIdOrNull(taskId) ?: badRequest("Task not found for ID '$taskId'")
     task.taskStatus = AppointmentTaskStatus.COMPLETE
     task.decisionMadeAt = OffsetDateTime.now()
     task.decisionMadeByUsername = contextService.getUserName()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentTaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentTaskService.kt
@@ -9,9 +9,9 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentTaskSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.NotFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventTriggerType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskEntity
@@ -79,7 +79,7 @@ class AppointmentTaskService(
   fun completeTask(
     taskId: UUID,
   ) {
-    val task = appointmentTaskEntityRepository.findByIdOrNull(taskId) ?: throw NotFoundException("Can't find task with id $taskId")
+    val task = appointmentTaskEntityRepository.findByIdOrNull(taskId) ?: notFound("Task", taskId)
     task.taskStatus = AppointmentTaskStatus.COMPLETE
     task.decisionMadeAt = OffsetDateTime.now()
     task.decisionMadeByUsername = contextService.getUserName()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentUpdateService.kt
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.ConflictException
@@ -67,8 +66,6 @@ class AppointmentUpdateService(
         appointmentId = deliusAppointmentId,
         updateAppointment = validatedUpdateDto.toNDUpdateAppointment(existingAppointment),
       )
-    } catch (_: WebClientResponseException.NotFound) {
-      notFound("Appointment", deliusAppointmentId.toString())
     } catch (_: WebClientResponseException.Conflict) {
       throw ConflictException("A newer version of the appointment exists. Stale version is '${validatedUpdateDto.dto.deliusVersionToUpdate}'")
     } catch (badRequest: WebClientResponseException.BadRequest) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentUpdateService.kt
@@ -5,11 +5,11 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.ConflictException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.InternalServerErrorException
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.NotFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService.ValidatedAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.UpdateAppointmentEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
@@ -68,7 +68,7 @@ class AppointmentUpdateService(
         updateAppointment = validatedUpdateDto.toNDUpdateAppointment(existingAppointment),
       )
     } catch (_: WebClientResponseException.NotFound) {
-      throw NotFoundException("Appointment", deliusAppointmentId.toString())
+      notFound("Appointment", deliusAppointmentId.toString())
     } catch (_: WebClientResponseException.Conflict) {
       throw ConflictException("A newer version of the appointment exists. Stale version is '${validatedUpdateDto.dto.deliusVersionToUpdate}'")
     } catch (badRequest: WebClientResponseException.BadRequest) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/SupervisorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/SupervisorService.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
 
 @Service
@@ -14,6 +13,6 @@ class SupervisorService(
   fun getSupervisorInfo(username: String) = try {
     communityPaybackAndDeliusClient.getSupervisor(username).toDto()
   } catch (_: WebClientResponseException.NotFound) {
-    notFound("Supervisor", username)
+    null
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/SupervisorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/SupervisorService.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.NotFoundException
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
 
 @Service
@@ -14,6 +14,6 @@ class SupervisorService(
   fun getSupervisorInfo(username: String) = try {
     communityPaybackAndDeliusClient.getSupervisor(username).toDto()
   } catch (_: WebClientResponseException.NotFound) {
-    throw NotFoundException("Supervisor", username)
+    notFound("Supervisor", username)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentTaskIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentTaskIT.kt
@@ -210,6 +210,16 @@ class AdminAppointmentTaskIT : IntegrationTestBase() {
     }
 
     @Test
+    fun `should 404 if task doesn't exist`() {
+      webTestClient.put()
+        .uri("/admin/appointment-tasks/${UUID.randomUUID()}/complete")
+        .addAdminUiAuthHeader("theusername")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @Test
     fun `should mark task as completed`() {
       val task = AppointmentTaskEntity.validPending().copy(
         appointment = AppointmentEntity.valid().persist(ctx),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentValidationServiceTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UnpaidWorkDetailsIdDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.BadRequestException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentReasonEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentReasonEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskEntity
@@ -74,7 +75,7 @@ class AdjustmentValidationServiceTest {
           upwDetailsId = UNPAID_WORK_DETAILS,
           username = USERNAME,
         )
-      }.hasMessage("Adjustment Reason not found for ID '74f0f62b-bbd4-49a4-9af8-1ce6cd94e3e1'")
+      }.isInstanceOf(BadRequestException::class.java).hasMessage("Adjustment Reason not found for ID '74f0f62b-bbd4-49a4-9af8-1ce6cd94e3e1'")
     }
 
     @Test
@@ -87,7 +88,7 @@ class AdjustmentValidationServiceTest {
           upwDetailsId = UNPAID_WORK_DETAILS,
           username = USERNAME,
         )
-      }.hasMessage("Task not found for ID '84f0f62b-bbd4-49a4-9af8-1ce6cd94e3e1'")
+      }.isInstanceOf(BadRequestException::class.java).hasMessage("Task not found for ID '84f0f62b-bbd4-49a4-9af8-1ce6cd94e3e1'")
     }
 
     @Test
@@ -107,7 +108,8 @@ class AdjustmentValidationServiceTest {
           upwDetailsId = UNPAID_WORK_DETAILS,
           username = USERNAME,
         )
-      }.hasMessage("Requested adjustment of '0 hours 51 minutes' exceeds the maximum allowed time '0 hours 50 minutes' for adjustment reason 'The reason name'")
+      }.isInstanceOf(BadRequestException::class.java)
+        .hasMessage("Requested adjustment of '0 hours 51 minutes' exceeds the maximum allowed time '0 hours 50 minutes' for adjustment reason 'The reason name'")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentTaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentTaskServiceTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDt
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.BadRequestException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskEntityRepository
@@ -249,7 +250,7 @@ class AppointmentTaskServiceTest {
 
       assertThatThrownBy {
         service.completeTask(taskId)
-      }.hasMessage("Task not found for ID '$taskId'")
+      }.isInstanceOf(BadRequestException::class.java).hasMessage("Task not found for ID '$taskId'")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentTaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentTaskServiceTest.kt
@@ -249,7 +249,7 @@ class AppointmentTaskServiceTest {
 
       assertThatThrownBy {
         service.completeTask(taskId)
-      }.hasMessage("Can't find task with id $taskId")
+      }.hasMessage("Task not found for ID '$taskId'")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentUpdateServiceTest.kt
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.BadRequestException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.ConflictException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.InternalServerErrorException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.NotFoundException

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentUpdateServiceTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.BadRequestException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.ConflictException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.InternalServerErrorException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.NotFoundException
@@ -73,26 +74,6 @@ class AppointmentUpdateServiceTest {
           trigger = TRIGGER,
         )
       }.isSameAs(upstreamException)
-    }
-
-    @Test
-    fun `if appointment not found on call to update, throw not found exception`() {
-      val validatedUpdateAppointment = ValidatedAppointment.validUpdateAppointment().copy(dto = updateRequest)
-      every { appointmentOutcomeValidationService.validateUpdate(any(), any()) } returns validatedUpdateAppointment
-      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, DELIUS_APPOINTMENT_ID) } returns existingAppointment
-      every { appointmentEventService.hasUpdateAlreadyBeenSent(any()) } returns false
-
-      every {
-        communityPaybackAndDeliusClient.updateAppointment(any(), any(), any())
-      } throws WebClientResponseExceptionFactory.notFound()
-
-      assertThatThrownBy {
-        service.updateAppointmentOutcome(
-          projectCode = PROJECT_CODE,
-          update = updateRequest,
-          trigger = TRIGGER,
-        )
-      }.isInstanceOf(NotFoundException::class.java).hasMessage("Appointment not found for ID '$DELIUS_APPOINTMENT_ID'")
     }
 
     @Test


### PR DESCRIPTION
Various changes to move logic returning 404s into the controllers (that understand the request in terms of the URL), instead of embedding the logic in services