### PR TITLE
Return 400 for badly formatted URL params

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CommunityPaybackApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CommunityPaybackApiExceptionHandler.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.servlet.resource.NoResourceFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.NotFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.BadRequestException
@@ -32,6 +33,7 @@ class CommunityPaybackApiExceptionHandler(
     MissingServletRequestParameterException::class,
     BadRequestException::class,
     MethodArgumentNotValidException::class,
+    MethodArgumentTypeMismatchException::class,
   )
   fun validationError(e: Exception): ResponseEntity<ErrorResponse> = ResponseEntity
     .status(BAD_REQUEST)


### PR DESCRIPTION
Before this commit a 500 would be returned