### PR TITLE
CPB-856: Add additional filters to `GET /admin/providers/{providerCode}/course-completions` endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminCourseCompletionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminCourseCompletionController.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.notF
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionRecommendationDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionEventDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionEventStatusDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionResolutionStatusDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.EteService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
@@ -74,16 +75,28 @@ class AdminCourseCompletionController(val eteService: EteService) {
     @Parameter(description = "If not defined both resolved and unresolved completions will be returned")
     resolutionStatus: EteCourseCompletionResolutionStatusDto?,
     @RequestParam
+    @Parameter(description = "Filter results by course completion outcome (either 'Passed' or 'Failed'). If not provided, defaults to 'Passed'.")
+    status: EteCourseCompletionEventStatusDto?,
+    @RequestParam
+    @Parameter(description = "Filter results by the attempt number if provided.")
+    attempts: Int?,
+    @RequestParam
+    @Parameter(description = "Filter by the external reference supplied by Community Campus.")
+    externalReference: String?,
+    @RequestParam
     @Parameter(description = "From date, inclusive", example = "2025-09-01")
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) dateFrom: LocalDate?,
     @RequestParam
     @Parameter(description = "To date, inclusive", example = "2025-09-01")
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) dateTo: LocalDate?,
-  ): Page<EteCourseCompletionEventDto> = eteService.getPassedCourseCompletionEvents(
+  ): Page<EteCourseCompletionEventDto> = eteService.getCourseCompletionEvents(
     providerCode,
     pduId,
     office,
     resolutionStatus = resolutionStatus,
+    completionStatus = status ?: EteCourseCompletionEventStatusDto.Passed,
+    attempts,
+    externalReference,
     dateFrom?.atFirstSecondOfDay(),
     dateTo?.atLastSecondOfDay(),
     pageable,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionEventEntityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionEventEntityRepository.kt
@@ -15,21 +15,26 @@ interface EteCourseCompletionEventEntityRepository : JpaRepository<EteCourseComp
     """
     SELECT e FROM EteCourseCompletionEventEntity e
     LEFT JOIN e.resolution r
-    WHERE e.status = 'PASSED' 
+    WHERE e.status = :completionStatus
     AND e.pdu.providerCode = :providerCode 
     AND ((CAST(:pduId AS uuid) IS NULL) OR (e.pdu.id = :pduId))
     AND (:officesCount = 0 OR e.office IN :offices)
     AND ((:#{#resolutionStatus.name()} = 'ANY') OR (:#{#resolutionStatus.name()} = 'RESOLVED' AND r IS NOT NULL) OR (:#{#resolutionStatus.name()} = 'UNRESOLVED' AND r IS NULL))
+    AND (:attempts IS NULL OR e.attempts = :attempts)
+    AND (:externalReference IS NULL OR e.externalReference = :externalReference)
     AND (cast(:fromDate as timestamp) IS NULL OR e.completionDateTime >= :fromDate)
     AND (cast(:toDate as timestamp) IS NULL OR e.completionDateTime <= :toDate)
   """,
   )
