### PR TITLE
CPB-943: Fix `IllegalStateException` when receiving an empty response

### DIFF
--- a/helm_deploy/hmpps-community-payback-api/files/stubs/mappings/get-project/project-TEST404-404.json
+++ b/helm_deploy/hmpps-community-payback-api/files/stubs/mappings/get-project/project-TEST404-404.json
@@ -1,0 +1,14 @@
+{
+  "priority": 1,
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/projects/TEST404"
+  },
+  "response": {
+    "status": 404,
+    "body": "",
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/WebClientConfiguration.kt
@@ -118,9 +118,9 @@ inline fun <reified T> WebClient.logErrorResponses(enabled: Boolean): WebClient 
   return this.mutate()
     .filter(
       ExchangeFilterFunction.ofResponseProcessor { response ->
-        response.bodyToMono<String>().map { body ->
+        response.bodyToMono<String>().defaultIfEmpty("").map { body ->
           if (response.statusCode().isError) {
-            logger.warn("Downstream API returned ${response.statusCode()}: $body")
+            logger.warn("Downstream API returned ${response.statusCode()}: ${body.ifEmpty { "<empty>" }}")
           } else {
             logger.debug("Downstream API returned successful response")
           }


### PR DESCRIPTION
Shortly after #645 was merged, the API started throwing `IllegalStateException`s with the following message:

    The underlying HTTP client completed without emitting a response.

This appears to be as a result of these changes, in that `bodyToMono` appears to return `Mono.never()` instead of `Mono.just("")` if the underlying response has a content length of 0.

To handle this, the response body is coerced into an empty string in the case that the `Mono` is empty, allowing the HTTP client to always successfully emit a response.

Additionally, the log message has been updated to explicitly indicate when the received response was empty so help future diagnosis.