### PR TITLE
Move Appointment 404 logic into controllers

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/ValidationFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/ValidationFunctions.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.common
 
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.BadRequestException
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.NotFoundException
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
@@ -35,4 +34,3 @@ inline fun validateLengthLessThan(
 
 fun badRequest(message: String): Nothing = throw BadRequestException(message)
 fun badRequestReferenceNotFound(entityType: String, id: Any): Nothing = throw BadRequestException("$entityType not found for ID '$id'")
-fun notFound(entityType: String, id: Any): Nothing = throw NotFoundException(entityType, id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CommunityPaybackApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CommunityPaybackApiExceptionHandler.kt
@@ -14,9 +14,9 @@ import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.NotFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.BadRequestException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.ConflictException
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.NotFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SentryService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
@@ -21,6 +21,8 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.badRequest
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
@@ -69,12 +71,13 @@ class AdminAppointmentController(
   fun getAppointment(
     @PathVariable projectCode: String,
     @PathVariable deliusAppointmentId: Long,
-  ) = appointmentService.getAppointment(
-    DeliusAppointmentIdDto(
+  ): AppointmentDto {
+    val id = DeliusAppointmentIdDto(
       projectCode = projectCode,
       deliusAppointmentId = deliusAppointmentId,
-    ),
-  )
+    )
+    return appointmentService.getAppointment(id) ?: notFound("Appointment", id)
+  }
 
   @PutMapping(
     path = ["/projects/{projectCode}/appointments/{deliusAppointmentId}"],
@@ -159,9 +162,8 @@ class AdminAppointmentController(
       badRequest("ID in URL should match ID in payload")
     }
 
-    val existingAppointment = appointmentService.getAppointment(
-      DeliusAppointmentIdDto(projectCode, update.deliusId),
-    )
+    val id = DeliusAppointmentIdDto(projectCode, update.deliusId)
+    val existingAppointment = appointmentService.getAppointment(id) ?: notFound("Appointment", id)
 
     appointmentService.updateAppointment(
       existingAppointment = existingAppointment,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.badRequest
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
+import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.badRequest
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
@@ -69,8 +70,10 @@ class AdminAppointmentController(
     @PathVariable projectCode: String,
     @PathVariable deliusAppointmentId: Long,
   ) = appointmentService.getAppointment(
-    projectCode = projectCode,
-    deliusAppointmentId = deliusAppointmentId,
+    DeliusAppointmentIdDto(
+      projectCode = projectCode,
+      deliusAppointmentId = deliusAppointmentId,
+    ),
   )
 
   @PutMapping(
@@ -156,7 +159,9 @@ class AdminAppointmentController(
       badRequest("ID in URL should match ID in payload")
     }
 
-    val existingAppointment = appointmentService.getAppointment(projectCode, update.deliusId)
+    val existingAppointment = appointmentService.getAppointment(
+      DeliusAppointmentIdDto(projectCode, update.deliusId),
+    )
 
     appointmentService.updateAppointment(
       existingAppointment = existingAppointment,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
@@ -156,8 +156,10 @@ class AdminAppointmentController(
       badRequest("ID in URL should match ID in payload")
     }
 
-    appointmentService.updateAppointmentOutcome(
-      projectCode = projectCode,
+    val existingAppointment = appointmentService.getAppointment(projectCode, update.deliusId)
+
+    appointmentService.updateAppointment(
+      existingAppointment = existingAppointment,
       update = update,
       trigger = AppointmentEventTrigger(
         triggeredAt = OffsetDateTime.now(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentTaskController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentTaskController.kt
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
+import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentTaskSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentTaskService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminCourseCompletionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminCourseCompletionController.kt
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.atFirstSecondOfDay
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.atLastSecondOfDay
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
+import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionRecommendationDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionEventDto

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminOffenderController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminOffenderController.kt
@@ -8,7 +8,7 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
+import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CaseDetailsSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ContextService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.OffenderService

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminProjectController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminProjectController.kt
@@ -8,7 +8,7 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
+import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ProjectService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import kotlin.String

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminProviderController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminProviderController.kt
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
+import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectOutcomeSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProviderSummariesDto

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminUpwDetailsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminUpwDetailsController.kt
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
+import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UnpaidWorkDetailsIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentService

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/common/CommonOffenderController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/common/CommonOffenderController.kt
@@ -4,7 +4,7 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
+import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.OffenderService
 
 /*

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/internal/NotFoundException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/internal/NotFoundException.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal
+
+/**
+ * Use of this exception is limited to controllers because they are the only
+ * code that has the context for whether an entity has been addressed in the
+ * URL
+ */
+class NotFoundException(message: String) : RuntimeException(message) {
+  constructor(entityType: String, id: Any) : this("$entityType not found for ID '$id'")
+}
+
+fun notFound(entityType: String, id: Any): Nothing = throw NotFoundException(entityType, id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorAppointmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorAppointmentsController.kt
@@ -138,15 +138,17 @@ class SupervisorAppointmentsController(
   fun updateAppointmentOutcome(
     @PathVariable projectCode: String,
     @PathVariable deliusAppointmentId: Long,
-    @RequestBody outcome: UpdateAppointmentOutcomeDto,
+    @RequestBody update: UpdateAppointmentOutcomeDto,
   ) {
-    if (outcome.deliusId != deliusAppointmentId) {
+    if (update.deliusId != deliusAppointmentId) {
       badRequest("ID in URL should match ID in payload")
     }
 
-    appointmentService.updateAppointmentOutcome(
-      update = outcome,
-      projectCode = projectCode,
+    val existingAppointment = appointmentService.getAppointment(projectCode, update.deliusId)
+
+    appointmentService.updateAppointment(
+      existingAppointment = existingAppointment,
+      update = update,
       trigger = AppointmentEventTrigger(
         triggeredAt = OffsetDateTime.now(),
         triggerType = AppointmentEventTriggerType.USER,
@@ -180,7 +182,7 @@ class SupervisorAppointmentsController(
   fun updateAppointments(
     @PathVariable projectCode: String,
     @RequestBody request: UpdateAppointmentsDto,
-  ) = appointmentService.updateAppointmentOutcomes(
+  ) = appointmentService.updateAppointments(
     projectCode = projectCode,
     request = request.toUpdateAppointmentOutcomesDto(),
     trigger = AppointmentEventTrigger(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorAppointmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorAppointmentsController.kt
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.badRequest
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
+import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentDto

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorAppointmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorAppointmentsController.kt
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.badRequest
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentsDto
@@ -58,8 +59,10 @@ class SupervisorAppointmentsController(
     @PathVariable projectCode: String,
     @PathVariable deliusAppointmentId: Long,
   ) = appointmentService.getAppointment(
-    projectCode = projectCode,
-    deliusAppointmentId = deliusAppointmentId,
+    DeliusAppointmentIdDto(
+      projectCode = projectCode,
+      deliusAppointmentId = deliusAppointmentId,
+    ),
   )
 
   @PutMapping(
@@ -144,7 +147,9 @@ class SupervisorAppointmentsController(
       badRequest("ID in URL should match ID in payload")
     }
 
-    val existingAppointment = appointmentService.getAppointment(projectCode, update.deliusId)
+    val existingAppointment = appointmentService.getAppointment(
+      DeliusAppointmentIdDto(projectCode, update.deliusId),
+    )
 
     appointmentService.updateAppointment(
       existingAppointment = existingAppointment,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorAppointmentsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorAppointmentsController.kt
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.badRequest
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
@@ -58,12 +60,10 @@ class SupervisorAppointmentsController(
   fun getAppointment(
     @PathVariable projectCode: String,
     @PathVariable deliusAppointmentId: Long,
-  ) = appointmentService.getAppointment(
-    DeliusAppointmentIdDto(
-      projectCode = projectCode,
-      deliusAppointmentId = deliusAppointmentId,
-    ),
-  )
+  ): AppointmentDto {
+    val id = DeliusAppointmentIdDto(projectCode, deliusAppointmentId)
+    return appointmentService.getAppointment(id) ?: notFound("Appointment", id)
+  }
 
   @PutMapping(
     path = ["/{deliusAppointmentId}"],
@@ -147,9 +147,8 @@ class SupervisorAppointmentsController(
       badRequest("ID in URL should match ID in payload")
     }
 
-    val existingAppointment = appointmentService.getAppointment(
-      DeliusAppointmentIdDto(projectCode, update.deliusId),
-    )
+    val id = DeliusAppointmentIdDto(projectCode, deliusAppointmentId)
+    val existingAppointment = appointmentService.getAppointment(id) ?: notFound("Appointment", id)
 
     appointmentService.updateAppointment(
       existingAppointment = existingAppointment,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorInfoController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorInfoController.kt
@@ -8,7 +8,7 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
+import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.SupervisorService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorSessionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorSessionsController.kt
@@ -10,8 +10,8 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.NotFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.NotFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.SessionService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDate

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/DeliusAppointmentIdDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/DeliusAppointmentIdDto.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
+
+data class DeliusAppointmentIdDto(
+  val projectCode: String,
+  val deliusAppointmentId: Long,
+) {
+  override fun toString() = "Project $projectCode, NDelius ID $deliusAppointmentId"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/exceptions/NotFoundException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/exceptions/NotFoundException.kt
@@ -1,5 +1,0 @@
-package uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions
-
-class NotFoundException(message: String) : RuntimeException(message) {
-  constructor(entityType: String, id: Any) : this("$entityType not found for ID '$id'")
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentBulkUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentBulkUpdateService.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeResultDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeResultType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomesDto
@@ -17,35 +19,37 @@ class AppointmentBulkUpdateService(
   private val sentryService: SentryService,
 ) {
 
-  fun updateAppointmentOutcomes(
+  fun updateAppointments(
     projectCode: String,
     request: UpdateAppointmentOutcomesDto,
     trigger: AppointmentEventTrigger,
   ): UpdateAppointmentsOutcomesResultDto {
-    request.validate(projectCode)
-
-    val outcomes = request.apply(projectCode, trigger)
+    val internalRequests = request.validate(projectCode)
+    val outcomes = internalRequests.apply(trigger)
 
     return UpdateAppointmentsOutcomesResultDto(outcomes)
   }
 
-  private fun UpdateAppointmentOutcomesDto.validate(projectCode: String) = updates.forEach {
-    appointmentUpdateValidationService.validateUpdate(
-      existingAppointment = appointmentRetrievalService.getAppointment(
-        projectCode,
-        it.deliusId,
-      ),
-      update = it,
-    )
+  private fun UpdateAppointmentOutcomesDto.validate(projectCode: String) = updates.map {
+    val deliusId = it.deliusId
+
+    val existingAppointment = appointmentRetrievalService.getAppointment(projectCode, deliusId)
+
+    appointmentUpdateValidationService.validateUpdate(existingAppointment, it)
+
+    AppointmentWithUpdateRequest(deliusId, existingAppointment, it)
   }
 
   @SuppressWarnings("TooGenericExceptionCaught")
-  private fun UpdateAppointmentOutcomesDto.apply(
-    projectCode: String,
+  private fun List<AppointmentWithUpdateRequest>.apply(
     trigger: AppointmentEventTrigger,
-  ) = updates.map { updateAppointmentOutcome ->
+  ) = map { internalUpdateRequest ->
     val outcome = try {
-      appointmentUpdateService.updateAppointmentOutcome(projectCode, updateAppointmentOutcome, trigger)
+      appointmentUpdateService.updateAppointment(
+        existingAppointment = internalUpdateRequest.existingAppointment,
+        update = internalUpdateRequest.update,
+        trigger = trigger,
+      )
       UpdateAppointmentOutcomeResultType.SUCCESS
     } catch (_: NotFoundException) {
       UpdateAppointmentOutcomeResultType.NOT_FOUND
@@ -56,6 +60,12 @@ class AppointmentBulkUpdateService(
       UpdateAppointmentOutcomeResultType.SERVER_ERROR
     }
 
-    UpdateAppointmentOutcomeResultDto(updateAppointmentOutcome.deliusId, outcome)
+    UpdateAppointmentOutcomeResultDto(internalUpdateRequest.deliusId, outcome)
   }
+
+  private data class AppointmentWithUpdateRequest(
+    val deliusId: Long,
+    val existingAppointment: AppointmentDto,
+    val update: UpdateAppointmentOutcomeDto,
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentBulkUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentBulkUpdateService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeResultDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeResultType
@@ -33,7 +34,7 @@ class AppointmentBulkUpdateService(
   private fun UpdateAppointmentOutcomesDto.validate(projectCode: String) = updates.map {
     val deliusId = it.deliusId
 
-    val existingAppointment = appointmentRetrievalService.getAppointment(projectCode, deliusId)
+    val existingAppointment = appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(projectCode, deliusId))
 
     appointmentUpdateValidationService.validateUpdate(existingAppointment, it)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentBulkUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentBulkUpdateService.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOut
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentsOutcomesResultDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.ConflictException
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.NotFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SentryService
 
 @Service
@@ -27,46 +26,48 @@ class AppointmentBulkUpdateService(
   ): UpdateAppointmentsOutcomesResultDto {
     val internalRequests = request.validate(projectCode)
     val outcomes = internalRequests.apply(trigger)
-
     return UpdateAppointmentsOutcomesResultDto(outcomes)
   }
 
   private fun UpdateAppointmentOutcomesDto.validate(projectCode: String) = updates.map {
-    val deliusId = it.deliusId
+    val id = DeliusAppointmentIdDto(projectCode, it.deliusId)
+    val existingAppointment = appointmentRetrievalService.getAppointment(id)
 
-    val existingAppointment = appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(projectCode, deliusId))
+    if (existingAppointment != null) {
+      appointmentUpdateValidationService.validateUpdate(existingAppointment, it)
+    }
 
-    appointmentUpdateValidationService.validateUpdate(existingAppointment, it)
-
-    AppointmentWithUpdateRequest(deliusId, existingAppointment, it)
+    AppointmentWithUpdateRequest(id, existingAppointment, it)
   }
 
   @SuppressWarnings("TooGenericExceptionCaught")
   private fun List<AppointmentWithUpdateRequest>.apply(
     trigger: AppointmentEventTrigger,
   ) = map { internalUpdateRequest ->
-    val outcome = try {
-      appointmentUpdateService.updateAppointment(
-        existingAppointment = internalUpdateRequest.existingAppointment,
-        update = internalUpdateRequest.update,
-        trigger = trigger,
-      )
-      UpdateAppointmentOutcomeResultType.SUCCESS
-    } catch (_: NotFoundException) {
+    val outcome = if (internalUpdateRequest.existingAppointment == null) {
       UpdateAppointmentOutcomeResultType.NOT_FOUND
-    } catch (_: ConflictException) {
-      UpdateAppointmentOutcomeResultType.VERSION_CONFLICT
-    } catch (t: Throwable) {
-      sentryService.captureException(t)
-      UpdateAppointmentOutcomeResultType.SERVER_ERROR
+    } else {
+      try {
+        appointmentUpdateService.updateAppointment(
+          existingAppointment = internalUpdateRequest.existingAppointment,
+          update = internalUpdateRequest.update,
+          trigger = trigger,
+        )
+        UpdateAppointmentOutcomeResultType.SUCCESS
+      } catch (_: ConflictException) {
+        UpdateAppointmentOutcomeResultType.VERSION_CONFLICT
+      } catch (t: Throwable) {
+        sentryService.captureException(t)
+        UpdateAppointmentOutcomeResultType.SERVER_ERROR
+      }
     }
 
-    UpdateAppointmentOutcomeResultDto(internalUpdateRequest.deliusId, outcome)
+    UpdateAppointmentOutcomeResultDto(internalUpdateRequest.id.deliusAppointmentId, outcome)
   }
 
   private data class AppointmentWithUpdateRequest(
-    val deliusId: Long,
-    val existingAppointment: AppointmentDto,
+    val id: DeliusAppointmentIdDto,
+    val existingAppointment: AppointmentDto?,
     val update: UpdateAppointmentOutcomeDto,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentRetrievalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentRetrievalService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackA
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntityRepository
@@ -26,13 +27,10 @@ class AppointmentRetrievalService(
   private val appointmentEntityRepository: AppointmentEntityRepository,
 ) {
 
-  fun getAppointment(
-    projectCode: String,
-    deliusAppointmentId: Long,
-  ): AppointmentDto = try {
+  fun getAppointment(id: DeliusAppointmentIdDto): AppointmentDto = try {
     communityPaybackAndDeliusClient.getAppointment(
-      projectCode = projectCode,
-      appointmentId = deliusAppointmentId,
+      projectCode = id.projectCode,
+      appointmentId = id.deliusAppointmentId,
       username = contextService.getUserName(),
     ).let { appointment ->
       val projectTypeCode = appointment.projectType.code
@@ -41,7 +39,7 @@ class AppointmentRetrievalService(
       appointmentMappers.toDto(appointment, projectType)
     }
   } catch (_: WebClientResponseException.NotFound) {
-    notFound("Appointment", "Project $projectCode, NDelius ID $deliusAppointmentId")
+    notFound("Appointment", "$id")
   }
 
   fun getAppointments(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentRetrievalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentRetrievalService.kt
@@ -6,7 +6,6 @@ import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
-import uk.gov.justice.digital.hmpps.communitypaybackapi.common.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
@@ -27,7 +26,7 @@ class AppointmentRetrievalService(
   private val appointmentEntityRepository: AppointmentEntityRepository,
 ) {
 
-  fun getAppointment(id: DeliusAppointmentIdDto): AppointmentDto = try {
+  fun getAppointment(id: DeliusAppointmentIdDto): AppointmentDto? = try {
     communityPaybackAndDeliusClient.getAppointment(
       projectCode = id.projectCode,
       appointmentId = id.deliusAppointmentId,
@@ -39,7 +38,7 @@ class AppointmentRetrievalService(
       appointmentMappers.toDto(appointment, projectType)
     }
   } catch (_: WebClientResponseException.NotFound) {
-    notFound("Appointment", "$id")
+    null
   }
 
   fun getAppointments(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
@@ -54,15 +55,15 @@ class AppointmentService(
     pageable = pageable,
   )
 
-  fun updateAppointmentOutcome(
-    projectCode: String,
+  fun updateAppointment(
+    existingAppointment: AppointmentDto,
     update: UpdateAppointmentOutcomeDto,
     trigger: AppointmentEventTrigger,
-  ) = appointmentUpdateService.updateAppointmentOutcome(projectCode, update, trigger)
+  ) = appointmentUpdateService.updateAppointment(existingAppointment, update, trigger)
 
-  fun updateAppointmentOutcomes(
+  fun updateAppointments(
     projectCode: String,
     request: UpdateAppointmentOutcomesDto,
     trigger: AppointmentEventTrigger,
-  ) = appointmentBulkUpdateService.updateAppointmentOutcomes(projectCode, request, trigger)
+  ) = appointmentBulkUpdateService.updateAppointments(projectCode, request, trigger)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentService.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentsDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomesDto
@@ -29,9 +30,8 @@ class AppointmentService(
   ) = appointmentCreationService.createAppointmentsForProject(appointments, trigger)
 
   fun getAppointment(
-    projectCode: String,
-    deliusAppointmentId: Long,
-  ) = appointmentRetrievalService.getAppointment(projectCode, deliusAppointmentId)
+    id: DeliusAppointmentIdDto,
+  ) = appointmentRetrievalService.getAppointment(id)
 
   fun getAppointments(
     crn: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentUpdateService.kt
@@ -27,12 +27,11 @@ class AppointmentUpdateService(
   }
 
   @Transactional
-  fun updateAppointmentOutcome(
-    projectCode: String,
+  fun updateAppointment(
+    existingAppointment: AppointmentDto,
     update: UpdateAppointmentOutcomeDto,
     trigger: AppointmentEventTrigger,
   ) {
-    val existingAppointment = appointmentRetrievalService.getAppointment(projectCode, update.deliusId)
     val appointmentEntity = appointmentRetrievalService.getOrCreateAppointmentEntity(existingAppointment)
 
     val validatedUpdateDto = appointmentUpdateValidationService.validateUpdate(existingAppointment, update)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
@@ -133,8 +133,8 @@ class EteService(
         deliusAppointmentId = courseCompletionResolution.creditTimeDetails.appointmentIdToUpdate,
       )
 
-      appointmentService.updateAppointmentOutcome(
-        projectCode = existingAppointment.projectCode,
+      appointmentService.updateAppointment(
+        existingAppointment = existingAppointment,
         update = eteMapper.toUpdateAppointmentDto(
           courseCompletionResolution = courseCompletionResolution,
           courseCompletionEvent = courseCompletionEvent,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionRecommendationDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionTypeDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionEventDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionResolutionStatusDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEventTriggerType
@@ -129,8 +130,10 @@ class EteService(
       )
     } else {
       val existingAppointment = appointmentService.getAppointment(
-        projectCode = courseCompletionResolution.creditTimeDetails.projectCode,
-        deliusAppointmentId = courseCompletionResolution.creditTimeDetails.appointmentIdToUpdate,
+        DeliusAppointmentIdDto(
+          projectCode = courseCompletionResolution.creditTimeDetails.projectCode,
+          deliusAppointmentId = courseCompletionResolution.creditTimeDetails.appointmentIdToUpdate,
+        ),
       )
 
       appointmentService.updateAppointment(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.badRequest
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionRecommendationDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionTypeDto
@@ -129,12 +130,11 @@ class EteService(
         trigger = appointmentEventTrigger,
       )
     } else {
-      val existingAppointment = appointmentService.getAppointment(
-        DeliusAppointmentIdDto(
-          projectCode = courseCompletionResolution.creditTimeDetails.projectCode,
-          deliusAppointmentId = courseCompletionResolution.creditTimeDetails.appointmentIdToUpdate,
-        ),
+      val appointmentId = DeliusAppointmentIdDto(
+        projectCode = courseCompletionResolution.creditTimeDetails.projectCode,
+        deliusAppointmentId = courseCompletionResolution.creditTimeDetails.appointmentIdToUpdate,
       )
+      val existingAppointment = appointmentService.getAppointment(appointmentId) ?: badRequest("Appointment not found with ID '$appointmentId'")
 
       appointmentService.updateAppointment(
         existingAppointment = existingAppointment,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentBulkUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentBulkUpdateServiceTest.kt
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOut
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.BadRequestException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.ConflictException
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.NotFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.validUpdateAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
@@ -84,9 +83,8 @@ class AppointmentBulkUpdateServiceTest {
       val appointment1Dto = AppointmentDto.valid()
       val update1 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 1L)
 
-      every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update1.deliusId)) } returns appointment1Dto
+      every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update1.deliusId)) } returns null
       every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
-      every { appointmentUpdateService.updateAppointment(appointment1Dto, update1, TRIGGER) } throws NotFoundException("appointment", "1")
 
       val result = service.updateAppointments(
         projectCode = PROJECT_CODE,
@@ -166,7 +164,6 @@ class AppointmentBulkUpdateServiceTest {
 
     @Test
     fun `mix of all outcomes`() {
-      val existing1 = AppointmentDto.valid()
       val existing2 = AppointmentDto.valid()
       val existing3 = AppointmentDto.valid()
       val existing4 = AppointmentDto.valid()
@@ -176,17 +173,15 @@ class AppointmentBulkUpdateServiceTest {
       val update3 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 3L)
       val update4 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 4L)
 
-      every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update1.deliusId)) } returns existing1
+      every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update1.deliusId)) } returns null
       every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update2.deliusId)) } returns existing2
       every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update3.deliusId)) } returns existing3
       every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update4.deliusId)) } returns existing4
 
-      every { appointmentUpdateValidationService.validateUpdate(existing1, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
       every { appointmentUpdateValidationService.validateUpdate(existing2, update2) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update2)
       every { appointmentUpdateValidationService.validateUpdate(existing3, update3) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update3)
       every { appointmentUpdateValidationService.validateUpdate(existing4, update4) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update4)
 
-      every { appointmentUpdateService.updateAppointment(existing1, update1, TRIGGER) } throws NotFoundException("appointment", "1")
       every { appointmentUpdateService.updateAppointment(existing2, update2, TRIGGER) } throws ConflictException("oh no")
       every { appointmentUpdateService.updateAppointment(existing3, update3, TRIGGER) } throws IllegalStateException("oh no")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentBulkUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentBulkUpdateServiceTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeResultType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomesDto
@@ -62,9 +63,9 @@ class AppointmentBulkUpdateServiceTest {
       val appointment2Dto = AppointmentDto.valid()
       val update2 = UpdateAppointmentOutcomeDto.valid()
 
-      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, update1.deliusId) } returns appointment1Dto
+      every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update1.deliusId)) } returns appointment1Dto
       every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
-      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, update2.deliusId) } returns appointment2Dto
+      every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update2.deliusId)) } returns appointment2Dto
       every { appointmentUpdateValidationService.validateUpdate(appointment2Dto, update2) } throws BadRequestException("oh dear")
 
       assertThatThrownBy {
@@ -83,7 +84,7 @@ class AppointmentBulkUpdateServiceTest {
       val appointment1Dto = AppointmentDto.valid()
       val update1 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 1L)
 
-      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, update1.deliusId) } returns appointment1Dto
+      every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update1.deliusId)) } returns appointment1Dto
       every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
       every { appointmentUpdateService.updateAppointment(appointment1Dto, update1, TRIGGER) } throws NotFoundException("appointment", "1")
 
@@ -103,7 +104,7 @@ class AppointmentBulkUpdateServiceTest {
       val appointment1Dto = AppointmentDto.valid()
       val update1 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 1L)
 
-      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, update1.deliusId) } returns appointment1Dto
+      every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update1.deliusId)) } returns appointment1Dto
       every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
       every { appointmentUpdateService.updateAppointment(appointment1Dto, update1, TRIGGER) } throws ConflictException("oh no")
 
@@ -123,7 +124,7 @@ class AppointmentBulkUpdateServiceTest {
       val appointment1Dto = AppointmentDto.valid()
       val update1 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 1L)
 
-      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, update1.deliusId) } returns appointment1Dto
+      every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update1.deliusId)) } returns appointment1Dto
       every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
 
       val exceptionReturned = IllegalStateException("oh no")
@@ -147,7 +148,7 @@ class AppointmentBulkUpdateServiceTest {
       val appointment1Dto = AppointmentDto.valid()
       val update1 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 1L)
 
-      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, update1.deliusId) } returns appointment1Dto
+      every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update1.deliusId)) } returns appointment1Dto
       every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
 
       val result = service.updateAppointments(
@@ -175,10 +176,10 @@ class AppointmentBulkUpdateServiceTest {
       val update3 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 3L)
       val update4 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 4L)
 
-      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, update1.deliusId) } returns existing1
-      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, update2.deliusId) } returns existing2
-      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, update3.deliusId) } returns existing3
-      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, update4.deliusId) } returns existing4
+      every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update1.deliusId)) } returns existing1
+      every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update2.deliusId)) } returns existing2
+      every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update3.deliusId)) } returns existing3
+      every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update4.deliusId)) } returns existing4
 
       every { appointmentUpdateValidationService.validateUpdate(existing1, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
       every { appointmentUpdateValidationService.validateUpdate(existing2, update2) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentBulkUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentBulkUpdateServiceTest.kt
@@ -68,14 +68,14 @@ class AppointmentBulkUpdateServiceTest {
       every { appointmentUpdateValidationService.validateUpdate(appointment2Dto, update2) } throws BadRequestException("oh dear")
 
       assertThatThrownBy {
-        service.updateAppointmentOutcomes(
+        service.updateAppointments(
           projectCode = PROJECT_CODE,
           request = UpdateAppointmentOutcomesDto(listOf(update1, update2)),
           trigger = TRIGGER,
         )
       }.isInstanceOf(BadRequestException::class.java)
 
-      verify(exactly = 0) { appointmentUpdateService.updateAppointmentOutcome(any(), any(), any()) }
+      verify(exactly = 0) { appointmentUpdateService.updateAppointment(any(), any(), any()) }
     }
 
     @Test
@@ -85,9 +85,9 @@ class AppointmentBulkUpdateServiceTest {
 
       every { appointmentRetrievalService.getAppointment(PROJECT_CODE, update1.deliusId) } returns appointment1Dto
       every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
-      every { appointmentUpdateService.updateAppointmentOutcome(PROJECT_CODE, update1, TRIGGER) } throws NotFoundException("appointment", "1")
+      every { appointmentUpdateService.updateAppointment(appointment1Dto, update1, TRIGGER) } throws NotFoundException("appointment", "1")
 
-      val result = service.updateAppointmentOutcomes(
+      val result = service.updateAppointments(
         projectCode = PROJECT_CODE,
         request = UpdateAppointmentOutcomesDto(listOf(update1)),
         trigger = TRIGGER,
@@ -105,9 +105,9 @@ class AppointmentBulkUpdateServiceTest {
 
       every { appointmentRetrievalService.getAppointment(PROJECT_CODE, update1.deliusId) } returns appointment1Dto
       every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
-      every { appointmentUpdateService.updateAppointmentOutcome(PROJECT_CODE, update1, TRIGGER) } throws ConflictException("oh no")
+      every { appointmentUpdateService.updateAppointment(appointment1Dto, update1, TRIGGER) } throws ConflictException("oh no")
 
-      val result = service.updateAppointmentOutcomes(
+      val result = service.updateAppointments(
         projectCode = PROJECT_CODE,
         request = UpdateAppointmentOutcomesDto(listOf(update1)),
         trigger = TRIGGER,
@@ -127,9 +127,9 @@ class AppointmentBulkUpdateServiceTest {
       every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
 
       val exceptionReturned = IllegalStateException("oh no")
-      every { appointmentUpdateService.updateAppointmentOutcome(PROJECT_CODE, update1, TRIGGER) } throws exceptionReturned
+      every { appointmentUpdateService.updateAppointment(appointment1Dto, update1, TRIGGER) } throws exceptionReturned
 
-      val result = service.updateAppointmentOutcomes(
+      val result = service.updateAppointments(
         projectCode = PROJECT_CODE,
         request = UpdateAppointmentOutcomesDto(listOf(update1)),
         trigger = TRIGGER,
@@ -150,7 +150,7 @@ class AppointmentBulkUpdateServiceTest {
       every { appointmentRetrievalService.getAppointment(PROJECT_CODE, update1.deliusId) } returns appointment1Dto
       every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
 
-      val result = service.updateAppointmentOutcomes(
+      val result = service.updateAppointments(
         projectCode = PROJECT_CODE,
         request = UpdateAppointmentOutcomesDto(listOf(update1)),
         trigger = TRIGGER,
@@ -160,23 +160,36 @@ class AppointmentBulkUpdateServiceTest {
       assertThat(result.results[0].deliusId).isEqualTo(1L)
       assertThat(result.results[0].result).isEqualTo(UpdateAppointmentOutcomeResultType.SUCCESS)
 
-      verify { appointmentUpdateService.updateAppointmentOutcome(PROJECT_CODE, update1, TRIGGER) }
+      verify { appointmentUpdateService.updateAppointment(appointment1Dto, update1, TRIGGER) }
     }
 
     @Test
     fun `mix of all outcomes`() {
+      val existing1 = AppointmentDto.valid()
+      val existing2 = AppointmentDto.valid()
+      val existing3 = AppointmentDto.valid()
+      val existing4 = AppointmentDto.valid()
+
       val update1 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 1L)
       val update2 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 2L)
       val update3 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 3L)
       val update4 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 4L)
 
-      every { appointmentUpdateValidationService.validateUpdate(any(), any()) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
+      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, update1.deliusId) } returns existing1
+      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, update2.deliusId) } returns existing2
+      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, update3.deliusId) } returns existing3
+      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, update4.deliusId) } returns existing4
 
-      every { appointmentUpdateService.updateAppointmentOutcome(PROJECT_CODE, update1, TRIGGER) } throws NotFoundException("appointment", "1")
-      every { appointmentUpdateService.updateAppointmentOutcome(PROJECT_CODE, update2, TRIGGER) } throws ConflictException("oh no")
-      every { appointmentUpdateService.updateAppointmentOutcome(PROJECT_CODE, update3, TRIGGER) } throws IllegalStateException("oh no")
+      every { appointmentUpdateValidationService.validateUpdate(existing1, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
+      every { appointmentUpdateValidationService.validateUpdate(existing2, update2) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update2)
+      every { appointmentUpdateValidationService.validateUpdate(existing3, update3) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update3)
+      every { appointmentUpdateValidationService.validateUpdate(existing4, update4) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update4)
 
-      val result = service.updateAppointmentOutcomes(
+      every { appointmentUpdateService.updateAppointment(existing1, update1, TRIGGER) } throws NotFoundException("appointment", "1")
+      every { appointmentUpdateService.updateAppointment(existing2, update2, TRIGGER) } throws ConflictException("oh no")
+      every { appointmentUpdateService.updateAppointment(existing3, update3, TRIGGER) } throws IllegalStateException("oh no")
+
+      val result = service.updateAppointments(
         projectCode = PROJECT_CODE,
         request = UpdateAppointmentOutcomesDto(listOf(update1, update2, update3, update4)),
         trigger = TRIGGER,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentRetrievalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentRetrievalServiceTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProjectType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.NotFoundException
@@ -82,7 +83,7 @@ class AppointmentRetrievalServiceTest {
       } throws WebClientResponseExceptionFactory.notFound()
 
       assertThatThrownBy {
-        service.getAppointment(PROJECT_CODE, 101L)
+        service.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, 101L))
       }.isInstanceOf(NotFoundException::class.java).hasMessage("Appointment not found for ID 'Project PROJ123, NDelius ID 101'")
     }
 
@@ -97,7 +98,7 @@ class AppointmentRetrievalServiceTest {
       val appointmentDto = AppointmentDto.valid()
       every { appointmentMappers.toDto(appointment, projectType) } returns appointmentDto
 
-      val result = service.getAppointment(PROJECT_CODE, 101L)
+      val result = service.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, 101L))
 
       assertThat(result).isSameAs(appointmentDto)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentRetrievalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentRetrievalServiceTest.kt
@@ -5,7 +5,6 @@ import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -21,7 +20,6 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDt
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.NotFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntity
@@ -73,7 +71,7 @@ class AppointmentRetrievalServiceTest {
   inner class GetAppointment {
 
     @Test
-    fun `if appointment not found, throw not found exception`() {
+    fun `if appointment not found return null`() {
       every {
         communityPaybackAndDeliusClient.getAppointment(
           projectCode = PROJECT_CODE,
@@ -82,9 +80,9 @@ class AppointmentRetrievalServiceTest {
         )
       } throws WebClientResponseExceptionFactory.notFound()
 
-      assertThatThrownBy {
-        service.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, 101L))
-      }.isInstanceOf(NotFoundException::class.java).hasMessage("Appointment not found for ID 'Project PROJ123, NDelius ID 101'")
+      val result = service.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, 101L))
+
+      assertThat(result).isNull()
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentUpdateServiceTest.kt
@@ -14,7 +14,6 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.ConflictException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.InternalServerErrorException
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.NotFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.validUpdateAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
@@ -62,29 +61,14 @@ class AppointmentUpdateServiceTest {
     val updateRequest = UpdateAppointmentOutcomeDto.valid().copy(deliusId = DELIUS_APPOINTMENT_ID)
 
     @Test
-    fun `if appointment not found on retrieval, pass through exception`() {
-      val upstreamException = NotFoundException("not found!")
-      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, DELIUS_APPOINTMENT_ID) } throws upstreamException
-
-      assertThatThrownBy {
-        service.updateAppointmentOutcome(
-          projectCode = PROJECT_CODE,
-          update = updateRequest,
-          trigger = TRIGGER,
-        )
-      }.isSameAs(upstreamException)
-    }
-
-    @Test
     fun `if there's no existing entries for the delius appointment ids, persist new entry, raise domain event and invoke update endpoint`() {
       val appointmentEntity = existingAppointment.toAppointmentEntity()
-      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, DELIUS_APPOINTMENT_ID) } returns existingAppointment
       every { appointmentRetrievalService.getOrCreateAppointmentEntity(existingAppointment) } returns appointmentEntity
       val validatedUpdateAppointment = ValidatedAppointment.validUpdateAppointment().copy(dto = updateRequest)
       every { appointmentOutcomeValidationService.validateUpdate(any(), any()) } returns validatedUpdateAppointment
 
-      service.updateAppointmentOutcome(
-        projectCode = PROJECT_CODE,
+      service.updateAppointment(
+        existingAppointment = existingAppointment,
         update = updateRequest,
         trigger = TRIGGER,
       )
@@ -101,13 +85,12 @@ class AppointmentUpdateServiceTest {
 
     @Test
     fun `if there's an existing entry for the delius appointment id and it's logically identical, do not send an update`() {
-      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, DELIUS_APPOINTMENT_ID) } returns existingAppointment
       val validatedUpdateAppointment = ValidatedAppointment.validUpdateAppointment().copy(dto = updateRequest)
       every { appointmentOutcomeValidationService.validateUpdate(any(), any()) } returns validatedUpdateAppointment
       every { appointmentEventService.hasUpdateAlreadyBeenSent(any()) } returns true
 
-      service.updateAppointmentOutcome(
-        projectCode = PROJECT_CODE,
+      service.updateAppointment(
+        existingAppointment = existingAppointment,
         update = updateRequest,
         trigger = TRIGGER,
       )
@@ -120,7 +103,6 @@ class AppointmentUpdateServiceTest {
 
     @Test
     fun `if appointment has newer version on update, throw conflict exception`() {
-      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, DELIUS_APPOINTMENT_ID) } returns existingAppointment
       every { appointmentOutcomeValidationService.validateUpdate(any(), any()) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = updateRequest)
 
       every { appointmentEventService.hasUpdateAlreadyBeenSent(any()) } returns false
@@ -130,8 +112,8 @@ class AppointmentUpdateServiceTest {
       } throws WebClientResponseExceptionFactory.conflict()
 
       assertThatThrownBy {
-        service.updateAppointmentOutcome(
-          projectCode = PROJECT_CODE,
+        service.updateAppointment(
+          existingAppointment = existingAppointment,
           update = updateRequest,
           trigger = TRIGGER,
         )
@@ -140,7 +122,6 @@ class AppointmentUpdateServiceTest {
 
     @Test
     fun `if bad request returned throw internal server error`() {
-      every { appointmentRetrievalService.getAppointment(PROJECT_CODE, DELIUS_APPOINTMENT_ID) } returns existingAppointment
       every { appointmentOutcomeValidationService.validateUpdate(any(), any()) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = updateRequest)
       every { appointmentEventService.hasUpdateAlreadyBeenSent(any()) } returns false
 
@@ -149,8 +130,8 @@ class AppointmentUpdateServiceTest {
       } throws WebClientResponseExceptionFactory.badRequest("didn't look good")
 
       assertThatThrownBy {
-        service.updateAppointmentOutcome(
-          projectCode = PROJECT_CODE,
+        service.updateAppointment(
+          existingAppointment = existingAppointment,
           update = updateRequest,
           trigger = TRIGGER,
         )


### PR DESCRIPTION
This is fixing the remaining code that was throwing Not Found Exception from the service layer

This PR also limits the  use of `NotFoundException` to controllers. Use of this exception is limited to controllers because they are the only code that has the context for whether an entity has been addressed in the URL. This constraint is tested by the existing `ArchitectureTest`