### PR TITLE
CPB-925: Filter personal information from `GET /admin/appointment-tasks/pending` endpoint for limited access people

### DIFF
--- a/helm_deploy/hmpps-community-payback-api/values.yaml
+++ b/helm_deploy/hmpps-community-payback-api/values.yaml
@@ -39,6 +39,7 @@ generic-service:
     COMMUNITY_PAYBACK_EDUCATION_COURSE_INTEGRATION_ENABLED: true
 
     CLIENT_COMMUNITY_PAYBACK_AND_DELIUS_URL: "http://localhost:8080/mocks/community-payback-and-delius"
+    CLIENT_PROBATION_ACCESS_CONTROL_URL: "http://localhost:8080/mocks/probation-access-control"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -23,6 +23,7 @@ generic-service:
 
     CLIENT_ARNS_URL: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk
     CLIENT_COMMUNITY_PAYBACK_AND_DELIUS_URL: https://community-payback-and-delius-dev.hmpps.service.justice.gov.uk
+    CLIENT_PROBATION_ACCESS_CONTROL_URL: https://probation-access-control-dev.hmpps.service.justice.gov.uk
 
     SPRINGDOC_API_DOCS_ENABLED: true
     SPRINGDOC_SWAGGER_UI_ENABLED: true

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -22,6 +22,7 @@ generic-service:
 
     CLIENT_COMMUNITY_PAYBACK_AND_DELIUS_URL: https://community-payback-and-delius-dev.hmpps.service.justice.gov.uk
     CLIENT_ARNS_URL: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk
+    CLIENT_PROBATION_ACCESS_CONTROL_URL: https://probation-access-control-dev.hmpps.service.justice.gov.uk
 
     SPRINGDOC_API_DOCS_ENABLED: true
     SPRINGDOC_SWAGGER_UI_ENABLED: true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/ProbationAccessControlClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/ProbationAccessControlClient.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.client
