### PR TITLE
CPB-840 - Sanitize free text fields

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
   implementation("net.javacrumbs.shedlock:shedlock-spring:7.7.0")
   implementation("net.javacrumbs.shedlock:shedlock-provider-redis-spring:7.7.0")
 
+  implementation("com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20260313.1")
+
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
 
   testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.1.0")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/SanitizingStringDeserializer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/SanitizingStringDeserializer.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.common
+
+import org.owasp.html.PolicyFactory
+import org.owasp.html.Sanitizers
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.deser.std.StdScalarDeserializer
+
+/**
+ * Use the OWASP HTML sanitizer to strip out potentially harmful HTML
+ */
+class SanitizingStringDeserializer : StdScalarDeserializer<String>(String::class.java) {
+  companion object {
+    val POLICY: PolicyFactory = Sanitizers.FORMATTING.and(Sanitizers.LINKS)
+  }
+
+  override fun deserialize(
+    p: JsonParser,
+    ctxt: DeserializationContext,
+  ): String? = POLICY.sanitize(p.valueAsString)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CourseCompletionResolutionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CourseCompletionResolutionDto.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Min
+import tools.jackson.databind.annotation.JsonDeserialize
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.SanitizingStringDeserializer
 import java.time.LocalDate
 
 data class CourseCompletionResolutionDto(
@@ -24,6 +26,7 @@ data class CourseCompletionCreditTimeDetailsDto(
   val minutesToCredit: Long,
   val contactOutcomeCode: String,
   val projectCode: String,
+  @field:JsonDeserialize(using = SanitizingStringDeserializer::class)
   val notes: String?,
   val alertActive: Boolean?,
   val sensitive: Boolean?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CreateAppointmentDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CreateAppointmentDto.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import tools.jackson.databind.annotation.JsonDeserialize
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.SanitizingStringDeserializer
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -25,6 +27,7 @@ data class CreateAppointmentDto(
   override val attendanceData: AttendanceDataDto? = null,
   @param:Schema(description = "Will default to the unallocated supervisor for the project's team if not defined")
   val supervisorOfficerCode: String? = null,
+  @field:JsonDeserialize(using = SanitizingStringDeserializer::class)
   override val notes: String? = null,
   @param:Schema(description = "If the corresponding delius contact should be alerted")
   val alertActive: Boolean? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/UpdateAppointmentDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/UpdateAppointmentDto.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import tools.jackson.databind.annotation.JsonDeserialize
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.SanitizingStringDeserializer
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
@@ -28,6 +30,7 @@ data class UpdateAppointmentDto(
   override val contactOutcomeCode: String?,
   override val attendanceData: AttendanceDataDto?,
   val supervisorOfficerCode: String,
+  @field:JsonDeserialize(using = SanitizingStringDeserializer::class)
   override val notes: String? = null,
   val alertActive: Boolean?,
   @param:Schema(description = "If the corresponding delius contact should be marked as sensitive")
@@ -45,6 +48,7 @@ data class UpdateAppointmentDto(
     attendanceData = attendanceData,
     enforcementData = null,
     supervisorOfficerCode = supervisorOfficerCode,
+    notes = notes,
     alertActive = alertActive,
     sensitive = sensitive,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/UpdateAppointmentOutcomeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/UpdateAppointmentOutcomeDto.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import tools.jackson.databind.annotation.JsonDeserialize
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.SanitizingStringDeserializer
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
@@ -22,6 +24,7 @@ data class UpdateAppointmentOutcomeDto(
   @param:Schema(description = "Setting specific enforcement data is not supported", deprecated = true)
   val enforcementData: EnforcementDto?,
   val supervisorOfficerCode: String,
+  @field:JsonDeserialize(using = SanitizingStringDeserializer::class)
   override val notes: String? = null,
   val alertActive: Boolean?,
   @param:Schema(description = "If the corresponding delius contact should be marked as sensitive")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
@@ -46,6 +46,9 @@ class AdminAppointmentIT : IntegrationTestBase() {
   lateinit var appointmentTaskEntityRepository: AppointmentTaskEntityRepository
 
   @Autowired
+  lateinit var appointmentEventEntityRepository: AppointmentEventEntityRepository
+
+  @Autowired
   lateinit var domainEventAsserter: DomainEventAsserter
 
   @Nested
@@ -197,8 +200,9 @@ class AdminAppointmentIT : IntegrationTestBase() {
     }
 
     @Test
-    fun `Should update upstream, raise domain event and create travel time task`() {
+    fun `Should update upstream, raise domain event create travel time task & sanitise notes`() {
       appointmentTaskEntityRepository.deleteAll()
+      appointmentEventEntityRepository.deleteAll()
 
       CommunityPaybackAndDeliusMockServer.Aggregates.setupGetDataMocksForUpdateAppointment(
         existingAppointment = NDAppointment.validNoOutcome(ctx).copy(
@@ -227,6 +231,7 @@ class AdminAppointmentIT : IntegrationTestBase() {
             contactOutcomeCode = CODE_ATTENDED_COMPLIED,
             startTime = LocalTime.of(0, 0),
             endTime = LocalTime.of(1, 0),
+            notes = "A note with some script <script>here()</script>",
           ),
         )
         .exchange()
@@ -241,6 +246,7 @@ class AdminAppointmentIT : IntegrationTestBase() {
       domainEventAsserter.assertEventCount("community-payback.appointment.updated", 1)
 
       assertThat(appointmentTaskEntityRepository.findAll()).hasSize(1)
+      assertThat(appointmentEventEntityRepository.findAll()[0].notes).isEqualTo("A note with some script ")
     }
   }
 
@@ -311,7 +317,7 @@ class AdminAppointmentIT : IntegrationTestBase() {
     }
 
     @Test
-    fun `Should update upstream, raise domain event and create travel time task`() {
+    fun `Should update upstream, raise domain event, create travel time task and sanitise notes`() {
       appointmentTaskEntityRepository.deleteAll()
 
       CommunityPaybackAndDeliusMockServer.Aggregates.setupGetDataMocksForUpdateAppointment(
@@ -341,6 +347,7 @@ class AdminAppointmentIT : IntegrationTestBase() {
             contactOutcomeCode = CODE_ATTENDED_COMPLIED,
             startTime = LocalTime.of(0, 0),
             endTime = LocalTime.of(1, 0),
+            notes = "A note with some script <script>here()</script>",
           ),
         )
         .exchange()
@@ -355,6 +362,7 @@ class AdminAppointmentIT : IntegrationTestBase() {
       domainEventAsserter.assertEventCount("community-payback.appointment.updated", 1)
 
       assertThat(appointmentTaskEntityRepository.findAll()).hasSize(1)
+      assertThat(appointmentEventEntityRepository.findAll()[0].notes).isEqualTo("A note with some script ")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
@@ -630,7 +630,7 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
     }
 
     @Test
-    fun `if type is CREDIT_TIME, should create appointment when appointmentIdToUpdate is null`() {
+    fun `if type is CREDIT_TIME, should create appointment when appointmentIdToUpdate is null, with sanitized notes`() {
       val eventEntity = eteCourseCompletionEventEntityRepository.save(
         EteCourseCompletionEventEntity.valid(ctx).copy(),
       )
@@ -644,6 +644,7 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
           appointmentIdToUpdate = null,
           projectCode = PROJECT_CODE,
           minutesToCredit = 90,
+          notes = "A note with some script <script>here()</script>",
         ),
       )
 
@@ -678,10 +679,11 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
 
       val resolutionEntity = eteCourseCompletionEventEntityRepository.findByIdOrNull(eventEntity.id)!!.resolution!!
       assertThat(resolutionEntity.resolution).isEqualTo(EteCourseCompletionResolution.CREDIT_TIME)
+      assertThat(resolutionEntity.notes).isEqualTo("A note with some script ")
     }
 
     @Test
-    fun `if type is CREDIT_TIME, should update appointment when appointmentIdToUpdate is present`() {
+    fun `if type is CREDIT_TIME, should update appointment when appointmentIdToUpdate is present, with sanitized notes`() {
       val appointmentId = 12345L
 
       CommunityPaybackAndDeliusMockServer.Aggregates.setupGetDataMocksForUpdateAppointment(
@@ -715,6 +717,7 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
           appointmentIdToUpdate = appointmentId,
           projectCode = PROJECT_CODE,
           minutesToCredit = 30,
+          notes = "A note with some script <script>here()</script>",
         ),
       )
 
@@ -739,6 +742,7 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
 
       val resolutionEntity = eteCourseCompletionEventEntityRepository.findByIdOrNull(eventEntity.id)!!.resolution!!
       assertThat(resolutionEntity.resolution).isEqualTo(EteCourseCompletionResolution.CREDIT_TIME)
+      assertThat(resolutionEntity.notes).isEqualTo("A note with some script ")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/common/SanitizingStringDeserializerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/common/SanitizingStringDeserializerTest.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import tools.jackson.databind.annotation.JsonDeserialize
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.SanitizingStringDeserializer
+
+class SanitizingStringDeserializerTest {
+  @Test
+  fun `sanitise html`() {
+    val result = jacksonObjectMapper().readValue(
+      """
+        {"notes": "a note with some script<script>alert('hello')</script>"}
+      """.trimIndent(),
+      MyRequestDto::class.java,
+    )
+
+    assertThat(result.notes).isEqualTo("a note with some script")
+  }
+
+  data class MyRequestDto(
+    @field:JsonDeserialize(using = SanitizingStringDeserializer::class)
+    val notes: String,
+  )
+}


### PR DESCRIPTION
This commit adds a custom Jackson Deserializer that applies the OWASP HTML santiser to all free text fields, to counter any attempted HTML injection

There is a [discussion here](https://github.com/OWASP/java-html-sanitizer/blob/main/docs/html-validation.md) as to why it’s recommended to sanitise HTML instead of validate