### PR TITLE
CPB-880: Persist name and project type on appointments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/OffenderDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/OffenderDto.kt
@@ -70,3 +70,10 @@ enum class OffenderType(@get:JsonValue val value: String) {
     fun forValue(value: String) = entries.first { it.value == value }
   }
 }
+
+data class OffenderNameDto(
+  val forename: String,
+  val surname: String,
+) {
+  companion object
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/AppointmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/AppointmentEntity.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.entity
 
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.Id
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.hibernate.proxy.HibernateProxy
 import java.time.LocalDate
@@ -44,6 +46,12 @@ data class AppointmentEntity(
    */
   var date: LocalDate,
   var providerCode: String,
+  // Appointments created before the following fields were introduced may not have been updated
+  // and therefore have no values available.
+  var firstName: String? = null,
+  var lastName: String? = null,
+  @ManyToOne(fetch = FetchType.LAZY)
+  var projectType: ProjectTypeEntity? = null,
 ) {
   @Suppress("USELESS_IS_CHECK")
   override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentCreationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentCreationService.kt
@@ -19,6 +19,8 @@ import java.util.UUID
 @Service
 class AppointmentCreationService(
   private val appointmentValidationService: AppointmentValidationService,
+  private val offenderService: OffenderService,
+  private val projectService: ProjectService,
   private val communityPaybackAndDeliusClient: CommunityPaybackAndDeliusClient,
   private val appointmentEntityRepository: AppointmentEntityRepository,
   private val springEventPublisher: SpringEventPublisher,
@@ -48,6 +50,11 @@ class AppointmentCreationService(
     require(createAppointmentsDto.appointments.isNotEmpty()) { "At least one appointment must be provided" }
     require(createAppointmentsDto.appointments.count { it.projectCode != createAppointmentsDto.projectCode } == 0) { "All appointments must be for the same project code" }
 
+    val project = projectService.getProject(createAppointmentsDto.projectCode)
+    require(project != null) { "A valid project must be used" }
+    val projectType = projectService.getProjectTypeForCode(project.projectType.code)
+    require(projectType != null) { "A valid project type must be used" }
+
     val appointmentsToCreate = appointments.map {
       AppointmentToCreate(
         id = appointmentIdGenerator.generateId(),
@@ -62,10 +69,15 @@ class AppointmentCreationService(
 
     val appointmentEntities = appointmentEntityRepository.saveAll(
       appointmentsToCreate.map {
+        val name = offenderService.getNameIgnoringLimitedStatus(it.validatedAppointment.dto.crn)
+
         it.validatedAppointment.dto.toAppointmentEntity(
           id = it.id,
           deliusAppointmentId = creationResponse.findDeliusId(communityPaybackId = it.id),
           providerCode = it.validatedAppointment.project.providerCode,
+          firstName = name?.forename,
+          lastName = name?.surname,
+          projectType = projectType,
         )
       },
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentRetrievalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentRetrievalService.kt
@@ -84,7 +84,7 @@ class AppointmentRetrievalService(
       existing.date = existingAppointment.date
       appointmentEntityRepository.save(existing)
     } else {
-      appointmentEntityRepository.save(existingAppointment.toAppointmentEntity())
+      appointmentEntityRepository.save(existingAppointment.toAppointmentEntity(null, null, null))
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentRetrievalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentRetrievalService.kt
@@ -23,6 +23,7 @@ class AppointmentRetrievalService(
   private val appointmentMappers: AppointmentMappers,
   private val contextService: ContextService,
   private val projectService: ProjectService,
+  private val offenderService: OffenderService,
   private val appointmentEntityRepository: AppointmentEntityRepository,
 ) {
 
@@ -71,6 +72,9 @@ class AppointmentRetrievalService(
     existingAppointment: AppointmentDto,
   ): AppointmentEntity {
     val existing = appointmentEntityRepository.findByDeliusId(existingAppointment.id)
+    val name = offenderService.getNameIgnoringLimitedStatus(existingAppointment.offender.crn)
+    val projectTypeCode = projectService.getProject(existingAppointment.projectCode)?.projectType?.code
+    val projectType = projectTypeCode?.let { projectService.getProjectTypeForCode(it) }
 
     return if (existing != null) {
       /**
@@ -82,9 +86,19 @@ class AppointmentRetrievalService(
        * in sync with NDelius without relying on user interactions to trigger this check
        */
       existing.date = existingAppointment.date
+
+      if (name != null) {
+        existing.firstName = name.forename
+        existing.lastName = name.surname
+      }
+
+      if (projectType != null) {
+        existing.projectType = projectType
+      }
+
       appointmentEntityRepository.save(existing)
     } else {
-      appointmentEntityRepository.save(existingAppointment.toAppointmentEntity(null, null, null))
+      appointmentEntityRepository.save(existingAppointment.toAppointmentEntity(name?.forename, name?.surname, projectType))
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/OffenderService.kt
@@ -5,9 +5,11 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.ArnsClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CaseDetailsSummaryDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderNameDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UnpaidWorkDetailsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UnpaidWorkDetailsIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toOffenderNameDto
 
 @Service
 class OffenderService(
@@ -31,5 +33,11 @@ class OffenderService(
     communityPaybackAndDeliusClient.getUpwDetailsSummary(crn, userName).toDto()
   } catch (_: WebClientResponseException.NotFound) {
     return null
+  }
+
+  fun getNameIgnoringLimitedStatus(crn: String): OffenderNameDto? = try {
+    communityPaybackAndDeliusClient.getUpwDetailsSummary(crn, null).case.toOffenderNameDto()
+  } catch (_: WebClientResponseException.NotFound) {
+    null
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
@@ -237,6 +237,9 @@ object ToAppointmentEntity {
     id: UUID,
     deliusAppointmentId: Long,
     providerCode: String,
+    firstName: String?,
+    lastName: String?,
+    projectType: ProjectTypeEntity?,
   ): AppointmentEntity = AppointmentEntity(
     id = id,
     deliusId = deliusAppointmentId,
@@ -245,6 +248,9 @@ object ToAppointmentEntity {
     createdByCommunityPayback = true,
     date = this.date,
     providerCode = providerCode,
+    firstName = firstName,
+    lastName = lastName,
+    projectType = projectType,
   )
 
   fun AppointmentDto.toAppointmentEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
@@ -247,7 +247,11 @@ object ToAppointmentEntity {
     providerCode = providerCode,
   )
 
-  fun AppointmentDto.toAppointmentEntity(): AppointmentEntity = AppointmentEntity(
+  fun AppointmentDto.toAppointmentEntity(
+    firstName: String?,
+    lastName: String?,
+    projectType: ProjectTypeEntity?,
+  ): AppointmentEntity = AppointmentEntity(
     id = this.communityPaybackId ?: AppointmentEntity.generateId(),
     deliusId = this.id,
     crn = this.offender.crn,
@@ -255,6 +259,9 @@ object ToAppointmentEntity {
     createdByCommunityPayback = this.communityPaybackId != null,
     date = this.date,
     providerCode = this.providerCode,
+    firstName = firstName,
+    lastName = lastName,
+    projectType = projectType,
   )
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/CaseSummaryMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/CaseSummaryMapper.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers
 
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderNameDto
 
 fun NDCaseSummary.toDto() = if (isLimited()) {
   OffenderDto.OffenderLimitedDto(
@@ -16,5 +17,7 @@ fun NDCaseSummary.toDto() = if (isLimited()) {
     dateOfBirth = dateOfBirth,
   )
 }
+
+fun NDCaseSummary.toOffenderNameDto() = OffenderNameDto(this.name.forename, this.name.surname)
 
 private fun NDCaseSummary.isLimited() = this.currentExclusion || this.currentRestriction

--- a/src/main/resources/db/migration/20260424135450__add_name_and_type_to_appointments.sql
+++ b/src/main/resources/db/migration/20260424135450__add_name_and_type_to_appointments.sql
@@ -1,0 +1,5 @@
+ALTER TABLE appointments ADD COLUMN first_name TEXT NULL;
+ALTER TABLE appointments ADD COLUMN last_name TEXT NULL;
+
+ALTER TABLE appointments ADD COLUMN project_type_id UUID NULL;
+ALTER TABLE appointments ADD FOREIGN KEY (project_type_id) REFERENCES project_types(id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/OffenderNameDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/OffenderNameDtoFactory.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto
+
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderNameDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
+
+fun OffenderNameDto.Companion.valid() = OffenderNameDto(
+  forename = String.random(50),
+  surname = String.random(50),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentCreationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentCreationServiceTest.kt
@@ -15,8 +15,10 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCreateAppointme
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCreatedAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentsDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderNameDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.validCreateAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
@@ -25,6 +27,8 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentIdGenerator
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService.ValidatedAppointment
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.OffenderService
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ProjectService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.ToAppointmentEntity.toAppointmentEntity
@@ -35,6 +39,12 @@ import java.util.UUID
 class AppointmentCreationServiceTest {
   @RelaxedMockK
   lateinit var appointmentValidationService: AppointmentValidationService
+
+  @RelaxedMockK
+  lateinit var offenderService: OffenderService
+
+  @RelaxedMockK
+  lateinit var projectService: ProjectService
 
   @RelaxedMockK
   lateinit var communityPaybackAndDeliusClient: CommunityPaybackAndDeliusClient
@@ -108,8 +118,16 @@ class AppointmentCreationServiceTest {
       val validatedCreateAppointment2 = ValidatedAppointment.validCreateAppointment().copy(dto = createAppointment2Dto, project = PROJECT)
       every { appointmentValidationService.validateCreate(createAppointment2Dto) } returns validatedCreateAppointment2
 
-      val appointmentEntity1 = createAppointment1Dto.toAppointmentEntity(appointment1Id, ND_APPT1_ID, PROVIDER_CODE)
-      val appointmentEntity2 = createAppointment2Dto.toAppointmentEntity(appointment2Id, ND_APPT2_ID, PROVIDER_CODE)
+      val projectType = ProjectTypeEntity.valid()
+      every { projectService.getProjectTypeForCode(PROJECT_CODE) } returns projectType
+
+      val name1 = OffenderNameDto.valid()
+      val name2 = OffenderNameDto.valid()
+      every { offenderService.getNameIgnoringLimitedStatus(validatedCreateAppointment1.dto.crn) } returns name1
+      every { offenderService.getNameIgnoringLimitedStatus(validatedCreateAppointment2.dto.crn) } returns name2
+
+      val appointmentEntity1 = createAppointment1Dto.toAppointmentEntity(appointment1Id, ND_APPT1_ID, PROVIDER_CODE, firstName = name1.forename, lastName = name1.surname, projectType = projectType)
+      val appointmentEntity2 = createAppointment2Dto.toAppointmentEntity(appointment2Id, ND_APPT2_ID, PROVIDER_CODE, firstName = name2.forename, lastName = name2.surname, projectType = projectType)
       every { appointmentEntityRepository.saveAll(listOf(appointmentEntity1, appointmentEntity2)) } returnsArgument 0
 
       every {
@@ -140,8 +158,8 @@ class AppointmentCreationServiceTest {
       verify {
         appointmentEntityRepository.saveAll(
           listOf(
-            createAppointment1Dto.toAppointmentEntity(appointment1Id, ND_APPT1_ID, PROVIDER_CODE),
-            createAppointment2Dto.toAppointmentEntity(appointment2Id, ND_APPT2_ID, PROVIDER_CODE),
+            createAppointment1Dto.toAppointmentEntity(appointment1Id, ND_APPT1_ID, PROVIDER_CODE, firstName = name1.forename, lastName = name1.surname, projectType = projectType),
+            createAppointment2Dto.toAppointmentEntity(appointment2Id, ND_APPT2_ID, PROVIDER_CODE, firstName = name2.forename, lastName = name2.surname, projectType = projectType),
           ),
         )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentRetrievalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentRetrievalServiceTest.kt
@@ -205,11 +205,11 @@ class AppointmentRetrievalServiceTest {
       val existingAppointment = AppointmentDto.valid()
 
       every { appointmentEntityRepository.findByDeliusId(existingAppointment.id) } returns null
-      every { appointmentEntityRepository.save(existingAppointment.toAppointmentEntity()) } returnsArgument 0
+      every { appointmentEntityRepository.save(existingAppointment.toAppointmentEntity(null, null, null)) } returnsArgument 0
 
       val result = service.getOrCreateAppointmentEntity(existingAppointment)
 
-      assertThat(result).isEqualTo(existingAppointment.toAppointmentEntity())
+      assertThat(result).isEqualTo(existingAppointment.toAppointmentEntity(null, null, null))
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentRetrievalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentRetrievalServiceTest.kt
@@ -18,6 +18,8 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderNameDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
@@ -28,10 +30,12 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentRetrievalService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ContextService
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ProjectService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.toHttpParams
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.AppointmentMappers
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.ToAppointmentEntity.toAppointmentEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.unit.util.WebClientResponseExceptionFactory
 import java.time.LocalDate
 
@@ -49,6 +53,9 @@ class AppointmentRetrievalServiceTest {
 
   @RelaxedMockK
   private lateinit var projectService: ProjectService
+
+  @RelaxedMockK
+  private lateinit var offenderService: OffenderService
 
   @RelaxedMockK
   private lateinit var appointmentEntityRepository: AppointmentEntityRepository
@@ -203,13 +210,24 @@ class AppointmentRetrievalServiceTest {
     @Test
     fun `doesnt exist, save new entity`() {
       val existingAppointment = AppointmentDto.valid()
+      val projectType = ProjectTypeEntity.valid()
+      val project = ProjectDto.valid().copy(projectCode = existingAppointment.projectCode, projectType = projectType.toDto())
 
       every { appointmentEntityRepository.findByDeliusId(existingAppointment.id) } returns null
       every { appointmentEntityRepository.save(existingAppointment.toAppointmentEntity(null, null, null)) } returnsArgument 0
+      every { projectService.getProject(existingAppointment.projectCode) } returns project
+      every { projectService.getProjectTypeForCode(projectType.code) } returns projectType
+
+      val name = OffenderNameDto.valid()
+
+      every { offenderService.getNameIgnoringLimitedStatus(existingAppointment.offender.crn) } returns name
 
       val result = service.getOrCreateAppointmentEntity(existingAppointment)
 
       assertThat(result).isEqualTo(existingAppointment.toAppointmentEntity(null, null, null))
+      assertThat(result.projectType).isEqualTo(projectType)
+      assertThat(result.firstName).isEqualTo(name.forename)
+      assertThat(result.lastName).isEqualTo(name.surname)
     }
 
     @Test
@@ -223,6 +241,43 @@ class AppointmentRetrievalServiceTest {
       val result = service.getOrCreateAppointmentEntity(existingAppointment)
 
       assertThat(result.date).isEqualTo(LocalDate.of(2022, 2, 2))
+    }
+
+    @Test
+    fun `does exist, update project type and return updated version`() {
+      val existingAppointment = AppointmentDto.valid().copy(date = LocalDate.of(2022, 2, 2))
+      val existingEntity = AppointmentEntity.valid().copy(date = LocalDate.of(2021, 1, 1))
+
+      every { appointmentEntityRepository.findByDeliusId(existingAppointment.id) } returns existingEntity
+      every { appointmentEntityRepository.save(existingEntity) } returnsArgument 0
+
+      val projectType = ProjectTypeEntity.valid()
+      val project = ProjectDto.valid().copy(projectCode = existingAppointment.projectCode, projectType = projectType.toDto())
+
+      every { projectService.getProject(existingAppointment.projectCode) } returns project
+      every { projectService.getProjectTypeForCode(projectType.code) } returns projectType
+
+      val result = service.getOrCreateAppointmentEntity(existingAppointment)
+
+      assertThat(result.projectType).isEqualTo(projectType)
+    }
+
+    @Test
+    fun `does exist, update first and last name and return updated version`() {
+      val existingAppointment = AppointmentDto.valid().copy(date = LocalDate.of(2022, 2, 2))
+      val existingEntity = AppointmentEntity.valid().copy(date = LocalDate.of(2021, 1, 1))
+
+      every { appointmentEntityRepository.findByDeliusId(existingAppointment.id) } returns existingEntity
+      every { appointmentEntityRepository.save(existingEntity) } returnsArgument 0
+
+      val name = OffenderNameDto.valid()
+
+      every { offenderService.getNameIgnoringLimitedStatus(existingAppointment.offender.crn) } returns name
+
+      val result = service.getOrCreateAppointmentEntity(existingAppointment)
+
+      assertThat(result.firstName).isEqualTo(name.forename)
+      assertThat(result.lastName).isEqualTo(name.surname)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentUpdateServiceTest.kt
@@ -62,7 +62,7 @@ class AppointmentUpdateServiceTest {
 
     @Test
     fun `if there's no existing entries for the delius appointment ids, persist new entry, raise domain event and invoke update endpoint`() {
-      val appointmentEntity = existingAppointment.toAppointmentEntity()
+      val appointmentEntity = existingAppointment.toAppointmentEntity(null, null, null)
       every { appointmentRetrievalService.getOrCreateAppointmentEntity(existingAppointment) } returns appointmentEntity
       val validatedUpdateAppointment = ValidatedAppointment.validUpdateAppointment().copy(dto = updateRequest)
       every { appointmentOutcomeValidationService.validateUpdate(any(), any()) } returns validatedUpdateAppointment

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/OffenderServiceTest.kt
@@ -184,4 +184,38 @@ class OffenderServiceTest {
 
     assertThat(result).isNull()
   }
+
+  @Nested
+  inner class GetNameIgnoringLimitedStatusTest {
+
+    @Test
+    fun `returns offender name when found`() {
+      val caseDetailsSummary = NDCaseDetailsSummary.valid().copy(
+        unpaidWorkDetails = listOf(
+          NDUpwDetails.valid(),
+          NDUpwDetails.valid(),
+          NDUpwDetails.valid(),
+          NDUpwDetails.valid(),
+        ),
+      )
+
+      every { communityPaybackAndDeliusClient.getUpwDetailsSummary(CRN, null) } returns caseDetailsSummary
+
+      val result = service.getNameIgnoringLimitedStatus(CRN)
+
+      assertThat(result).isNotNull
+      assertThat(result!!.forename).isEqualTo(caseDetailsSummary.case.name.forename)
+      assertThat(result.surname).isEqualTo(caseDetailsSummary.case.name.surname)
+      verify(exactly = 1) { communityPaybackAndDeliusClient.getUpwDetailsSummary(CRN, null) }
+    }
+
+    @Test
+    fun `returns null when offender not found`() {
+      every { communityPaybackAndDeliusClient.getUpwDetailsSummary(CRN, null) } throws WebClientResponseExceptionFactory.notFound()
+
+      val result = service.getNameIgnoringLimitedStatus(CRN)
+
+      assertThat(result).isNull()
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
@@ -692,6 +692,7 @@ class AppointmentMappersTest {
     @Test
     fun success() {
       val communityPaybackId = UUID.randomUUID()
+      val projectType = ProjectTypeEntity.valid()
       val result = CreateAppointmentDto.valid().copy(
         crn = "CRN777",
         deliusEventNumber = 90,
@@ -700,6 +701,9 @@ class AppointmentMappersTest {
         id = communityPaybackId,
         deliusAppointmentId = 91283,
         providerCode = "PROV1",
+        firstName = "Some",
+        lastName = "Name",
+        projectType = projectType,
       )
 
       assertThat(result.id).isEqualTo(communityPaybackId)
@@ -709,6 +713,9 @@ class AppointmentMappersTest {
       assertThat(result.createdByCommunityPayback).isEqualTo(true)
       assertThat(result.date).isEqualTo(LocalDate.of(2009, 8, 7))
       assertThat(result.providerCode).isEqualTo("PROV1")
+      assertThat(result.firstName).isEqualTo("Some")
+      assertThat(result.lastName).isEqualTo("Name")
+      assertThat(result.projectType).isEqualTo(projectType)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
@@ -55,6 +55,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.validCreateA
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.validFull
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.validUpdateAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService.ValidatedAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.AppointmentMappers
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.ToAppointmentEntity.toAppointmentEntity
@@ -723,7 +724,7 @@ class AppointmentMappersTest {
         deliusEventNumber = 90,
         date = LocalDate.of(2009, 8, 7),
         providerCode = "PROV1",
-      ).toAppointmentEntity()
+      ).toAppointmentEntity(null, null, null)
 
       assertThat(result.id).isNotNull
       assertThat(result.deliusId).isEqualTo(9090)
@@ -744,7 +745,7 @@ class AppointmentMappersTest {
         deliusEventNumber = 90,
         date = LocalDate.of(2009, 8, 7),
         providerCode = "PROV1",
-      ).toAppointmentEntity()
+      ).toAppointmentEntity(null, null, null)
 
       assertThat(result.id).isEqualTo(communityPaybackId)
       assertThat(result.deliusId).isEqualTo(9090)
@@ -753,6 +754,18 @@ class AppointmentMappersTest {
       assertThat(result.createdByCommunityPayback).isEqualTo(true)
       assertThat(result.date).isEqualTo(LocalDate.of(2009, 8, 7))
       assertThat(result.providerCode).isEqualTo("PROV1")
+    }
+
+    @Test
+    fun `includes provided first name, last name, and project type`() {
+      val firstName = String.random(8)
+      val lastName = String.random(8)
+      val projectType = ProjectTypeEntity.valid()
+      val result = AppointmentDto.valid().toAppointmentEntity(firstName, lastName, projectType)
+
+      assertThat(result.firstName).isEqualTo(firstName)
+      assertThat(result.lastName).isEqualTo(lastName)
+      assertThat(result.projectType).isEqualTo(projectType)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/CaseSummaryMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/CaseSummaryMapperTest.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDName
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toOffenderNameDto
 import java.time.LocalDate
 
 class CaseSummaryMapperTest {
@@ -62,5 +63,62 @@ class CaseSummaryMapperTest {
       assertThat(result).isInstanceOf(OffenderDto.OffenderLimitedDto::class.java)
       assertThat(result.crn).isEqualTo("CRN123")
     }
+  }
+
+  @Nested
+  inner class CaseSummaryToOffenderNameDto {
+    @Test
+    fun `If no limitations return OffenderNameDto`() {
+      val result = NDCaseSummary(
+        crn = "CRN123",
+        name = NDName(
+          forename = "thefore",
+          surname = "thesur",
+          middleNames = listOf("themid"),
+        ),
+        dateOfBirth = LocalDate.of(1983, 12, 11),
+        currentExclusion = false,
+        currentRestriction = false,
+      ).toOffenderNameDto()
+
+      assertThat(result.forename).isEqualTo("thefore")
+      assertThat(result.surname).isEqualTo("thesur")
+    }
+  }
+
+  @Test
+  fun `If exclusion return OffenderNameDto`() {
+    val result = NDCaseSummary(
+      crn = "CRN123",
+      name = NDName(
+        forename = "thefore",
+        surname = "thesur",
+        middleNames = listOf("themid"),
+      ),
+      dateOfBirth = LocalDate.of(1983, 12, 11),
+      currentExclusion = true,
+      currentRestriction = false,
+    ).toOffenderNameDto()
+
+    assertThat(result.forename).isEqualTo("thefore")
+    assertThat(result.surname).isEqualTo("thesur")
+  }
+
+  @Test
+  fun `If restriction return OffenderNameDto`() {
+    val result = NDCaseSummary(
+      crn = "CRN123",
+      name = NDName(
+        forename = "thefore",
+        surname = "thesur",
+        middleNames = listOf("themid"),
+      ),
+      dateOfBirth = LocalDate.of(1983, 12, 11),
+      currentExclusion = true,
+      currentRestriction = false,
+    ).toOffenderNameDto()
+
+    assertThat(result.forename).isEqualTo("thefore")
+    assertThat(result.surname).isEqualTo("thesur")
   }
 }


### PR DESCRIPTION
This PR adds to an appointment the name of the person and the project type ID. This will in future allow pending appointment tasks to be sorted by these values.

To get the name for a CRN, it is not enough to use the `getOffenderByCrn` method - when a user does not have the correct permissions, it returns a `OffenderLimitedDto`, which drops this information. To solve this, a new `getNameIgnoringLimitedStatus` method has been added, which provides an `OffenderNameDto` regardless of any restrictions or exclusions. This name is then given to either the `AppointmentDto.toAppointmentEntity` or the `CreateAppointmentDto.toAppointmentEntity` method to update or create an appointment respectively.