### PR TITLE
CPB-948: Allow `court` and `convictionDate` to be nullable for case details

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
@@ -601,8 +601,8 @@ data class NDUpwDetails(
   val eventOutcome: String,
   val upwStatus: String?,
   val referralDate: LocalDate,
-  val convictionDate: LocalDate,
-  val court: NDCodeDescription,
+  val convictionDate: LocalDate?,
+  val court: NDCodeDescription?,
   val mainOffence: NDMainOffence,
 ) {
   companion object

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CaseDetailsSummaryDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CaseDetailsSummaryDto.kt
@@ -25,8 +25,8 @@ data class UnpaidWorkDetailsDto(
   val eventOutcome: String,
   val upwStatus: String?,
   val referralDate: LocalDate,
-  val convictionDate: LocalDate,
-  val court: CourtDto,
+  val convictionDate: LocalDate?,
+  val court: CourtDto?,
   val mainOffence: MainOffenceDto,
 ) {
   companion object

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/CaseDetailsSummaryMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/CaseDetailsSummaryMapper.kt
@@ -34,7 +34,7 @@ fun NDUpwDetails.toDto(): UnpaidWorkDetailsDto {
     upwStatus = this.upwStatus,
     referralDate = this.referralDate,
     convictionDate = this.convictionDate,
-    court = this.court.toDto(),
+    court = this.court?.toDto(),
     mainOffence = this.mainOffence.toDto(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/CaseDetailsSummaryMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/CaseDetailsSummaryMapperTest.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDMainOffence
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDUpwDetails
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourtDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.MainOffenceDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
 import java.time.LocalDate
 
@@ -67,6 +68,20 @@ class CaseDetailsSummaryMapperTest {
           description = "Court1",
         ),
       )
+    }
+
+    @Test
+    fun `maps correctly when court information is not provided`() {
+      val result = NDUpwDetails.valid().copy(court = null).toDto()
+
+      assertThat(result.court).isNull()
+    }
+
+    @Test
+    fun `maps correctly when conviction date is not provided`() {
+      val result = NDUpwDetails.valid().copy(convictionDate = null).toDto()
+
+      assertThat(result.convictionDate).isNull()
     }
   }
 }


### PR DESCRIPTION
The Community Payback and Delius API has updated the case summary endpoint to make these properties nullable in the response as a result of a bug (see https://mojdt.slack.com/archives/C09FG97FTGS/p1778504478966199 for more details).

This change requires our API to handle nulls for these properties.