### PR TITLE
Remove unused deprecated fields

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/SessionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/SessionDto.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
-import java.time.LocalTime
 
 data class SessionDto(
   val projectName: String,
@@ -12,11 +11,5 @@ data class SessionDto(
   val projectLocation: String?,
   val location: LocationDto,
   val date: LocalDate,
-  @Deprecated("Will be removed")
-  @param:Schema(description = "Deprecated", deprecated = true)
-  val startTime: LocalTime?,
-  @Deprecated("Will be removed")
-  @param:Schema(description = "Deprecated", deprecated = true)
-  val endTime: LocalTime?,
   val appointmentSummaries: List<AppointmentSummaryDto>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/SessionSummariesDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/SessionSummariesDto.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
-import java.time.LocalTime
 
 data class SessionSummariesDto(
   @param:Schema(description = "List of project allocations")
@@ -16,12 +15,6 @@ data class SessionSummaryDto(
   val projectCode: String,
   @param:Schema(description = "Allocation date", example = "2025-09-01")
   val date: LocalDate,
-  @Deprecated("Will be removed")
-  @param:Schema(description = "Allocation start local time (deprecated)", example = "09:00", pattern = "^([0-1][0-9]|2[0-3]):[0-5][0-9]$", deprecated = true)
-  val startTime: LocalTime?,
-  @Deprecated("Will be removed")
-  @param:Schema(description = "Allocation end local time (deprecated)", example = "17:00", pattern = "^([0-1][0-9]|2[0-3]):[0-5][0-9]$", deprecated = true)
-  val endTime: LocalTime?,
   @param:Schema(description = "Number of offenders allocated", example = "12")
   val numberOfOffendersAllocated: Int,
   @param:Schema(description = "Number of offenders with outcomes", example = "2")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/UpdateAppointmentDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/UpdateAppointmentDto.kt
@@ -46,7 +46,6 @@ data class UpdateAppointmentDto(
     endTime = endTime,
     contactOutcomeCode = contactOutcomeCode,
     attendanceData = attendanceData,
-    enforcementData = null,
     supervisorOfficerCode = supervisorOfficerCode,
     notes = notes,
     alertActive = alertActive,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/UpdateAppointmentOutcomeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/UpdateAppointmentOutcomeDto.kt
@@ -20,9 +20,6 @@ data class UpdateAppointmentOutcomeDto(
   override val endTime: LocalTime,
   override val contactOutcomeCode: String?,
   override val attendanceData: AttendanceDataDto?,
-  @Deprecated("Setting specific enforcement data is not supported")
-  @param:Schema(description = "Setting specific enforcement data is not supported", deprecated = true)
-  val enforcementData: EnforcementDto?,
   val supervisorOfficerCode: String,
   @field:JsonDeserialize(using = SanitizingStringDeserializer::class)
   override val notes: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/EteMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/EteMappers.kt
@@ -76,7 +76,6 @@ class EteMappers(
       endTime = calculateEndTime(creditTime.minutesToCredit),
       contactOutcomeCode = creditTime.contactOutcomeCode,
       attendanceData = createAttendanceData(),
-      enforcementData = null,
       supervisorOfficerCode = existingAppointment.supervisorOfficerCode,
       notes = buildNote(creditTime.notes, courseCompletionEvent),
       alertActive = creditTime.alertActive,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/SessionMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/SessionMappers.kt
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionSummariesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntityRepository
 import java.time.LocalDate
-import java.time.LocalTime
 
 @Service
 class SessionMappers(
@@ -31,8 +30,6 @@ class SessionMappers(
     appointmentSummaries = appointments,
     // deprecated fields
     projectLocation = "",
-    startTime = LocalTime.of(0, 0),
-    endTime = LocalTime.of(0, 0),
   )
 
   fun toSummaryDto(
@@ -43,8 +40,6 @@ class SessionMappers(
     projectName = project.projectName,
     projectCode = project.projectCode,
     date = date,
-    startTime = LocalTime.of(0, 0),
-    endTime = LocalTime.of(0, 0),
     numberOfOffendersAllocated = appointments.size,
     numberOfOffendersWithEA = appointments.count { it.hasOutcome() && findOutcome(it.contactOutcome!!.code).enforceable },
     numberOfOffendersWithOutcomes = appointments.count { it.hasOutcome() },
@@ -58,8 +53,6 @@ fun NDSessionSummary.toDto() = SessionSummaryDto(
   projectName = this.project.description,
   projectCode = this.project.code,
   date = this.date,
-  startTime = LocalTime.of(0, 0),
-  endTime = LocalTime.of(0, 0),
   numberOfOffendersAllocated = this.allocatedCount,
   numberOfOffendersWithOutcomes = this.outcomeCount,
   numberOfOffendersWithEA = this.enforcementActionCount,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/UpdateAppointmentOutcomeDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/UpdateAppointmentOutcomeDtoFactory.kt
@@ -1,17 +1,14 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto
 
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AttendanceDataDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EnforcementDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
-import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomLocalDate
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
 
 fun UpdateAppointmentOutcomeDto.Companion.valid(
   contactOutcomeCode: String = "OUTCOME1",
-  enforcementActionId: UUID = UUID.randomUUID(),
 ) = UpdateAppointmentOutcomeDto(
   deliusId = Long.random(),
   deliusVersionToUpdate = UUID.randomUUID(),
@@ -22,10 +19,6 @@ fun UpdateAppointmentOutcomeDto.Companion.valid(
   supervisorOfficerCode = String.random(),
   notes = String.random(400),
   attendanceData = AttendanceDataDto.valid(),
-  enforcementData = EnforcementDto(
-    enforcementActionId = enforcementActionId,
-    respondBy = randomLocalDate(),
-  ),
   alertActive = Boolean.random(),
   sensitive = Boolean.random(),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/UpdateAppointmentOutcomesDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/UpdateAppointmentOutcomesDtoFactory.kt
@@ -1,16 +1,15 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto
 
+import org.springframework.beans.factory.getBean
 import org.springframework.context.ApplicationContext
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntityRepository
-import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EnforcementActionEntityRepository
 
 fun UpdateAppointmentOutcomesDto.Companion.valid() = UpdateAppointmentOutcomesDto(
   updates = listOf(UpdateAppointmentOutcomeDto.valid()),
 )
 
 fun UpdateAppointmentOutcomeDto.Companion.valid(ctx: ApplicationContext) = UpdateAppointmentOutcomeDto.valid(
-  contactOutcomeCode = ctx.getBean(ContactOutcomeEntityRepository::class.java).findAll().first().code,
-  enforcementActionId = ctx.getBean(EnforcementActionEntityRepository::class.java).findAll().first().id,
+  contactOutcomeCode = ctx.getBean<ContactOutcomeEntityRepository>().findAll().first().code,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentEventEntityFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentEventEntityFactoryTest.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentWorkQualityDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AttendanceDataDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EnforcementDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PickUpDataDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PickUpLocationDto
@@ -57,7 +56,6 @@ class AppointmentEventEntityFactoryTest {
 
   companion object {
     const val CONTACT_OUTCOME_CODE: String = "CONTACT-1"
-    val ENFORCEMENT_ACTION_ID: UUID = UUID.randomUUID()
     val TRIGGERED_AT: OffsetDateTime = OffsetDateTime.now()
     const val TRIGGERED_BY: String = "User1"
     val ID: UUID = UUID.randomUUID()
@@ -288,10 +286,6 @@ class AppointmentEventEntityFactoryTest {
                 workQuality = AppointmentWorkQualityDto.SATISFACTORY,
                 behaviour = AppointmentBehaviourDto.UNSATISFACTORY,
               ),
-              enforcementData = EnforcementDto(
-                enforcementActionId = ENFORCEMENT_ACTION_ID,
-                respondBy = LocalDate.of(2026, 8, 10),
-              ),
               alertActive = false,
               sensitive = true,
             ),
@@ -363,7 +357,6 @@ class AppointmentEventEntityFactoryTest {
               supervisorOfficerCode = "N45",
               notes = null,
               attendanceData = null,
-              enforcementData = null,
               alertActive = null,
               sensitive = null,
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/EteMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/EteMappersTest.kt
@@ -271,7 +271,6 @@ class EteMappersTest {
       assertThat(result.deliusVersionToUpdate).isEqualTo(existingAppointment.version)
       assertThat(result.date).isEqualTo(LocalDate.of(2025, 1, 1))
       assertThat(result.contactOutcomeCode).isEqualTo(CONTACT_OUTCOME_CODE)
-      assertThat(result.enforcementData).isNull()
       assertThat(result.supervisorOfficerCode).isEqualTo(existingAppointment.supervisorOfficerCode)
       assertThat(result.notes).isEqualTo(
         """

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/SessionMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/SessionMappersTest.kt
@@ -26,7 +26,6 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.SessionM
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toFullAddress
 import java.time.LocalDate
-import java.time.LocalTime
 
 @ExtendWith(MockKExtension::class)
 class SessionMappersTest {
@@ -76,8 +75,6 @@ class SessionMappersTest {
 
       assertThat(projectAllocationsDto.allocations[0].projectName).isEqualTo("Community Garden")
       assertThat(projectAllocationsDto.allocations[0].date).isEqualTo(LocalDate.of(2025, 9, 1))
-      assertThat(projectAllocationsDto.allocations[0].startTime).isEqualTo(LocalTime.of(0, 0))
-      assertThat(projectAllocationsDto.allocations[0].endTime).isEqualTo(LocalTime.of(0, 0))
       assertThat(projectAllocationsDto.allocations[0].projectCode).isEqualTo("cg")
       assertThat(projectAllocationsDto.allocations[0].numberOfOffendersAllocated).isEqualTo(0)
       assertThat(projectAllocationsDto.allocations[0].numberOfOffendersWithOutcomes).isEqualTo(1)
@@ -85,8 +82,6 @@ class SessionMappersTest {
 
       assertThat(projectAllocationsDto.allocations[1].projectName).isEqualTo("Park Cleanup")
       assertThat(projectAllocationsDto.allocations[1].date).isEqualTo(LocalDate.of(2025, 9, 8))
-      assertThat(projectAllocationsDto.allocations[1].startTime).isEqualTo(LocalTime.of(0, 0))
-      assertThat(projectAllocationsDto.allocations[1].endTime).isEqualTo(LocalTime.of(0, 0))
       assertThat(projectAllocationsDto.allocations[1].projectCode).isEqualTo("pc")
       assertThat(projectAllocationsDto.allocations[1].numberOfOffendersAllocated).isEqualTo(3)
       assertThat(projectAllocationsDto.allocations[1].numberOfOffendersWithOutcomes).isEqualTo(4)
@@ -113,8 +108,6 @@ class SessionMappersTest {
         SessionSummaryDto(
           projectName = "Community Garden",
           date = LocalDate.of(2025, 9, 1),
-          startTime = LocalTime.of(0, 0),
-          endTime = LocalTime.of(0, 0),
           projectCode = "cg",
           numberOfOffendersAllocated = 40,
           numberOfOffendersWithOutcomes = 0,
@@ -150,8 +143,6 @@ class SessionMappersTest {
       assertThat(result.appointmentSummaries).isEqualTo(appointments)
 
       assertThat(result.projectLocation).isEqualTo("")
-      assertThat(result.startTime).isEqualTo(LocalTime.of(0, 0))
-      assertThat(result.endTime).isEqualTo(LocalTime.of(0, 0))
     }
   }
 


### PR DESCRIPTION
Remove `UpdateAppointmentDto.enforcementData`
Remove `SessionDto.startTime`
Remove `SessionDto.endTime`
Remove `SessionSummariesDto.startTime`
Remove `SessionSummariesDto.endTime`

These have been deprecated for some time.