### PR TITLE
CPB-873: Use pagination for 'find group sessions' endpoint in PI client

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
@@ -3,6 +3,7 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.client
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonUnwrapped
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.format.annotation.DateTimeFormat
@@ -159,6 +160,8 @@ data class NDProviderTeamSummary(
 
 data class NDSessionSummaries(
   val sessions: List<NDSessionSummary>,
+  @get:JsonUnwrapped
+  val pageResponse: PageResponse<NDSessionSummary>,
 ) {
   companion object
 }
@@ -577,6 +580,7 @@ data class PageResponse<T>(
     val totalElements: Long,
     val totalPages: Int,
   )
+  companion object
 }
 
 data class NDCaseDetailsSummary(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
@@ -48,6 +48,7 @@ interface CommunityPaybackAndDeliusClient {
     @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate,
     @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate,
     @RequestParam typeCode: List<String>?,
+    @RequestParam params: Map<String, String>,
   ): NDSessionSummaries
 
   @Cacheable(CacheKey.Delius.GET_PROJECT)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminProviderController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminProviderController.kt
@@ -123,6 +123,7 @@ class AdminProviderController(
     @PathVariable teamCode: String,
   ): SupervisorSummariesDto = providerService.getTeamSupervisors(TeamId(providerCode, teamCode))
 
+  @PageableAsQueryParam
   @GetMapping("/{providerCode}/teams/{teamCode}/sessions")
   @Operation(
     description = "Get sessions within a date range for a specific team",
@@ -151,12 +152,15 @@ class AdminProviderController(
     @RequestParam
     @Parameter(description = "End date, inclusive", example = "2025-09-01")
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate,
+    @Parameter(hidden = true)
+    @PageableDefault(size = 50, sort = ["projectName"], direction = Sort.Direction.ASC) pageable: Pageable,
   ) = sessionService.getSessions(
     providerCode,
     teamCode,
     startDate,
     endDate,
     ProjectTypeGroupDto.GROUP,
+    pageable,
   )
 
   @GetMapping("/{providerCode}/teams/{teamCode}/projects")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorSessionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorSessionsController.kt
@@ -5,6 +5,10 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.springdoc.core.converters.models.PageableAsQueryParam
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
@@ -50,6 +54,7 @@ class SupervisorSessionsController(
     @PathVariable supervisorCode: String,
   ) = sessionService.getNextAllocationForSupervisor(supervisorCode) ?: throw NotFoundException("There are no future sessions for supervisor $supervisorCode")
 
+  @PageableAsQueryParam
   @GetMapping(
     path = [ "/supervisor/providers/{providerCode}/teams/{teamCode}/sessions/future"],
     produces = [MediaType.APPLICATION_JSON_VALUE],
@@ -66,12 +71,15 @@ class SupervisorSessionsController(
   fun getFutureSessions(
     @PathVariable providerCode: String,
     @PathVariable teamCode: String,
+    @Parameter(hidden = true)
+    @PageableDefault(size = 50, sort = ["startDate"], direction = Sort.Direction.DESC) pageable: Pageable,
   ) = sessionService.getSessions(
     providerCode,
     teamCode,
     LocalDate.now(),
     LocalDate.now().plusDays(7),
     projectTypeGroup = ProjectTypeGroupDto.GROUP,
+    pageable = pageable,
   )
 
   @GetMapping(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/PageMetaDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/PageMetaDto.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
+
+data class PageMetaDto(val size: Int, val number: Int, val totalElements: Long, val totalPages: Int)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/SessionSummariesDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/SessionSummariesDto.kt
@@ -4,8 +4,17 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
 data class SessionSummariesDto(
-  @param:Schema(description = "List of project allocations")
+  @param:Schema(
+    deprecated = true,
+    description = """
+      Deprecated: use the `content` property instead.
+      
+      List of project allocations
+    """,
+  )
   val allocations: List<SessionSummaryDto>,
+  val content: List<SessionSummaryDto>,
+  val page: PageMetaDto,
 )
 
 data class SessionSummaryDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/SessionService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -15,6 +16,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.SessionSupervisorEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.SessionSupervisorEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.SessionSupervisorId
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.toHttpParams
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.SessionMappers
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
 import java.time.LocalDate
@@ -39,6 +41,7 @@ class SessionService(
     startDate: LocalDate,
     endDate: LocalDate,
     projectTypeGroup: ProjectTypeGroupDto?,
+    pageable: Pageable,
   ): SessionSummariesDto {
     if (ChronoUnit.DAYS.between(startDate, endDate) > 7) {
       badRequest("Date range cannot be greater than 7 days")
@@ -52,6 +55,7 @@ class SessionService(
       typeCode = projectTypeGroup?.let { projectTypeGroup ->
         projectService.projectTypesForGroup(projectTypeGroup).map { it.code }
       },
+      params = pageable.toHttpParams(),
     ).toDto()
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/SessionMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/SessionMappers.kt
@@ -4,7 +4,9 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAddress
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummary
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PageMetaDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionSummariesDto
@@ -48,7 +50,19 @@ class SessionMappers(
   private fun findOutcome(deliusCode: String) = contactOutcomeEntityRepository.findByCode(deliusCode) ?: error("Can't find outcome for code $deliusCode")
 }
 
-fun NDSessionSummaries.toDto() = SessionSummariesDto(this.sessions.map { it.toDto() })
+fun NDSessionSummaries.toDto() = SessionSummariesDto(
+  allocations = this.sessions.map { it.toDto() },
+  content = this.pageResponse.content.map { it.toDto() },
+  page = this.pageResponse.page.toDto(),
+)
+
+fun PageResponse.PageMeta.toDto() = PageMetaDto(
+  size = size,
+  number = number,
+  totalElements = totalElements,
+  totalPages = totalPages,
+)
+
 fun NDSessionSummary.toDto() = SessionSummaryDto(
   projectName = this.project.description,
   projectCode = this.project.code,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDSessionSummariesFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDSessionSummariesFactory.kt
@@ -2,10 +2,19 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client
 
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummary
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
 
-fun NDSessionSummaries.Companion.valid() = NDSessionSummaries(
-  listOf(
+fun NDSessionSummaries.Companion.valid(): NDSessionSummaries {
+  val summaries = listOf(
     NDSessionSummary.valid(),
     NDSessionSummary.valid(),
-  ),
-)
+  )
+
+  return NDSessionSummaries(
+    sessions = summaries,
+    pageResponse = PageResponse(
+      content = summaries,
+      page = PageResponse.PageMeta(50, 0, 2, 1),
+    ),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/PageResponseFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/PageResponseFactory.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client
+
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
+
+fun <T> PageResponse.Companion.empty() = PageResponse<T>(content = emptyList(), page = PageResponse.PageMeta(50, 0, 0, 0))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminProvidersIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminProvidersIT.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProviderSummariesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProviderTeamSummariesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionSummariesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SupervisorSummariesDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.empty
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.util.bodyAsObject
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.wiremock.CommunityPaybackAndDeliusMockServer
@@ -317,6 +318,13 @@ class AdminProvidersIT : IntegrationTestBase() {
 
     @Test
     fun `should return OK with project session summaries`() {
+      val projectName1 = "Community Garden Maintenance"
+      val projectName2 = "Park Cleanup"
+      val sessions = listOf(
+        NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = projectName1)),
+        NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = projectName2)),
+      )
+
       CommunityPaybackAndDeliusMockServer.setupGetSessionsResponse(
         providerCode = "PC01",
         teamCode = "999",
@@ -324,9 +332,10 @@ class AdminProvidersIT : IntegrationTestBase() {
         endDate = LocalDate.of(2025, 1, 12),
         typeCode = listOf("NP1", "NP2", "PL"),
         projectSessions = NDSessionSummaries(
-          listOf(
-            NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = "Community Garden Maintenance")),
-            NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = "Park Cleanup")),
+          sessions,
+          pageResponse = PageResponse(
+            content = sessions,
+            page = PageResponse.PageMeta(50, 0, 2, 1),
           ),
         ),
       )
@@ -352,7 +361,7 @@ class AdminProvidersIT : IntegrationTestBase() {
         startDate = LocalDate.of(2025, 1, 9),
         endDate = LocalDate.of(2025, 1, 11),
         typeCode = listOf("NP1", "NP2", "PL"),
-        projectSessions = NDSessionSummaries(emptyList()),
+        projectSessions = NDSessionSummaries(emptyList(), pageResponse = PageResponse.empty()),
       )
 
       val sessionSummaries = webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminProvidersIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminProvidersIT.kt
@@ -349,8 +349,60 @@ class AdminProvidersIT : IntegrationTestBase() {
         .bodyAsObject<SessionSummariesDto>()
 
       assertThat(sessionSearchResults.allocations).hasSize(2)
-      assertThat(sessionSearchResults.allocations[0].projectName).isEqualTo("Community Garden Maintenance")
-      assertThat(sessionSearchResults.allocations[1].projectName).isEqualTo("Park Cleanup")
+      assertThat(sessionSearchResults.allocations[0].projectName).isEqualTo(projectName1)
+      assertThat(sessionSearchResults.allocations[1].projectName).isEqualTo(projectName2)
+      assertThat(sessionSearchResults.content).hasSize(2)
+      assertThat(sessionSearchResults.content[0].projectName).isEqualTo(projectName1)
+      assertThat(sessionSearchResults.content[1].projectName).isEqualTo(projectName2)
+      assertThat(sessionSearchResults.page.size).isEqualTo(50)
+      assertThat(sessionSearchResults.page.totalPages).isEqualTo(1)
+      assertThat(sessionSearchResults.page.totalElements).isEqualTo(2)
+      assertThat(sessionSearchResults.page.number).isEqualTo(0)
+    }
+
+    @Test
+    fun `should return OK with paginated response when pagination parameters are provided`() {
+      val projectName1 = "Community Garden Maintenance"
+      val projectName2 = "Park Cleanup"
+      val sessions = listOf(
+        NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = projectName1)),
+        NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = projectName2)),
+      )
+
+      CommunityPaybackAndDeliusMockServer.setupGetSessionsResponse(
+        providerCode = "PC01",
+        teamCode = "999",
+        startDate = LocalDate.of(2025, 1, 9),
+        endDate = LocalDate.of(2025, 1, 12),
+        typeCode = listOf("NP1", "NP2", "PL"),
+        projectSessions = NDSessionSummaries(
+          sessions,
+          pageResponse = PageResponse(
+            content = sessions,
+            page = PageResponse.PageMeta(25, 0, 2, 1),
+          ),
+        ),
+        sortString = "projectName,desc",
+      )
+
+      val sessionSearchResults = webTestClient.get()
+        .uri("/admin/providers/PC01/teams/999/sessions?startDate=2025-01-09&endDate=2025-01-12&page=0&size=25&sort=projectName,desc")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<SessionSummariesDto>()
+
+      assertThat(sessionSearchResults.allocations).hasSize(2)
+      assertThat(sessionSearchResults.allocations[0].projectName).isEqualTo(projectName1)
+      assertThat(sessionSearchResults.allocations[1].projectName).isEqualTo(projectName2)
+      assertThat(sessionSearchResults.content).hasSize(2)
+      assertThat(sessionSearchResults.content[0].projectName).isEqualTo(projectName1)
+      assertThat(sessionSearchResults.content[1].projectName).isEqualTo(projectName2)
+      assertThat(sessionSearchResults.page.size).isEqualTo(25)
+      assertThat(sessionSearchResults.page.totalPages).isEqualTo(1)
+      assertThat(sessionSearchResults.page.totalElements).isEqualTo(2)
+      assertThat(sessionSearchResults.page.number).isEqualTo(0)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/SupervisorSessionsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/SupervisorSessionsIT.kt
@@ -235,9 +235,12 @@ class SupervisorSessionsIT : IntegrationTestBase() {
 
     @Test
     fun `should return OK with project session`() {
+      val projectName1 = "Community Garden Maintenance"
+      val projectName2 = "Park Cleanup"
+
       val sessions = listOf(
-        NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = "Community Garden Maintenance")),
-        NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = "Park Cleanup")),
+        NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = projectName1)),
+        NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = projectName2)),
       )
 
       CommunityPaybackAndDeliusMockServer.setupGetSessionsResponse(
@@ -253,6 +256,7 @@ class SupervisorSessionsIT : IntegrationTestBase() {
             page = PageResponse.PageMeta(50, 0, 2, 1),
           ),
         ),