+
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.service.annotation.PostExchange
+
+interface ProbationAccessControlClient {
+  @PostExchange("/user/{userName}/access")
+  fun getAccessControlForCrns(
+    @PathVariable userName: String,
+    @RequestBody crns: List<String>,
+  ): NDCaseAccess
+}
+
+data class NDCaseAccess(
+  val access: List<NDCaseAccessItem>,
+) {
+  companion object
+}
+
+data class NDCaseAccessItem(
+  val crn: String,
+  val userExcluded: Boolean,
+  val userRestricted: Boolean,
+  val exclusionMessage: String?,
+  val restrictionMessage: String?,
+) {
+  companion object
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/WebClientConfiguration.kt
@@ -8,9 +8,10 @@ import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.support.WebClientAdapter
 import org.springframework.web.service.invoker.HttpServiceProxyFactory
+import org.springframework.web.service.invoker.createClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.ArnsClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
-import uk.gov.justice.digital.hmpps.communitypaybackapi.listener.DomainEventListener
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.ProbationAccessControlClient
 import uk.gov.justice.hmpps.kotlin.auth.authorisedWebClient
 import uk.gov.justice.hmpps.kotlin.auth.healthWebClient
 import java.time.Duration
@@ -28,6 +29,9 @@ class WebClientConfiguration(
 
   @param:Value("\${client.arns.url}") val arnsUrl: String,
   @param:Value("\${client.arns.timeout:5s}") val arnsTimeout: Duration,
+
+  @param:Value("\${client.probation-access-control.url}") val probationAccessControlUrl: String,
+  @param:Value("\${client.probation-access-control.timeout:5s}") val probationAccessControlTimeout: Duration,
 ) {
 
   companion object {
@@ -55,7 +59,7 @@ class WebClientConfiguration(
   fun communityPaybackAndDeliusClient(communityPaybackAndDeliusWebClient: WebClient): CommunityPaybackAndDeliusClient = HttpServiceProxyFactory
     .builderFor(WebClientAdapter.create(communityPaybackAndDeliusWebClient))
     .build()
-    .createClient(CommunityPaybackAndDeliusClient::class.java)
+    .createClient<CommunityPaybackAndDeliusClient>()
 
   @Bean
   fun arnsWebClient(
@@ -74,5 +78,24 @@ class WebClientConfiguration(
   fun arnsClient(arnsWebClient: WebClient): ArnsClient = HttpServiceProxyFactory
     .builderFor(WebClientAdapter.create(arnsWebClient))
     .build()
-    .createClient(ArnsClient::class.java)
+    .createClient<ArnsClient>()
+
+  @Bean
+  fun probationAccessControlWebClient(
+    authorizedClientManager: OAuth2AuthorizedClientManager,
+    builder: WebClient.Builder,
+  ): WebClient = builder
+    .authorisedWebClient(
+      authorizedClientManager = authorizedClientManager,
+      registrationId = API_CLIENT_ID,
+      url = probationAccessControlUrl,
+      timeout = probationAccessControlTimeout,
+    )
+
+  @Bean
+  @DependsOn("probationAccessControlWebClient")
+  fun probationAccessControlClient(probationAccessControlWebClient: WebClient): ProbationAccessControlClient = HttpServiceProxyFactory
+    .builderFor(WebClientAdapter.create(probationAccessControlWebClient))
+    .build()
+    .createClient<ProbationAccessControlClient>()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/AppointmentTaskSummaryDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/AppointmentTaskSummaryDto.kt
@@ -15,4 +15,6 @@ data class AppointmentTaskSummaryDto(
   val date: LocalDate? = null,
   @param:Schema(description = "The name of the project attended in this appointment.")
   val projectTypeName: String? = null,
-)
+) {
+  companion object
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/AppointmentTaskSummaryDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/AppointmentTaskSummaryDto.kt
@@ -1,11 +1,18 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
 import java.util.UUID
 
 data class AppointmentTaskSummaryDto(
   @param:Schema(description = "The unique identifier for the appointment task", example = "550e8400-e29b-41d4-a716-446655440000")
   val taskId: UUID,
-  @param:Schema(description = "Summary details of the appointment associated with this task")
+  @param:Schema(description = "Deprecated: use top-level properties of this response instead.\n\nSummary details of the appointment associated with this task", deprecated = true)
   val appointment: AppointmentSummaryDto,
+  @param:Schema(description = "")
+  val offender: OffenderDto,
+  @param:Schema(description = "The date of the appointment.")
+  val date: LocalDate? = null,
+  @param:Schema(description = "The name of the project attended in this appointment.")
+  val projectTypeName: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/OffenderDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/OffenderDto.kt
@@ -48,10 +48,10 @@ sealed interface OffenderDto {
 
   data class OffenderFullDto(
     override val crn: String,
-    val forename: String,
-    val surname: String,
-    val middleNames: List<String>,
-    val dateOfBirth: LocalDate,
+    val forename: String?,
+    val surname: String?,
+    val middleNames: List<String>?,
+    val dateOfBirth: LocalDate?,
   ) : OffenderDto {
     override val objectType = OffenderType.FULL
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/AppointmentEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/AppointmentEntity.kt
@@ -50,7 +50,7 @@ data class AppointmentEntity(
   // and therefore have no values available.
   var firstName: String? = null,
   var lastName: String? = null,
-  @ManyToOne(fetch = FetchType.LAZY)
+  @ManyToOne(fetch = FetchType.EAGER)
   var projectType: ProjectTypeEntity? = null,
 ) {
   @Suppress("USELESS_IS_CHECK")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentTaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentTaskService.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeGroup
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentUpdatedEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.AppointmentTaskMappers
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -32,6 +33,8 @@ class AppointmentTaskService(
   private val appointmentTaskEntityRepository: AppointmentTaskEntityRepository,
   private val appointmentRetrievalService: AppointmentRetrievalService,
   private val contextService: ContextService,
+  private val caseVisibilityService: CaseVisibilityService,
+  private val appointmentTaskMappers: AppointmentTaskMappers,
 ) {
 
   @EventListener
@@ -131,9 +134,16 @@ class AppointmentTaskService(
       deliusAppointmentIds = deliusAppointmentIds.sorted(),
       pageable = PageRequest.of(0, deliusAppointmentIds.size, Sort.by(Sort.Direction.DESC, "name")),
     )
+
+    val caseVisibility = caseVisibilityService.isLimitedForCurrentUser(orderedTasks.map { it.appointment.crn })
+
     return PageImpl(
       pagedTasks.content.map { task ->
-        AppointmentTaskSummaryDto(taskId = task.id, appointment = appointments.content.first { it.id == task.appointment.deliusId })
+        appointmentTaskMappers.toDto(
+          task = task,
+          isLimited = caseVisibility[task.appointment.crn] ?: false,
+          appointment = appointments.content.first { it.id == task.appointment.deliusId },
+        )
       },
       pageable,
       pagedTasks.totalElements,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/CaseVisibilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/CaseVisibilityService.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.ProbationAccessControlClient
+
+@Service
+class CaseVisibilityService(
+  private val contextService: ContextService,
+  private val probationAccessControlClient: ProbationAccessControlClient,
+) {
+  fun isLimitedForCurrentUser(crns: List<String>): Map<String, Boolean> {
+    if (crns.isEmpty()) return emptyMap()
+
+    val caseAccess = probationAccessControlClient.getAccessControlForCrns(contextService.getUserName(), crns)
+    return crns.associateWith { crn ->
+      val case = caseAccess.access.firstOrNull { it.crn == crn }
+
+      case != null && (case.userRestricted || case.userExcluded)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentTaskMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentTaskMappers.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentTaskSummaryDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskEntity
+
+@Service
+class AppointmentTaskMappers {
+  fun toDto(
+    task: AppointmentTaskEntity,
+    isLimited: Boolean,
+    appointment: AppointmentSummaryDto,
+  ) = AppointmentTaskSummaryDto(
+    taskId = task.id,
+    offender = if (isLimited) {
+      OffenderDto.OffenderLimitedDto(task.appointment.crn)
+    } else {
+      OffenderDto.OffenderFullDto(
+        task.appointment.crn,
+        task.appointment.firstName,
+        task.appointment.lastName,
+        null,
+        null,
+      )
+    },
+    date = task.appointment.date,
+    projectTypeName = task.appointment.projectType?.name,
+    appointment = appointment,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDCaseAccessFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDCaseAccessFactory.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client
+
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseAccess
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseAccessItem
+
+fun NDCaseAccess.Companion.valid(vararg items: NDCaseAccessItem) = NDCaseAccess(items.toList())
+
+fun NDCaseAccessItem.Companion.unrestricted(crn: String) = NDCaseAccessItem(
+  crn = crn,
+  userExcluded = false,
+  userRestricted = false,
+  exclusionMessage = null,
+  restrictionMessage = null,
+)
+
+fun NDCaseAccessItem.Companion.excluded(crn: String) = NDCaseAccessItem(
+  crn = crn,
+  userExcluded = true,
+  userRestricted = false,
+  exclusionMessage = "Test exclusion",
+  restrictionMessage = null,
+)
+
+fun NDCaseAccessItem.Companion.restricted(crn: String) = NDCaseAccessItem(
+  crn = crn,
+  userExcluded = false,
+  userRestricted = true,
+  exclusionMessage = null,
+  restrictionMessage = "Test restriction",
+)
+
+fun NDCaseAccessItem.Companion.excludedAndRestricted(crn: String) = NDCaseAccessItem(
+  crn = crn,
+  userExcluded = true,
+  userRestricted = true,
+  exclusionMessage = "Test exclusion",
+  restrictionMessage = "Test restriction",
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/AppointmentTaskSummaryDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/AppointmentTaskSummaryDtoFactory.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto
+
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentTaskSummaryDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
+import java.time.LocalDate
+import java.util.UUID
+
+fun AppointmentTaskSummaryDto.Companion.valid() = AppointmentTaskSummaryDto(
+  taskId = UUID.randomUUID(),
+  appointment = AppointmentSummaryDto.valid(),
+  offender = OffenderDto.validFull().copy(middleNames = null, dateOfBirth = null),
+  date = LocalDate.now(),
+  projectTypeName = String.random(50),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentTaskIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentTaskIT.kt
@@ -1,37 +1,64 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.getBean
+import org.springframework.context.ApplicationContext
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointmentSummary
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseAccessItem
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentTaskSummaryDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskStatus
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskType
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.excluded
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.excludedAndRestricted
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.restricted
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.unrestricted
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.persist
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.validPending
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.util.bodyAsObject
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.wiremock.CommunityPaybackAndDeliusMockServer
+import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.wiremock.ProbationAccessControlMockServer
 import java.time.LocalDate
 import java.util.UUID
 
 class AdminAppointmentTaskIT : IntegrationTestBase() {
+
+  private lateinit var fixtureFactory: FixtureFactory
 
   @Autowired
   lateinit var appointmentTaskEntityRepository: AppointmentTaskEntityRepository
 
   @Autowired
   lateinit var appointmentEntityRepository: AppointmentEntityRepository
+
+  @BeforeEach
+  fun setup() {
+    ProbationAccessControlMockServer.setupGetAccessControlForCrnsDefault()
+    fixtureFactory = FixtureFactory(ctx)
+  }
+
+  @AfterEach
+  fun cleanup() {
+    fixtureFactory.cleanup()
+  }
 
   @Nested
   @DisplayName("GET /admin/appointment-tasks/pending")
@@ -82,10 +109,14 @@ class AdminAppointmentTaskIT : IntegrationTestBase() {
 
     @Test
     fun `should return pending appointment tasks with default pagination`() {
+      val projectType = fixtureFactory.projectType()
       val appointment = AppointmentEntity.valid().copy(
         deliusId = 101L,
         providerCode = "PROVIDER1",
         date = LocalDate.now(),
+        firstName = "thefirstname",
+        lastName = "thelastname",
+        projectType = projectType,
       ).persist(ctx)
       saveTask(appointment)
 
@@ -108,6 +139,13 @@ class AdminAppointmentTaskIT : IntegrationTestBase() {
       assertThat(pageResponse.content).hasSize(1)
       assertThat(pageResponse.content[0].appointment.id).isEqualTo(101L)
       assertThat(pageResponse.page.size).isEqualTo(50)
+      assertThat(pageResponse.content[0].offender).isInstanceOf(OffenderDto.OffenderFullDto::class.java)
+      val offender = pageResponse.content[0].offender as OffenderDto.OffenderFullDto
+      assertThat(offender.crn).isEqualTo(appointment.crn)
+      assertThat(offender.forename).isEqualTo("thefirstname")
+      assertThat(offender.surname).isEqualTo("thelastname")
+      assertThat(pageResponse.content[0].date).isEqualTo(appointment.date)
+      assertThat(pageResponse.content[0].projectTypeName).isEqualTo(appointment.projectType!!.name)
     }
 
     @Test
@@ -296,6 +334,107 @@ class AdminAppointmentTaskIT : IntegrationTestBase() {
       assertThat(pageResponse.content[0].appointment.date).isEqualTo(matchingAppointment.date)
     }
 
+    @Test
+    fun `should censor names of people who have exclusions or restrictions for the current user`() {
+      val appointment = AppointmentEntity.valid().copy(
+        deliusId = 101L,
+        providerCode = "PROVIDER1",
+        date = LocalDate.now(),
+        firstName = "A${String.random(8)}",
+        lastName = "A${String.random(8)}",
+      ).persist(ctx)
+      saveTask(appointment)
+
+      val appointment2 = AppointmentEntity.valid().copy(
+        deliusId = 102L,
+        providerCode = "PROVIDER1",
+        date = LocalDate.now(),
+        firstName = "B${String.random(8)}",
+        lastName = "B${String.random(8)}",
+      ).persist(ctx)
+      saveTask(appointment2)
+
+      val appointment3 = AppointmentEntity.valid().copy(
+        deliusId = 103L,
+        providerCode = "PROVIDER1",
+        date = LocalDate.now(),
+        firstName = "C${String.random(8)}",
+        lastName = "C${String.random(8)}",
+      ).persist(ctx)
+      saveTask(appointment3)
+
+      val appointment4 = AppointmentEntity.valid().copy(
+        deliusId = 104L,
+        providerCode = "PROVIDER1",
+        date = LocalDate.now(),
+        firstName = "D${String.random(8)}",
+        lastName = "D${String.random(8)}",
+      ).persist(ctx)
+      saveTask(appointment4)
+
+      val appointment5 = AppointmentEntity.valid().copy(
+        deliusId = 105L,
+        providerCode = "PROVIDER1",
+        date = LocalDate.now(),
+        firstName = "E${String.random(8)}",
+        lastName = "E${String.random(8)}",
+      ).persist(ctx)
+      saveTask(appointment5)
+
+      CommunityPaybackAndDeliusMockServer.setupGetAppointmentsResponse(
+        username = "theusername",
+        appointments = listOf(
+          NDAppointmentSummary.forAppointment(appointment),
+          NDAppointmentSummary.forAppointment(appointment2),
+          NDAppointmentSummary.forAppointment(appointment3),
+          NDAppointmentSummary.forAppointment(appointment4),
+          NDAppointmentSummary.forAppointment(appointment5),
+        ),
+        appointmentIds = listOf(101L, 102L, 103L, 104L, 105L),
+        sortString = "name,desc",
+        pageSize = 5,
+      )
+
+      ProbationAccessControlMockServer.setupGetAccessControlForCrnsResponse(
+        "theusername",
+        NDCaseAccessItem.excluded(appointment.crn),
+        NDCaseAccessItem.restricted(appointment2.crn),
+        NDCaseAccessItem.excludedAndRestricted(appointment3.crn),
+        NDCaseAccessItem.unrestricted(appointment4.crn),
+        NDCaseAccessItem.unrestricted(appointment5.crn),
+      )
+
+      val pageResponse = webTestClient.get()
+        .uri("/admin/appointment-tasks/pending?sort=appointment.firstName,asc")
+        .addAdminUiAuthHeader("theusername")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<PageResponse<AppointmentTaskSummaryDto>>()
+
+      assertThat(pageResponse.content).hasSize(5)
+      // Restricted or excluded, or both
+      assertThat(pageResponse.content[0].appointment.id).isEqualTo(101L)
+      assertThat(pageResponse.content[0].offender).isInstanceOf(OffenderDto.OffenderLimitedDto::class.java)
+      assertThat(pageResponse.content[1].appointment.id).isEqualTo(102L)
+      assertThat(pageResponse.content[1].offender).isInstanceOf(OffenderDto.OffenderLimitedDto::class.java)
+      assertThat(pageResponse.content[2].appointment.id).isEqualTo(103L)
+      assertThat(pageResponse.content[2].offender).isInstanceOf(OffenderDto.OffenderLimitedDto::class.java)
+      // Unrestricted
+      assertThat(pageResponse.content[3].appointment.id).isEqualTo(104L)
+      assertThat(pageResponse.content[3].offender).isInstanceOf(OffenderDto.OffenderFullDto::class.java)
+      var offender = pageResponse.content[3].offender as OffenderDto.OffenderFullDto
+      assertThat(offender.crn).isEqualTo(appointment4.crn)
+      assertThat(offender.forename).isNotNull
+      assertThat(offender.surname).isNotNull
+      assertThat(pageResponse.content[4].appointment.id).isEqualTo(105L)
+      assertThat(pageResponse.content[4].offender).isInstanceOf(OffenderDto.OffenderFullDto::class.java)
+      offender = pageResponse.content[4].offender as OffenderDto.OffenderFullDto
+      assertThat(offender.crn).isEqualTo(appointment5.crn)
+      assertThat(offender.forename).isNotNull
+      assertThat(offender.surname).isNotNull
+    }
+
     private fun saveTask(appointment: AppointmentEntity): AppointmentTaskEntity = appointmentTaskEntityRepository.save(
       AppointmentTaskEntity(
         id = UUID.randomUUID(),
@@ -370,5 +509,21 @@ class AdminAppointmentTaskIT : IntegrationTestBase() {
 
       assertThat(appointmentTaskEntityRepository.findByIdOrNull(task.id)!!.taskStatus).isEqualTo(AppointmentTaskStatus.COMPLETE)
     }
+  }
+}
+
+class FixtureFactory(ctx: ApplicationContext) {
+  private val appointmentTaskEntityRepository = ctx.getBean<AppointmentTaskEntityRepository>()
+  private val appointmentEntityRepository = ctx.getBean<AppointmentEntityRepository>()
+  private val projectTypeEntityRepository = ctx.getBean<ProjectTypeEntityRepository>()
+
+  private val projectTypes = mutableListOf<ProjectTypeEntity>()
+
+  fun projectType(): ProjectTypeEntity = projectTypeEntityRepository.save(ProjectTypeEntity.valid()).also { projectTypes += it }
+
+  fun cleanup() {
+    appointmentTaskEntityRepository.deleteAll()
+    appointmentEntityRepository.deleteAll()
+    projectTypeEntityRepository.deleteAll(projectTypes)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/ProbationAccessControlMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/ProbationAccessControlMockServer.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.integration.wiremock
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlMatching
+import tools.jackson.databind.json.JsonMapper
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseAccess
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseAccessItem
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
+
+object ProbationAccessControlMockServer {
+
+  val jsonMapper = JsonMapper()
+
+  fun setupGetAccessControlForCrnsDefault() {
+    stubFor(
+      post(urlMatching("/probation-access-control/user/.*/access"))
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(jsonMapper.writeValueAsString(NDCaseAccess.valid())),
+        ),
+    )
+  }
+
+  fun setupGetAccessControlForCrnsResponse(username: String, vararg response: NDCaseAccessItem) {
+    stubFor(
+      post("/probation-access-control/user/$username/access")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(jsonMapper.writeValueAsString(NDCaseAccess.valid(*response))),
+        ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentTaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentTaskServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service
 
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.slot
@@ -9,6 +10,7 @@ import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -19,6 +21,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentTaskSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
@@ -39,10 +42,12 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentEventT
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentRetrievalService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentTaskService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService.ValidatedAppointment
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.CaseVisibilityService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ContextService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentUpdatedEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.AppointmentTaskMappers
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
@@ -60,11 +65,27 @@ class AppointmentTaskServiceTest {
   @RelaxedMockK
   private lateinit var contextService: ContextService
 
+  @RelaxedMockK
+  private lateinit var caseVisibilityService: CaseVisibilityService
+
+  @MockK
+  private lateinit var appointmentTaskMappers: AppointmentTaskMappers
+
   @InjectMockKs
   private lateinit var service: AppointmentTaskService
 
   private companion object {
     const val PROVIDER_CODE = "PROV123"
+  }
+
+  @BeforeEach
+  fun setup() {
+    every { appointmentTaskMappers.toDto(any(), any(), any()) } answers {
+      AppointmentTaskSummaryDto.valid().copy(
+        taskId = (args[0] as AppointmentTaskEntity).id,
+        appointment = args[2] as AppointmentSummaryDto,
+      )
+    }
   }
 
   @Nested
@@ -330,6 +351,8 @@ class AppointmentTaskServiceTest {
       assertThat(result.content[0].taskId).isEqualTo(taskId)
       assertThat(result.content[0].appointment).isEqualTo(appointmentSummary)
       assertThat(result.totalElements).isEqualTo(1L)
+
+      verify { appointmentTaskMappers.toDto(taskEntity, false, appointmentSummary) }
     }
 
     @Test
@@ -394,6 +417,8 @@ class AppointmentTaskServiceTest {
       assertThat(result.content[0].taskId).isEqualTo(taskId)
       assertThat(result.content[0].appointment).isEqualTo(appointmentSummary)
       assertThat(result.totalElements).isEqualTo(1L)
+
+      verify { appointmentTaskMappers.toDto(taskEntity, false, appointmentSummary) }
     }
 
     @Test
@@ -498,6 +523,9 @@ class AppointmentTaskServiceTest {
       assertThat(result.content[1].taskId).isEqualTo(task2Id)
       assertThat(result.content[1].appointment).isEqualTo(appointmentSummary2)
       assertThat(result.totalElements).isEqualTo(2L)
+
+      verify { appointmentTaskMappers.toDto(taskEntity1, false, appointmentSummary1) }
+      verify { appointmentTaskMappers.toDto(taskEntity2, false, appointmentSummary2) }
     }
 
     @Test
@@ -553,6 +581,72 @@ class AppointmentTaskServiceTest {
 
       assertThat(result.content).hasSize(1)
       assertThat(result.content[0].taskId).isEqualTo(taskId)
+
+      verify { appointmentTaskMappers.toDto(taskEntity, false, appointmentSummary) }
+    }
+
+    @Test
+    fun `uses case visibility to determine whether task mapping should be limited access`() {
+      val pageable = PageRequest.of(0, 10)
+      val taskId = UUID.randomUUID()
+      val appointmentId = UUID.randomUUID()
+      val deliusAppointmentId = 101L
+
+      val appointmentEntity = AppointmentEntity.valid().copy(
+        id = appointmentId,
+        deliusId = deliusAppointmentId,
+        providerCode = PROVIDER_CODE,
+        date = LocalDate.of(2026, 3, 27),
+      )
+
+      val taskEntity = AppointmentTaskEntity(
+        id = taskId,
+        appointment = appointmentEntity,
+        taskType = AppointmentTaskType.ADJUSTMENT_TRAVEL_TIME,
+        createdAt = OffsetDateTime.now(),
+        taskStatus = AppointmentTaskStatus.PENDING,
+      )
+
+      val appointmentSummary = AppointmentSummaryDto.valid().copy(id = deliusAppointmentId)
+
+      every {
+        appointmentTaskEntityRepository.findPendingTasksWithFiltersAndAppointments(
+          fromDate = null,
+          toDate = null,
+          providerCode = null,
+          pageable = pageable,
+        )
+      } returns PageImpl(listOf(taskEntity), pageable, 1L)
+
+      every {
+        appointmentRetrievalService.getAppointments(
+          crn = null,
+          fromDate = null,
+          toDate = null,
+          outcomeCodes = null,
+          projectCodes = null,
+          projectTypeGroup = null,
+          eventNumber = null,
+          deliusAppointmentIds = listOf(deliusAppointmentId),
+          pageable = PageRequest.of(0, 1, Sort.by(Sort.Direction.DESC, "name")),
+        )
+      } returns PageImpl(listOf(appointmentSummary), PageRequest.of(0, 1), 1L)
+
+      every { caseVisibilityService.isLimitedForCurrentUser(any()) } answers {
+        @Suppress("unchecked_cast")
+        val crns = args[0] as List<String>
+
+        crns.associateWith { true }
+      }
+
+      val result = service.getPendingAppointmentTasks(pageable = pageable)
+
+      assertThat(result.content).hasSize(1)
+      assertThat(result.content[0].taskId).isEqualTo(taskId)
+      assertThat(result.content[0].appointment).isEqualTo(appointmentSummary)
+      assertThat(result.totalElements).isEqualTo(1L)
+
+      verify { appointmentTaskMappers.toDto(taskEntity, true, appointmentSummary) }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/CaseVisibilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/CaseVisibilityServiceTest.kt
@@ -1,0 +1,127 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseAccess
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseAccessItem
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.ProbationAccessControlClient
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.excluded
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.excludedAndRestricted
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.restricted
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.unrestricted
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.CaseVisibilityService
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ContextService
+
+@ExtendWith(MockKExtension::class)
+class CaseVisibilityServiceTest {
+
+  @MockK
+  lateinit var contextService: ContextService
+
+  @MockK
+  lateinit var probationAccessControlClient: ProbationAccessControlClient
+
+  @InjectMockKs
+  lateinit var caseVisibilityService: CaseVisibilityService
+
+  @BeforeEach
+  fun beforeEach() {
+    every { contextService.getUserName() } answers { String.random(8) }
+  }
+
+  @Nested
+  inner class IsLimitedForCurrentUser {
+    @Test
+    fun `returns empty map for an empty list of CRNs`() {
+      val result = caseVisibilityService.isLimitedForCurrentUser(emptyList())
+
+      assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `CRN defaults to not limited if not provided in Probation Access Control API response`() {
+      val crns = listOf(
+        "X123456",
+        "Y234567",
+        "Z345678",
+        "W456789",
+      )
+      every { probationAccessControlClient.getAccessControlForCrns(any(), crns) } returns NDCaseAccess.valid(
+        NDCaseAccessItem.unrestricted("X123456"),
+        NDCaseAccessItem.unrestricted("Y234567"),
+        NDCaseAccessItem.unrestricted("Z345678"),
+      )
+
+      val result = caseVisibilityService.isLimitedForCurrentUser(crns)
+
+      assertThat(result).hasSize(4)
+      assertThat(result).containsOnlyKeys(crns)
+      assertThat(result["W456789"]).isEqualTo(false)
+    }
+
+    @Test
+    fun `CRN is limited to user if excluded`() {
+      val crns = listOf("X123456")
+      every { probationAccessControlClient.getAccessControlForCrns(any(), crns) } returns NDCaseAccess.valid(
+        NDCaseAccessItem.excluded("X123456"),
+      )
+
+      val result = caseVisibilityService.isLimitedForCurrentUser(crns)
+
+      assertThat(result).hasSize(1)
+      assertThat(result).containsOnlyKeys(crns)
+      assertThat(result["X123456"]).isEqualTo(true)
+    }
+
+    @Test
+    fun `CRN is limited to user if restricted`() {
+      val crns = listOf("Y234567")
+      every { probationAccessControlClient.getAccessControlForCrns(any(), crns) } returns NDCaseAccess.valid(
+        NDCaseAccessItem.restricted("Y234567"),
+      )
+
+      val result = caseVisibilityService.isLimitedForCurrentUser(crns)
+
+      assertThat(result).hasSize(1)
+      assertThat(result).containsOnlyKeys(crns)
+      assertThat(result["Y234567"]).isEqualTo(true)
+    }
+
+    @Test
+    fun `CRN is limited to user if excluded and restricted`() {
+      val crns = listOf("Z345678")
+      every { probationAccessControlClient.getAccessControlForCrns(any(), crns) } returns NDCaseAccess.valid(
+        NDCaseAccessItem.excludedAndRestricted("Z345678"),
+      )
+
+      val result = caseVisibilityService.isLimitedForCurrentUser(crns)
+
+      assertThat(result).hasSize(1)
+      assertThat(result).containsOnlyKeys(crns)
+      assertThat(result["Z345678"]).isEqualTo(true)
+    }
+
+    @Test
+    fun `CRN is not limited to user when unrestricted`() {
+      val crns = listOf("W456789")
+      every { probationAccessControlClient.getAccessControlForCrns(any(), crns) } returns NDCaseAccess.valid(
+        NDCaseAccessItem.unrestricted("W456789"),
+      )
+
+      val result = caseVisibilityService.isLimitedForCurrentUser(crns)
+
+      assertThat(result).hasSize(1)
+      assertThat(result).containsOnlyKeys(crns)
+      assertThat(result["W456789"]).isEqualTo(false)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentTaskMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentTaskMappersTest.kt
@@ -1,0 +1,102 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.mappers
+
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.valid
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.validPending
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.AppointmentTaskMappers
+
+@ExtendWith(MockKExtension::class)
+class AppointmentTaskMappersTest {
+
+  @InjectMockKs
+  lateinit var appointmentTaskMappers: AppointmentTaskMappers
+
+  @Nested
+  inner class AppointmentTaskEntityToDTO {
+    @Test
+    fun `should map task with full appointment when isLimited is false`() {
+      val projectType = ProjectTypeEntity.valid()
+      val appointment = AppointmentEntity.valid().copy(firstName = String.random(8), lastName = String.random(8), projectType = projectType)
+      val task = AppointmentTaskEntity.validPending().copy(appointment = appointment)
+      val appointmentSummaryDto = AppointmentSummaryDto.valid().copy(id = appointment.deliusId)
+
+      val result = appointmentTaskMappers.toDto(task = task, isLimited = false, appointment = appointmentSummaryDto)
+
+      assertThat(result.taskId).isEqualTo(task.id)
+      assertThat(result.appointment).isEqualTo(appointmentSummaryDto)
+      assertThat(result.offender).isNotNull
+      assertThat(result.offender).isInstanceOf(OffenderDto.OffenderFullDto::class.java)
+      val offender = result.offender as OffenderDto.OffenderFullDto
+      assertThat(offender.crn).isEqualTo(appointment.crn)
+      assertThat(offender.forename).isEqualTo(appointment.firstName)
+      assertThat(offender.surname).isEqualTo(appointment.lastName)
+      assertThat(result.date).isEqualTo(appointment.date)
+      assertThat(result.projectTypeName).isEqualTo(projectType.name)
+    }
+
+    @Test
+    fun `should map task with partial appointment when isLimited is false`() {
+      val task = AppointmentTaskEntity.validPending()
+      val appointmentSummaryDto = AppointmentSummaryDto.valid()
+
+      val result = appointmentTaskMappers.toDto(task = task, isLimited = false, appointment = appointmentSummaryDto)
+
+      assertThat(result.taskId).isEqualTo(task.id)
+      assertThat(result.appointment).isEqualTo(appointmentSummaryDto)
+      assertThat(result.offender).isNotNull
+      assertThat(result.offender).isInstanceOf(OffenderDto.OffenderFullDto::class.java)
+      val offender = result.offender as OffenderDto.OffenderFullDto
+      assertThat(offender.crn).isEqualTo(task.appointment.crn)
+      assertThat(offender.forename).isNull()
+      assertThat(offender.surname).isNull()
+      assertThat(result.date).isEqualTo(task.appointment.date)
+      assertThat(result.projectTypeName).isNull()
+    }
+
+    @Test
+    fun `should map task with full appointment when isLimited is true`() {
+      val projectType = ProjectTypeEntity.valid()
+      val appointment = AppointmentEntity.valid().copy(firstName = String.random(8), lastName = String.random(8), projectType = projectType)
+      val task = AppointmentTaskEntity.validPending().copy(appointment = appointment)
+      val appointmentSummaryDto = AppointmentSummaryDto.valid().copy(id = appointment.deliusId)
+
+      val result = appointmentTaskMappers.toDto(task = task, isLimited = true, appointment = appointmentSummaryDto)
+
+      assertThat(result.taskId).isEqualTo(task.id)
+      assertThat(result.appointment).isEqualTo(appointmentSummaryDto)
+      assertThat(result.offender).isInstanceOf(OffenderDto.OffenderLimitedDto::class.java)
+      val offender = result.offender as OffenderDto.OffenderLimitedDto
+      assertThat(offender.crn).isEqualTo(appointment.crn)
+      assertThat(result.date).isEqualTo(appointment.date)
+      assertThat(result.projectTypeName).isEqualTo(projectType.name)
+    }
+
+    @Test
+    fun `should map task with partial appointment when isLimited is true`() {
+      val task = AppointmentTaskEntity.validPending()
+      val appointmentSummaryDto = AppointmentSummaryDto.valid()
+
+      val result = appointmentTaskMappers.toDto(task = task, isLimited = true, appointment = appointmentSummaryDto)
+
+      assertThat(result.taskId).isEqualTo(task.id)
+      assertThat(result.appointment).isEqualTo(appointmentSummaryDto)
+      assertThat(result.offender).isInstanceOf(OffenderDto.OffenderLimitedDto::class.java)
+      val offender = result.offender as OffenderDto.OffenderLimitedDto
+      assertThat(offender.crn).isEqualTo(task.appointment.crn)
+      assertThat(result.date).isEqualTo(task.appointment.date)
+      assertThat(result.projectTypeName).isNull()
+    }
+  }
+}

--- a/src/test/resources/application-integrationtest.yml
+++ b/src/test/resources/application-integrationtest.yml
@@ -94,3 +94,5 @@ client:
     url: http://localhost:${wiremock.server.port}/arns
   community-payback-and-delius:
     url: http://localhost:${wiremock.server.port}/community-payback-and-delius
+  probation-access-control:
+    url: http://localhost:${wiremock.server.port}/probation-access-control

--- a/tools/cp-stack/.env.api.template
+++ b/tools/cp-stack/.env.api.template
@@ -32,6 +32,7 @@ SPRINGDOC_SWAGGER_UI_ENABLED=true
 COMMUNITY_PAYBACK_REQUEST_LOGGING_ENABLED=true
 
 CLIENT_ARNS_URL=https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk
+CLIENT_PROBATION_ACCESS_CONTROL_URL=https://probation-access-control-dev.hmpps.service.justice.gov.uk
 # this is overridden in docker-compose when using the docker image
 CLIENT_COMMUNITY_PAYBACK_AND_DELIUS_URL=http://localhost:9004
 


### PR DESCRIPTION
This PR updates the `GET /admin/appointment-tasks/pending` endpoint so that:
- Personal and project type information is sourced from the Community Payback database
- Personal data is censored for CRNs for which the current user does not have the correct permissions to view

To include the information from the database while maintaining backwards compatibility, the shape of the response from this endpoint has changed:
```jsonc
{
  "content": [
    {
      "taskId": "550e8400-e29b-41d4-a716-446655440000", // Existing, unchanged
      "appointment": { // Existing, unchanged
        // ...
      },
      "offender": { // New
        "crn": "string",
        "forename": "string",
        "surname": "string",
        "objectType": "Full"
      },
      "date": "2026-05-01", // New
      "projectTypeName": "string" // New
    }
  ],
  "page": { // Existing, unchanged
    "size": 0,
    "number": 0,
    "totalElements": 0,
    "totalPages": 0
  }
}
```

The current behaviour of using the PI team's API to retrieve appointment details used in the `appointment` property is preserved, although this field is now deprecated. The new properties source their data from the Community Payback database and should be used instead. Once the UI has been updated to use these new properties, the `appointment` property is intended to be removed entirely.

A consumer of the API may encounter situations where either `firstName` or `lastName` (or both) are null. This may be either because the person's details are not accessible to the current user, or that they were not available at the time the appointment was last updated. In the first case, the `isLimited` property will be `true`, so this can be used to distinguish between censored and unavailable data.