### PR TITLE
Ensure all deprecated fields are optional

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/SessionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/SessionDto.kt
@@ -9,14 +9,14 @@ data class SessionDto(
   val projectCode: String,
   @Deprecated("Use [location] instead")
   @param:Schema(description = "Deprecated, use the structured location instead", deprecated = true)
-  val projectLocation: String,
+  val projectLocation: String?,
   val location: LocationDto,
   val date: LocalDate,
   @Deprecated("Will be removed")
   @param:Schema(description = "Deprecated", deprecated = true)
-  val startTime: LocalTime,
+  val startTime: LocalTime?,
   @Deprecated("Will be removed")
   @param:Schema(description = "Deprecated", deprecated = true)
-  val endTime: LocalTime,
+  val endTime: LocalTime?,
   val appointmentSummaries: List<AppointmentSummaryDto>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/SessionSummariesDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/SessionSummariesDto.kt
@@ -18,10 +18,10 @@ data class SessionSummaryDto(
   val date: LocalDate,
   @Deprecated("Will be removed")
   @param:Schema(description = "Allocation start local time (deprecated)", example = "09:00", pattern = "^([0-1][0-9]|2[0-3]):[0-5][0-9]$", deprecated = true)
-  val startTime: LocalTime,
+  val startTime: LocalTime?,
   @Deprecated("Will be removed")
   @param:Schema(description = "Allocation end local time (deprecated)", example = "17:00", pattern = "^([0-1][0-9]|2[0-3]):[0-5][0-9]$", deprecated = true)
-  val endTime: LocalTime,
+  val endTime: LocalTime?,
   @param:Schema(description = "Number of offenders allocated", example = "12")
   val numberOfOffendersAllocated: Int,
   @param:Schema(description = "Number of offenders with outcomes", example = "2")


### PR DESCRIPTION
This will allow us to remove them from the API without breaking UI runtime code