+        sortString = "startDate,desc",
       )
 
       val result = webTestClient.get()
@@ -264,9 +268,62 @@ class SupervisorSessionsIT : IntegrationTestBase() {
         .bodyAsObject<SessionSummariesDto>()
 
       assertThat(result.allocations).hasSize(2)
-      assertThat(result.allocations[0].projectName).isEqualTo("Community Garden Maintenance")
-      assertThat(result.allocations[1].projectName).isEqualTo("Park Cleanup")
+      assertThat(result.allocations[0].projectName).isEqualTo(projectName1)
+      assertThat(result.allocations[1].projectName).isEqualTo(projectName2)
+      assertThat(result.content).hasSize(2)
+      assertThat(result.content[0].projectName).isEqualTo(projectName1)
+      assertThat(result.content[1].projectName).isEqualTo(projectName2)
+      assertThat(result.page.size).isEqualTo(50)
+      assertThat(result.page.totalPages).isEqualTo(1)
+      assertThat(result.page.totalElements).isEqualTo(2)
+      assertThat(result.page.number).isEqualTo(0)
     }
+  }
+
+  @Test
+  fun `should return OK with paginated response when pagination parameters are provided`() {
+    val projectName1 = "Community Garden Maintenance"
+    val projectName2 = "Park Cleanup"
+
+    val sessions = listOf(
+      NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = projectName1)),
+      NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = projectName2)),
+    )
+
+    CommunityPaybackAndDeliusMockServer.setupGetSessionsResponse(
+      providerCode = "P123",
+      teamCode = "T456",
+      startDate = LocalDate.now(),
+      endDate = LocalDate.now().plusDays(7),
+      typeCode = listOf("NP1", "NP2", "PL"),
+      projectSessions = NDSessionSummaries(
+        sessions,
+        pageResponse = PageResponse(
+          content = sessions,
+          page = PageResponse.PageMeta(25, 0, 2, 1),
+        ),
+      ),
+      sortString = "projectName,asc",
+    )
+
+    val result = webTestClient.get()
+      .uri("/supervisor/providers/P123/teams/T456/sessions/future?page=0&size=25&sort=projectName,asc")
+      .addSupervisorUiAuthHeader(username = "USER1")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .bodyAsObject<SessionSummariesDto>()
+
+    assertThat(result.allocations).hasSize(2)
+    assertThat(result.allocations[0].projectName).isEqualTo(projectName1)
+    assertThat(result.allocations[1].projectName).isEqualTo(projectName2)
+    assertThat(result.content).hasSize(2)
+    assertThat(result.content[0].projectName).isEqualTo(projectName1)
+    assertThat(result.content[1].projectName).isEqualTo(projectName2)
+    assertThat(result.page.size).isEqualTo(25)
+    assertThat(result.page.totalPages).isEqualTo(1)
+    assertThat(result.page.totalElements).isEqualTo(2)
+    assertThat(result.page.number).isEqualTo(0)
   }
 
   private fun allocateSessionToSupervisor1(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/SupervisorSessionsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/SupervisorSessionsIT.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProject
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProjectSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummary
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionSummariesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionSummaryDto
@@ -234,6 +235,11 @@ class SupervisorSessionsIT : IntegrationTestBase() {
 
     @Test
     fun `should return OK with project session`() {
+      val sessions = listOf(
+        NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = "Community Garden Maintenance")),
+        NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = "Park Cleanup")),
+      )
+
       CommunityPaybackAndDeliusMockServer.setupGetSessionsResponse(
         providerCode = "P123",
         teamCode = "T456",
@@ -241,9 +247,10 @@ class SupervisorSessionsIT : IntegrationTestBase() {
         endDate = LocalDate.now().plusDays(7),
         typeCode = listOf("NP1", "NP2", "PL"),
         projectSessions = NDSessionSummaries(
-          listOf(
-            NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = "Community Garden Maintenance")),
-            NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = "Park Cleanup")),
+          sessions,
+          pageResponse = PageResponse(
+            content = sessions,
+            page = PageResponse.PageMeta(50, 0, 2, 1),
           ),
         ),
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
@@ -246,12 +246,16 @@ object CommunityPaybackAndDeliusMockServer {
     endDate: LocalDate,
     projectSessions: NDSessionSummaries,
     typeCode: List<String> = emptyList(),
+    sortString: String = "projectName,asc",
   ) {
     val url = buildString {
       append("/community-payback-and-delius/providers/$providerCode/teams/$teamCode/sessions?startDate=${startDate.toIsoDateString()}&endDate=${endDate.toIsoDateString()}")
       typeCode.forEach {
         append("&typeCode=$it")
       }
+      append("&page=${projectSessions.pageResponse.page.number}")
+      append("&size=${projectSessions.pageResponse.page.size}")
+      append("&sort=${URLEncoder.encode(sortString, "UTF-8")}")
     }
 
     WireMock.stubFor(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/SessionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/SessionServiceTest.kt
@@ -9,9 +9,13 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummary
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.BadRequestException
@@ -61,12 +65,21 @@ class SessionServiceTest {
           startDate = LocalDate.of(2025, 1, 1),
           endDate = LocalDate.of(2025, 1, 9),
           projectTypeGroup = null,
+          pageable = Pageable.unpaged(),
         )
       }.isInstanceOf(BadRequestException::class.java).hasMessage("Date range cannot be greater than 7 days")
     }
 
     @Test
     fun `success path`() {
+      val pageNumber = 0
+      val pageSize = 20
+      val sessions = listOf(
+        NDSessionSummary.valid(),
+        NDSessionSummary.valid(),
+        NDSessionSummary.valid(),
+      )
+
       every {
         projectService.projectTypesForGroup(ProjectTypeGroupDto.GROUP)
       } returns listOf(ProjectTypeDto.valid().copy(code = "PT1"))
@@ -78,12 +91,13 @@ class SessionServiceTest {
           startDate = LocalDate.of(2025, 1, 1),
           endDate = LocalDate.of(2025, 1, 5),
           typeCode = listOf("PT1"),
+          params = mapOf("page" to pageNumber.toString(), "size" to pageSize.toString(), "sort" to "projectName,asc"),
         )
       } returns NDSessionSummaries.valid().copy(
-        sessions = listOf(
-          NDSessionSummary.valid(),
-          NDSessionSummary.valid(),
-          NDSessionSummary.valid(),
+        sessions = sessions,
+        pageResponse = PageResponse(
+          content = sessions,
+          PageResponse.PageMeta(pageSize, pageNumber, 3, 1),
         ),
       )
 
@@ -93,9 +107,15 @@ class SessionServiceTest {
         startDate = LocalDate.of(2025, 1, 1),
         endDate = LocalDate.of(2025, 1, 5),
         projectTypeGroup = ProjectTypeGroupDto.GROUP,
+        pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.ASC, "projectName")),
       )
 
       assertThat(result.allocations).hasSize(3)