-  fun findAllPassedWithFilters(
+  fun findAllWithFilters(
     providerCode: String,
     pduId: UUID?,
     officesCount: Int,
     offices: List<String>,
     resolutionStatus: ResolutionStatus,
+    completionStatus: EteCourseCompletionEventStatus,
+    attempts: Int?,
+    externalReference: String?,
     fromDate: OffsetDateTime?,
     toDate: OffsetDateTime?,
     pageable: Pageable,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
@@ -11,12 +11,14 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionReso
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionTypeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionEventDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionEventStatusDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionResolutionStatusDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEventTriggerType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository.ResolutionStatus
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventResolutionRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventStatus
 import uk.gov.justice.digital.hmpps.communitypaybackapi.listener.EducationCourseCompletionMessage
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.EteMappers
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
@@ -40,18 +42,21 @@ class EteService(
     eteCourseCompletionEventEntityRepository.save(eteMapper.toCourseCompletionEventEntity(message))
   }
 
-  fun getPassedCourseCompletionEvents(
+  fun getCourseCompletionEvents(
     providerCode: String,
     pduId: UUID?,
     offices: List<String>?,
     resolutionStatus: EteCourseCompletionResolutionStatusDto?,
+    completionStatus: EteCourseCompletionEventStatusDto,
+    attempts: Int?,
+    externalReference: String?,
     fromDate: OffsetDateTime?,
     toDate: OffsetDateTime?,
     pageable: Pageable,
   ): Page<EteCourseCompletionEventDto> {
     val officesNormalised = offices ?: emptyList()
 
-    val page = eteCourseCompletionEventEntityRepository.findAllPassedWithFilters(
+    val page = eteCourseCompletionEventEntityRepository.findAllWithFilters(
       providerCode,
       pduId,
       officesNormalised.size,
@@ -61,6 +66,12 @@ class EteService(
         EteCourseCompletionResolutionStatusDto.Unresolved -> ResolutionStatus.UNRESOLVED
         null -> ResolutionStatus.ANY
       },
+      completionStatus = when (completionStatus) {
+        EteCourseCompletionEventStatusDto.Passed -> EteCourseCompletionEventStatus.PASSED
+        EteCourseCompletionEventStatusDto.Failed -> EteCourseCompletionEventStatus.FAILED
+      },
+      attempts,
+      externalReference,
       fromDate,
       toDate,
       pageable,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
@@ -183,7 +183,7 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
     }
 
     @Test
-    fun `should exclude failed completions`() {
+    fun `should exclude failed completions by default`() {
       val pdu = communityCampusPduEntityRepository.findByNameIgnoreCase("Dyfed Powys")!!
 
       val completionPassed = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu))
@@ -198,6 +198,42 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
         .bodyAsObject<PagedModel<EteCourseCompletionEventDto>>()
 
       assertThat(pagedCourseCompletions.content.map { it.id }).containsExactly(completionPassed.id)
+    }
+
+    @Test
+    fun `should exclude failed completions when completion status of 'passed' requested`() {
+      val pdu = communityCampusPduEntityRepository.findByNameIgnoreCase("Dyfed Powys")!!
+
+      val completionPassed = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu))
+      eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(pdu = pdu))
+
+      val pagedCourseCompletions = webTestClient.get()
+        .uri("/admin/providers/${pdu.providerCode}/course-completions?status=Passed")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<PagedModel<EteCourseCompletionEventDto>>()
+
+      assertThat(pagedCourseCompletions.content.map { it.id }).containsExactly(completionPassed.id)
+    }
+
+    @Test
+    fun `should exclude passed completions when completion status of 'failed' requested`() {
+      val pdu = communityCampusPduEntityRepository.findByNameIgnoreCase("Dyfed Powys")!!
+
+      eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu))
+      val completionFailed = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(pdu = pdu))
+
+      val pagedCourseCompletions = webTestClient.get()
+        .uri("/admin/providers/${pdu.providerCode}/course-completions?status=Failed")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<PagedModel<EteCourseCompletionEventDto>>()
+
+      assertThat(pagedCourseCompletions.content.map { it.id }).containsExactly(completionFailed.id)
     }
 
     @Test
@@ -344,6 +380,82 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
         .bodyAsObject<PagedModel<EteCourseCompletionEventDto>>()
 
       assertThat(result.content.map { it.id }).containsExactlyInAnyOrder(unresolved.id)
