### PR TITLE
Remove `ContactOutcomeDto.availableToSupervisors`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/ContactOutcomeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/ContactOutcomeDto.kt
@@ -14,9 +14,6 @@ data class ContactOutcomeDto(
   val enforceable: Boolean,
   @param:Schema(description = "If this outcome represents attendance, and as such attendance information is required", example = "false")
   val attended: Boolean,
-  @Deprecated("If required, use a contact outcome group instead")
-  @param:Schema(description = "If this outcome can be used by a supervisor. Deprecated, If required, use a contact outcome group instead", example = "false", deprecated = true)
-  val availableToSupervisors: Boolean?,
   val willAlertEnforcementDiary: Boolean,
 ) {
   companion object

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/ReferenceMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/ReferenceMappers.kt
@@ -41,7 +41,6 @@ fun ContactOutcomeEntity.toDto() = ContactOutcomeDto(
   code = this.code,
   enforceable = this.enforceable,
   attended = this.attended,
-  availableToSupervisors = false,
   willAlertEnforcementDiary = this.enforceable,
 )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/ContactOutcomeDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/ContactOutcomeDtoFactory.kt
@@ -6,10 +6,9 @@ import java.util.UUID
 
 fun ContactOutcomeDto.Companion.valid() = ContactOutcomeDto(
   id = UUID.randomUUID(),
-  name = String.Companion.random(),
+  name = String.random(),
   code = String.random(5),
   enforceable = Boolean.random(),
   attended = Boolean.random(),
-  availableToSupervisors = Boolean.random(),
   willAlertEnforcementDiary = Boolean.random(),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/ReferenceMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/ReferenceMappersTest.kt
@@ -212,7 +212,6 @@ class ReferenceMappersTest {
           code = "ATTC",
           enforceable = false,
           attended = true,
-          availableToSupervisors = false,
           willAlertEnforcementDiary = false,
         ),
       )


### PR DESCRIPTION
This field is deprecated and not used by the UIs