### PR TITLE
Fixing the call to the POST adjustment endpoint on PI to include the reference (which is the adjustment id in our database)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
@@ -624,6 +624,7 @@ data class NDAdjustmentRequest(
   val date: LocalDate,
   val reason: String,
   val minutes: Int,
+  val reference: UUID,
 )
 
 enum class NDAdjustmentType(val code: String) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/AdjustmentEventEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/AdjustmentEventEntity.kt
@@ -63,7 +63,9 @@ data class AdjustmentEventEntity(
 
   override fun toString(): String = "AdjustmentEvent(id=$id)"
 
-  companion object
+  companion object {
+    fun generateId(): UUID = UUID.randomUUID()
+  }
 }
 
 enum class AdjustmentEventType {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentEventEntityFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentEventEntityFactory.kt
@@ -8,7 +8,6 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventTr
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import java.time.OffsetDateTime
-import java.util.UUID
 
 @Service
 class AdjustmentEventEntityFactory {
@@ -16,7 +15,7 @@ class AdjustmentEventEntityFactory {
   fun buildAdjustmentCreated(
     details: AdjustmentCreatedEvent,
   ) = AdjustmentEventEntity(
-    id = UUID.randomUUID(),
+    id = details.id,
     eventType = AdjustmentEventType.CREATE,
     triggeredAt = details.trigger.triggeredAt,
     triggerType = details.trigger.triggerType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentService.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UnpaidWorkDetailsIdDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventTriggerType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
@@ -13,6 +14,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringE
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toNDAdjustmentRequest
 import java.time.Clock
 import java.time.OffsetDateTime
+import java.util.UUID
 
 @Service
 class AdjustmentService(
@@ -20,6 +22,7 @@ class AdjustmentService(
   private val communityPaybackAndDeliusClient: CommunityPaybackAndDeliusClient,
   private val clock: Clock,
   private val springEventPublisher: SpringEventPublisher,
+  private val adjustmentIdGenerator: AdjustmentIdGenerator,
 ) {
 
   @Transactional
@@ -29,7 +32,7 @@ class AdjustmentService(
     username: String,
   ) {
     val validatedAdjustment = adjustmentValidationService.validateCreate(createAdjustment, upwDetailsId, username)
-
+    val adjustmentId = adjustmentIdGenerator.generateId()
     val (crn, deliusEventNumber) = upwDetailsId
 
     val deliusAdjustmentId = communityPaybackAndDeliusClient.postAdjustments(
@@ -39,12 +42,14 @@ class AdjustmentService(
           crn = crn,
           deliusEventNumber = deliusEventNumber,
           reason = validatedAdjustment.reason,
+          reference = adjustmentId,
         ),
       ),
     ).single().id
 
     springEventPublisher.publishEvent(
       AdjustmentCreatedEvent(
+        id = adjustmentId,
         createDto = createAdjustment,
         appointmentEntity = validatedAdjustment.task.appointment,
         reason = validatedAdjustment.reason,
@@ -67,4 +72,13 @@ class AdjustmentService(
       communityPaybackAndDeliusClient.deleteAdjustment(event.deliusAdjustmentId)
     }
   }
+}
+
+interface AdjustmentIdGenerator {
+  fun generateId(): UUID
+}
+
+@Service
+class DefaultAdjustmentIdGenerator : AdjustmentIdGenerator {
+  override fun generateId() = AdjustmentEventEntity.generateId()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentEventTrigger
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentEventTrigger
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService
+import java.util.UUID
 
 @Service
 class SpringEventPublisher(
@@ -41,6 +42,7 @@ sealed interface CommunityPaybackSpringEvent {
     val reason: AdjustmentReasonEntity,
     val deliusAdjustmentId: Long,
     val trigger: AdjustmentEventTrigger,
+    val id: UUID,
   ) : CommunityPaybackSpringEvent {
     companion object
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AdjustmentMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AdjustmentMappers.kt
@@ -7,11 +7,13 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.domainevent.AdjustmentCreatedDomainEventDetailsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentReasonEntity
+import java.util.UUID
 
 fun CreateAdjustmentDto.toNDAdjustmentRequest(
   crn: String,
   deliusEventNumber: Int,
   reason: AdjustmentReasonEntity,
+  reference: UUID,
 ) = NDAdjustmentRequest(
   crn = crn,
   eventNumber = deliusEventNumber,
@@ -22,6 +24,7 @@ fun CreateAdjustmentDto.toNDAdjustmentRequest(
   date = dateOfAdjustment,
   reason = reason.deliusCode,
   minutes = minutes,
+  reference = reference,
 )
 
 fun AdjustmentEventEntity.toAdjustmentCreatedDomainEvent() = this.toAdjustmentDomainEvent()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/event/AdjustmentCreatedEventFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/event/AdjustmentCreatedEventFactory.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentEventTrigger
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import java.time.OffsetDateTime
+import java.util.UUID
 
 fun AdjustmentCreatedEvent.Companion.valid() = AdjustmentCreatedEvent(
   createDto = CreateAdjustmentDto.valid(),
@@ -17,6 +18,7 @@ fun AdjustmentCreatedEvent.Companion.valid() = AdjustmentCreatedEvent(
   reason = AdjustmentReasonEntity.valid(),
   deliusAdjustmentId = Long.random(),
   trigger = AdjustmentEventTrigger.valid(),
+  id = UUID.randomUUID(),
 )
 
 fun AdjustmentEventTrigger.Companion.valid() = AdjustmentEventTrigger(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentEventEntityFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentEventEntityFactoryTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentEventT
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.util.UUID
 
 class AdjustmentEventEntityFactoryTest {
 
@@ -24,7 +25,7 @@ class AdjustmentEventEntityFactoryTest {
     val triggeredAt = OffsetDateTime.now()
     val appointment = AppointmentEntity.valid()
     val reason = AdjustmentReasonEntity.valid()
-
+    val id = UUID.randomUUID()
     val result = AdjustmentEventEntityFactory().buildAdjustmentCreated(
       AdjustmentCreatedEvent(
         createDto = CreateAdjustmentDto.valid().copy(
@@ -40,6 +41,7 @@ class AdjustmentEventEntityFactoryTest {
           triggerType = AdjustmentEventTriggerType.APPOINTMENT_TASK,
           triggeredBy = "task id",
         ),
+        id = id,
       ),
     )
 
@@ -53,5 +55,6 @@ class AdjustmentEventEntityFactoryTest {
     assertThat(result.adjustmentMinutes).isEqualTo(61)
     assertThat(result.adjustmentDate).isEqualTo(LocalDate.of(1971, 8, 23))
     assertThat(result.adjustmentReason).isEqualTo(reason)
+    assertThat(result.id).isEqualTo(id)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentServiceTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.config.ClockConfiguration
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentEventTrigger
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentIdGenerator
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentValidationService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
@@ -41,6 +42,9 @@ class AdjustmentServiceTest {
   @RelaxedMockK
   private lateinit var springEventPublisher: SpringEventPublisher
 
+  @RelaxedMockK
+  lateinit var adjustmentIdGenerator: AdjustmentIdGenerator
+
   val clock: Clock = ClockConfiguration.MutableClock(Instant.now())
 
   @InjectMockKs
@@ -61,6 +65,7 @@ class AdjustmentServiceTest {
     fun success() {
       val reason = AdjustmentReasonEntity.valid().copy(maxMinutesAllowed = 50)
       val appointmentTask = AppointmentTaskEntity.valid()
+      val id = UUID.randomUUID()
 
       val request = CreateAdjustmentDto.valid().copy(
         adjustmentReasonId = REASON_ID,
@@ -68,6 +73,8 @@ class AdjustmentServiceTest {
       )
 
       val validatedAdjustment = AdjustmentValidationService.ValidatedCreateAdjustment(request, reason, appointmentTask)
+      every { adjustmentIdGenerator.generateId() } returns id
+
       every {
         adjustmentValidationService.validateCreate(request, UNPAID_WORK_DETAILS, USERNAME)
       } returns validatedAdjustment
@@ -80,6 +87,7 @@ class AdjustmentServiceTest {
               crn = CRN,
               deliusEventNumber = EVENT_NUMBER,
               reason = reason,
+              reference = id,
             ),
           ),
         )
@@ -94,6 +102,7 @@ class AdjustmentServiceTest {
       verify {
         springEventPublisher.publishEvent(
           AdjustmentCreatedEvent(
+            id = id,
             createDto = request,
             appointmentEntity = appointmentTask.appointment,
             reason = validatedAdjustment.reason,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AdjustmentMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AdjustmentMappersTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toNDAdjustmentRequest
 import java.time.LocalDate
+import java.util.UUID
 
 class AdjustmentMappersTest {
 
@@ -27,6 +28,7 @@ class AdjustmentMappersTest {
       typeDto: CreateAdjustmentTypeDto,
       expectedUpstreamType: NDAdjustmentType,
     ) {
+      val id = UUID.randomUUID()
       val result = CreateAdjustmentDto.valid().copy(
         dateOfAdjustment = LocalDate.of(2014, 11, 4),
         type = typeDto,
@@ -35,6 +37,7 @@ class AdjustmentMappersTest {
         crn = "CRN888",
         deliusEventNumber = 5,
         reason = AdjustmentReasonEntity.valid().copy(deliusCode = "REASON1"),
+        reference = id,
       )
 
       assertThat(result.crn).isEqualTo("CRN888")
@@ -43,6 +46,7 @@ class AdjustmentMappersTest {
       assertThat(result.date).isEqualTo(LocalDate.of(2014, 11, 4))
       assertThat(result.reason).isEqualTo("REASON1")
       assertThat(result.minutes).isEqualTo(5)
+      assertThat(result.reference).isEqualTo(id)
     }
   }
 }


### PR DESCRIPTION
Fixing the call to the POST adjustment endpoint on PI to include the reference (which is the adjustment id in our database)