+    }
+
+    @Test
+    fun `should return results with any attempt count if attempts parameter is not defined`() {
+      val pdu = communityCampusPduEntityRepository.findAll().first()
+
+      val firstAttemptCompletion = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu, attempts = 1))
+      val secondAttemptCompletion = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu, attempts = 2))
+      val thirdAttemptCompletion = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu, attempts = 3))
+
+      val result = webTestClient.get()
+        .uri("/admin/providers/${pdu.providerCode}/course-completions")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<PagedModel<EteCourseCompletionEventDto>>()
+
+      assertThat(result.content.map { it.id }).containsExactlyInAnyOrder(firstAttemptCompletion.id, secondAttemptCompletion.id, thirdAttemptCompletion.id)
+    }
+
+    @Test
+    fun `should only return results with the requested attempt count`() {
+      val pdu = communityCampusPduEntityRepository.findAll().first()
+
+      eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu, attempts = 1))
+      eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu, attempts = 2))
+      val thirdAttemptCompletion = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu, attempts = 3))
+
+      val result = webTestClient.get()
+        .uri("/admin/providers/${pdu.providerCode}/course-completions?attempts=3")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<PagedModel<EteCourseCompletionEventDto>>()
+
+      assertThat(result.content.map { it.id }).containsExactlyInAnyOrder(thirdAttemptCompletion.id)
+    }
+
+    @Test
+    fun `should return results with any external reference if external reference parameter is not defined`() {
+      val pdu = communityCampusPduEntityRepository.findAll().first()
+
+      val completion1 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu, externalReference = "EXT-REF-000001"))
+      val completion2 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu, externalReference = "EXT-REF-000002"))
+      val completion3 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu, externalReference = "EXT-REF-000003"))
+
+      val result = webTestClient.get()
+        .uri("/admin/providers/${pdu.providerCode}/course-completions")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<PagedModel<EteCourseCompletionEventDto>>()
+
+      assertThat(result.content.map { it.id }).containsExactlyInAnyOrder(completion1.id, completion2.id, completion3.id)
+    }
+
+    @Test
+    fun `should only return results with the requested external reference`() {
+      val pdu = communityCampusPduEntityRepository.findAll().first()
+
+      val completion1 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu, externalReference = "EXT-REF-000001"))
+      eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu, externalReference = "EXT-REF-000002"))
+      eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu, externalReference = "EXT-REF-000003"))
+
+      val result = webTestClient.get()
+        .uri("/admin/providers/${pdu.providerCode}/course-completions?externalReference=EXT-REF-000001")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<PagedModel<EteCourseCompletionEventDto>>()
+
+      assertThat(result.content.map { it.id }).containsExactlyInAnyOrder(completion1.id)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
@@ -14,10 +14,12 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.atFirstSecondOfDay
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.atLastSecondOfDay
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionEventStatusDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository.ResolutionStatus
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventResolutionRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventStatus
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.listener.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.listener.EducationCourseCompletionMessage
@@ -81,16 +83,21 @@ class EteServiceTest {
       val pduId = UUID.randomUUID()
       val providerCode = "PC01"
       val offices = listOf("office1", "office2")
+      val attempts = 1
+      val externalReference = "EXT-REF-123456"
       val fromDate = LocalDate.of(2026, 1, 1).atFirstSecondOfDay()
       val toDate = LocalDate.of(2026, 12, 31).atLastSecondOfDay()
 
       every {
-        eteCourseCompletionEventEntityRepository.findAllPassedWithFilters(
+        eteCourseCompletionEventEntityRepository.findAllWithFilters(
           providerCode = providerCode,
           pduId = pduId,
           officesCount = 2,
           offices = offices,
           resolutionStatus = ResolutionStatus.ANY,
+          completionStatus = EteCourseCompletionEventStatus.PASSED,
+          attempts = attempts,
+          externalReference = externalReference,
           fromDate = fromDate,
           toDate = toDate,
           pageable = pageable,
@@ -103,11 +110,14 @@ class EteServiceTest {
         ),
       )
 
-      val result = eteService.getPassedCourseCompletionEvents(
+      val result = eteService.getCourseCompletionEvents(
         providerCode = providerCode,
         pduId = pduId,
         offices = offices,
         resolutionStatus = null,
+        completionStatus = EteCourseCompletionEventStatusDto.Passed,
+        attempts = attempts,
+        externalReference = externalReference,
         fromDate = fromDate,
         toDate = toDate,
         pageable = pageable,


### PR DESCRIPTION
This adds three new optional query parameters to this endpoint that can be used to filter results:
- `status`: filter course completions by whether the course was passed or failed. To preserve backwards compatibility, if this parameter is not present, it defaults to `Passed`.
- `attempts`: filter course completions by the attempt number (e.g. `attempts=3` only returns completions that represent the third attempt). If this parameter is not present, this filter is ignored.
- `externalReference`: filter course completions by the Community Campus reference ID. If this parameter is not present, this filter is ignored.

The `EteCourseCompletionEventEntityRepository.findAllPassedWithFilters` and `EteService.getPassedCourseCompletionEvents` methods have been renamed to `findAllWithFilters` and `getCourseCompletionEvents` respectively to better reflect their new behaviours as a result of this change.