### PR TITLE
CPB-943: Add logging for 4xx and 5xx responses from downstream APIs

### DIFF
--- a/helm_deploy/hmpps-community-payback-api/values.yaml
+++ b/helm_deploy/hmpps-community-payback-api/values.yaml
@@ -41,6 +41,8 @@ generic-service:
     CLIENT_COMMUNITY_PAYBACK_AND_DELIUS_URL: "http://localhost:8080/mocks/community-payback-and-delius"
     CLIENT_PROBATION_ACCESS_CONTROL_URL: "http://localhost:8080/mocks/probation-access-control"
 
+    CLIENT_LOG_DOWNSTREAM_ERROR_RESPONSES: false
+
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
   #   [name of kubernetes secret]:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -25,6 +25,8 @@ generic-service:
     CLIENT_COMMUNITY_PAYBACK_AND_DELIUS_URL: https://community-payback-and-delius-dev.hmpps.service.justice.gov.uk
     CLIENT_PROBATION_ACCESS_CONTROL_URL: https://probation-access-control-dev.hmpps.service.justice.gov.uk
 
+    CLIENT_LOG_DOWNSTREAM_ERROR_RESPONSES: true
+
     SPRINGDOC_API_DOCS_ENABLED: true
     SPRINGDOC_SWAGGER_UI_ENABLED: true
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/WebClientConfiguration.kt
@@ -1,11 +1,14 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.config
 
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.DependsOn
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
 import org.springframework.web.reactive.function.client.support.WebClientAdapter
 import org.springframework.web.service.invoker.HttpServiceProxyFactory
 import org.springframework.web.service.invoker.createClient
@@ -32,6 +35,8 @@ class WebClientConfiguration(
 
   @param:Value("\${client.probation-access-control.url}") val probationAccessControlUrl: String,
   @param:Value("\${client.probation-access-control.timeout:5s}") val probationAccessControlTimeout: Duration,
+
+  @param:Value("\${client.log-downstream-error-responses:false}") val logDownstreamErrorResponses: Boolean,
 ) {
 
   companion object {
@@ -53,6 +58,7 @@ class WebClientConfiguration(
       url = communityPaybackAndDeliusUrl,
       timeout = communityPaybackAndDeliusTimeout,
     )
+    .logErrorResponses<CommunityPaybackAndDeliusClient>(logDownstreamErrorResponses)
 
   @Bean
   @DependsOn("communityPaybackAndDeliusWebClient")
@@ -72,6 +78,7 @@ class WebClientConfiguration(
       url = arnsUrl,
       timeout = arnsTimeout,
     )
+    .logErrorResponses<ArnsClient>(logDownstreamErrorResponses)
 
   @Bean
   @DependsOn("arnsWebClient")
@@ -91,6 +98,7 @@ class WebClientConfiguration(
       url = probationAccessControlUrl,
       timeout = probationAccessControlTimeout,
     )
+    .logErrorResponses<ProbationAccessControlClient>(logDownstreamErrorResponses)
 
   @Bean
   @DependsOn("probationAccessControlWebClient")
@@ -98,4 +106,28 @@ class WebClientConfiguration(
     .builderFor(WebClientAdapter.create(probationAccessControlWebClient))
     .build()
     .createClient<ProbationAccessControlClient>()
+}
+
+inline fun <reified T> WebClient.logErrorResponses(enabled: Boolean): WebClient {
+  if (!enabled) {
+    return this
+  }
+
+  val logger = LoggerFactory.getLogger(T::class.java)
+
+  return this.mutate()
+    .filter(
+      ExchangeFilterFunction.ofResponseProcessor { response ->
+        response.bodyToMono<String>().map { body ->
+          if (response.statusCode().isError) {
+            logger.warn("Downstream API returned ${response.statusCode()}: $body")
+          } else {
+            logger.debug("Downstream API returned successful response")
+          }
+
+          response.mutate().body(body).build()
+        }
+      },
+    )
+    .build()
 }

--- a/tools/cp-stack/.env.api.template
+++ b/tools/cp-stack/.env.api.template
@@ -36,6 +36,9 @@ CLIENT_PROBATION_ACCESS_CONTROL_URL=https://probation-access-control-dev.hmpps.s
 # this is overridden in docker-compose when using the docker image
 CLIENT_COMMUNITY_PAYBACK_AND_DELIUS_URL=http://localhost:9004
 
+# log error responses (4xx and 5xx) from downstream services
+CLIENT_LOG_DOWNSTREAM_ERROR_RESPONSES=true
+
 # without this e2es will intermittently fail
 COMMUNITY_PAYBACK_APPOINTMENT_SCHEDULING_DISABLE_NON_WORKING_DAYS=true
 


### PR DESCRIPTION
Currently, when a PUT or POST request returns an error, this information is lost.

This makes it difficult to diagnose certain problems, such as those causing SQS messages to be put on the dead-letter queue.

To help discover the issue, this adds an `ExchangeFilterFunction` to the configured `WebClient`s that logs the body for downstream API responses if it has an error status code.

This is configured by default to be disabled, and is only enabled locally and on dev.