+      assertThat(result.content).hasSize(3)
+      assertThat(result.page.totalElements).isEqualTo(3)
+      assertThat(result.page.totalPages).isEqualTo(1)
+      assertThat(result.page.number).isEqualTo(pageNumber)
+      assertThat(result.page.size).isEqualTo(pageSize)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/SessionMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/SessionMappersTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAddress
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProjectSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummary
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ContactOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
@@ -44,28 +45,34 @@ class SessionMappersTest {
 
     @Test
     fun `should map ProjectAllocations to DTO correctly`() {
+      val sessions = listOf(
+        NDSessionSummary(
+          project = NDProjectSummary(
+            code = "cg",
+            description = "Community Garden",
+          ),
+          date = LocalDate.of(2025, 9, 1),
+          allocatedCount = 0,
+          outcomeCount = 1,
+          enforcementActionCount = 2,
+        ),
+        NDSessionSummary(
+          project = NDProjectSummary(
+            code = "pc",
+            description = "Park Cleanup",
+          ),
+          date = LocalDate.of(2025, 9, 8),
+          allocatedCount = 3,
+          outcomeCount = 4,
+          enforcementActionCount = 5,
+        ),
+      )
+
       val projectSessions = NDSessionSummaries(
-        listOf(
-          NDSessionSummary(
-            project = NDProjectSummary(
-              code = "cg",
-              description = "Community Garden",
-            ),
-            date = LocalDate.of(2025, 9, 1),
-            allocatedCount = 0,
-            outcomeCount = 1,
-            enforcementActionCount = 2,
-          ),
-          NDSessionSummary(
-            project = NDProjectSummary(
-              code = "pc",
-              description = "Park Cleanup",
-            ),
-            date = LocalDate.of(2025, 9, 8),
-            allocatedCount = 3,
-            outcomeCount = 4,
-            enforcementActionCount = 5,
-          ),
+        sessions,
+        pageResponse = PageResponse(
+          content = sessions,
+          page = PageResponse.PageMeta(50, 0, 2, 1),
         ),
       )
 


### PR DESCRIPTION
The PI team has introduced pagination to the `GET /providers/{providerCode}/teams/{teamCode}/sessions` endpoint in [PI-4034](https://dsdmoj.atlassian.net/browse/PI-4034). This endpoint is passed through our API using the `GET /admin/providers/{providerCode}/teams/{teamCode}/sessions` and `GET /supervisor/providers/{providerCode}/teams/{teamCode}/sessions/future` endpoints. This allows for our API to also add paging and sorting to these endpoints.

[PI-4034]: https://dsdmoj.atlassian.net/browse/PI-4034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