### PR TITLE
CPB-913: Prevent sensitive applications from being updated to not sensitive

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentValidationService.kt
@@ -68,6 +68,10 @@ class AppointmentValidationService(
     val project = projectService.getProject(existingAppointment.projectCode) ?: error("Can't retrieve project ${existingAppointment.projectCode}")
     val upwDetailsId = UnpaidWorkDetailsIdDto(existingAppointment.offender.crn, existingAppointment.deliusEventNumber)
 
+    if (existingAppointment.sensitive == true && update.sensitive != true) {
+      badRequest("This appointment has previously been marked as sensitive so this cannot be changed")
+    }
+
     val ctx = ValidationContext(
       command = update,
       project = project,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDAppointmentFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDAppointmentFactory.kt
@@ -69,6 +69,6 @@ fun NDAppointment.Companion.valid() = NDAppointment(
   workQuality = NDAppointmentWorkQuality.entries.toTypedArray().random(),
   behaviour = NDAppointmentBehaviour.entries.toTypedArray().random(),
   notes = String.random(),
-  sensitive = Boolean.random(),
+  sensitive = false,
   alertActive = Boolean.random(),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/UpdateAppointmentDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/UpdateAppointmentDtoFactory.kt
@@ -26,7 +26,7 @@ fun UpdateAppointmentDto.Companion.valid() = UpdateAppointmentDto(
   notes = String.random(400),
   attendanceData = AttendanceDataDto.valid(),
   alertActive = Boolean.random(),
-  sensitive = Boolean.random(),
+  sensitive = false,
 )
 
 fun UpdateAppointmentDto.Companion.valid(ctx: ApplicationContext) = UpdateAppointmentDto.valid().copy(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentValidationServiceTest.kt
@@ -1468,5 +1468,22 @@ class AppointmentValidationServiceTest {
         }
       }
     }
+
+    @Nested
+    inner class Sensitive {
+      @Test
+      fun `throws BadRequestException when existing appointment is sensitive but the update is not`() {
+        val existingAppointment = baselineExistingAppointment.copy(sensitive = true)
+        val update = baselineUpdate.copy(sensitive = false)
+
+        assertThatThrownBy {
+          service.validateUpdate(
+            existingAppointment = existingAppointment,
+            update = update,
+          )
+        }.isInstanceOf(BadRequestException::class.java)
+          .hasMessage("This appointment has previously been marked as sensitive so this cannot be changed")
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR changes the API to prevent updates to appointments from removing the 'sensitive' flag if it's set.

As there is no enforcement of this behaviour in Delius, this is done through the `AppointmentValidationService.validateUpdate` method.  If the `existingAppointment` is marked as sensitive, then the `update` is required to also have `sensitive` set to `true`, otherwise a 400 Bad Request response is returned.