### PR TITLE
CPB-933: Fix 500 response when an appointment has an unknown outcome code

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/ContactOutcomeEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/ContactOutcomeEntity.kt
@@ -60,6 +60,17 @@ data class ContactOutcomeEntity(
 
   companion object {
     const val CODE_ATTENDED_COMPLIED = "ATTC"
+
+    fun unknown(code: String): ContactOutcomeEntity = ContactOutcomeEntity(
+      id = UUID(0L, 0L),
+      code = code,
+      name = "Unknown ($code)",
+      enforceable = false,
+      attended = false,
+      groups = emptyList(),
+      createdAt = OffsetDateTime.now(),
+      updatedAt = OffsetDateTime.now(),
+    )
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers
 
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointmentBehaviour
@@ -27,6 +28,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.domainevent.Appointm
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.Behaviour
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EnforcementActionEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntity
@@ -40,12 +42,20 @@ class AppointmentMappers(
   private val enforcementActionEntityRepository: EnforcementActionEntityRepository,
 ) {
 
+  private val logger = LoggerFactory.getLogger(javaClass)
+
   fun toDto(
     appointment: NDAppointment,
     projectType: ProjectTypeEntity,
   ): AppointmentDto {
     val contactOutcomeEntity = appointment.outcome?.code?.let {
-      contactOutcomeEntityRepository.findByCode(it) ?: error("Can't find outcome for code $it")
+      val result = contactOutcomeEntityRepository.findByCode(it)
+
+      if (result == null) {
+        logger.warn("Can't find outcome for code $it")
+      }
+
+      result ?: ContactOutcomeEntity.unknown(it)
     }
 
     return AppointmentDto(
@@ -98,8 +108,14 @@ class AppointmentMappers(
   ) = AppointmentSummaryDto(
     id = appointmentSummary.id,
     contactOutcome = appointmentSummary.outcome?.code?.let {
-      contactOutcomeEntityRepository.findByCode(it)?.toDto() ?: error("Can't find outcome for code $it")
-    },
+      val result = contactOutcomeEntityRepository.findByCode(it)
+
+      if (result == null) {
+        logger.warn("Can't find outcome for code $it")
+      }
+
+      result ?: ContactOutcomeEntity.unknown(it)
+    }?.toDto(),
     requirementMinutes = appointmentSummary.requirementProgress.requiredMinutes,
     adjustmentMinutes = appointmentSummary.requirementProgress.adjustments,
     completedMinutes = appointmentSummary.requirementProgress.completedMinutes,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
@@ -635,6 +635,22 @@ class AppointmentMappersTest {
 
       assertThat(result.attendanceData).isNull()
     }
+
+    @Test
+    fun `should gracefully handle unknown outcome codes`() {
+      val projectAppointment = NDAppointment.valid().copy(
+        outcome = NDContactOutcome.valid().copy(code = "UNKNOWN"),
+        enforcementAction = NDEnforcementAction.valid().copy(code = "ENFORCE1"),
+      )
+
+      every { contactOutcomeEntityRepository.findByCode("UNKNOWN") } returns null
+      every { enforcementActionEntityRepository.findByCode("ENFORCE1") } returns EnforcementActionEntity.valid()
+
+      val result = service.toDto(projectAppointment, ProjectTypeEntity.valid())
+
+      assertThat(result.contactOutcomeCode).isEqualTo("UNKNOWN")
+      assertThat(result.attendanceData).isNull()
+    }
   }
 
   @Nested
@@ -683,6 +699,21 @@ class AppointmentMappersTest {
       assertThat(result.projectTypeName).isEqualTo("PROJECTYPE1")
       assertThat(result.projectTypeCode).isEqualTo("PT1")
       assertThat(result.notes).isEqualTo("The notes")
+    }
+
+    @Test
+    fun `should gracefully handle unknown outcome codes`() {
+      val projectAppointment = NDAppointmentSummary.valid().copy(
+        outcome = NDContactOutcome.valid().copy(code = "UNKNOWN"),
+      )
+
+      every { contactOutcomeEntityRepository.findByCode("UNKNOWN") } returns null
+
+      val result = service.toSummaryDto(projectAppointment)
+
+      assertThat(result.contactOutcome).isNotNull
+      assertThat(result.contactOutcome!!.id).isEqualTo(UUID(0L, 0L))
+      assertThat(result.contactOutcome.code).isEqualTo("UNKNOWN")
     }
   }
 


### PR DESCRIPTION
This PR modifies the appointment mapping logic so that when a contact outcome with an unrecognised code is encountered, it is handled gracefully rather than throwing an exception.

This fixes at least two situations in the Community Payback service where appointments are listed and one of them has an unrecognised contact outcome code:
1. Viewing the bookings on a group session
2. Finding a pending travel time adjustment task

As a result of this change, the UI will now display an empty value for the contact outcome in this situation:
<img width="2978" height="2678" alt="image" src="https://github.com/user-attachments/assets/2f7e90f0-19a3-4925-b720-fc4344232bc9" />

