### PR TITLE
CPB-777: Remove `dateOfAdjustment` from `CreateAdjustmentDto`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CreateAdjustmentDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CreateAdjustmentDto.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Min
-import java.time.LocalDate
 import java.util.UUID
 
 data class CreateAdjustmentDto(
@@ -12,7 +11,6 @@ data class CreateAdjustmentDto(
   @field:Min(value = 1)
   @param:Schema(description = "Adjustment minutes, must be greater than 0")
   val minutes: Int,
-  val dateOfAdjustment: LocalDate,
   val adjustmentReasonId: UUID,
 ) {
   companion object

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentEventEntityFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentEventEntityFactory.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventEn
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventTriggerType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
+import java.time.LocalDate
 import java.time.OffsetDateTime
 
 @Service
@@ -14,6 +15,7 @@ class AdjustmentEventEntityFactory {
 
   fun buildAdjustmentCreated(
     details: AdjustmentCreatedEvent,
+    adjustmentDate: LocalDate,
   ) = AdjustmentEventEntity(
     id = details.id,
     eventType = AdjustmentEventType.CREATE,
@@ -27,7 +29,7 @@ class AdjustmentEventEntityFactory {
       CreateAdjustmentTypeDto.Negative -> AdjustmentEventAdjustmentType.NEGATIVE
     },
     adjustmentMinutes = details.createDto.minutes,
-    adjustmentDate = details.createDto.dateOfAdjustment,
+    adjustmentDate = adjustmentDate,
     adjustmentReason = details.reason,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentEventService.kt
@@ -8,6 +8,8 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventEn
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toAdjustmentCreatedDomainEvent
+import java.time.Clock
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -16,6 +18,7 @@ class AdjustmentEventService(
   private val adjustmentEventEntityRepository: AdjustmentEventEntityRepository,
   private val adjustmentEventEntityFactory: AdjustmentEventEntityFactory,
   private val domainEventService: DomainEventService,
+  private val clock: Clock,
 ) {
   fun getCreatedDomainEventDetails(id: UUID) = adjustmentEventEntityRepository.findByIdOrNullForDomainEventDetails(id, AdjustmentEventType.CREATE)?.toAdjustmentCreatedDomainEvent()
 
@@ -24,7 +27,7 @@ class AdjustmentEventService(
   @EventListener
   fun persistAndPublishCreateAdjustmentDomainEvent(event: AdjustmentCreatedEvent) {
     val persistedEvent = adjustmentEventEntityRepository.save(
-      adjustmentEventEntityFactory.buildAdjustmentCreated(event),
+      adjustmentEventEntityFactory.buildAdjustmentCreated(event, LocalDate.now(clock)),
     )
 
     domainEventService.publishOnTransactionCommit(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.Communi
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toNDAdjustmentRequest
 import java.time.Clock
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -43,6 +44,7 @@ class AdjustmentService(
           deliusEventNumber = deliusEventNumber,
           reason = validatedAdjustment.reason,
           reference = adjustmentId,
+          dateOfAdjustment = LocalDate.now(clock),
         ),
       ),
     ).single().id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/LockService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/LockService.kt
@@ -56,7 +56,9 @@ class RedisLockService(
         log.trace("Have acquired lock '{}' with lease '{}'", key, leaseTime)
         return exec.invoke()
       } finally {
-        lock.unlock()
+        if (lock.isLocked) {
+          lock.unlock()
+        }
         log.trace("Have unlocked '{}'", key)
       }
     } else {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AdjustmentMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AdjustmentMappers.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.domainevent.AdjustmentCreatedDomainEventDetailsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentReasonEntity
+import java.time.LocalDate
 import java.util.UUID
 
 fun CreateAdjustmentDto.toNDAdjustmentRequest(
@@ -14,6 +15,7 @@ fun CreateAdjustmentDto.toNDAdjustmentRequest(
   deliusEventNumber: Int,
   reason: AdjustmentReasonEntity,
   reference: UUID,
+  dateOfAdjustment: LocalDate,
 ) = NDAdjustmentRequest(
   crn = crn,
   eventNumber = deliusEventNumber,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/CreateAdjustmentDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/CreateAdjustmentDtoFactory.kt
@@ -6,14 +6,12 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentTypeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentReasonEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
-import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomLocalDate
 import java.util.UUID
 
 fun CreateAdjustmentDto.Companion.valid() = CreateAdjustmentDto(
   taskId = UUID.randomUUID(),
   type = CreateAdjustmentTypeDto.entries.random(),
   minutes = Int.random(1, 180),
-  dateOfAdjustment = randomLocalDate(),
   adjustmentReasonId = UUID.randomUUID(),
 )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentEventEntityFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentEventEntityFactoryTest.kt
@@ -31,7 +31,6 @@ class AdjustmentEventEntityFactoryTest {
         createDto = CreateAdjustmentDto.valid().copy(
           type = CreateAdjustmentTypeDto.Negative,
           minutes = 61,
-          dateOfAdjustment = LocalDate.of(1971, 8, 23),
         ),
         appointmentEntity = appointment,
         reason = reason,
@@ -43,6 +42,7 @@ class AdjustmentEventEntityFactoryTest {
         ),
         id = id,
       ),
+      adjustmentDate = LocalDate.of(1971, 8, 23),
     )
 
     assertThat(result.eventType).isEqualTo(AdjustmentEventType.CREATE)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentServiceTest.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringE
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toNDAdjustmentRequest
 import java.time.Clock
 import java.time.Instant
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -87,6 +88,7 @@ class AdjustmentServiceTest {
               deliusEventNumber = EVENT_NUMBER,
               reason = reason,
               reference = id,
+              dateOfAdjustment = LocalDate.now(clock),
             ),
           ),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AdjustmentMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AdjustmentMappersTest.kt
@@ -30,7 +30,6 @@ class AdjustmentMappersTest {
     ) {
       val id = UUID.randomUUID()
       val result = CreateAdjustmentDto.valid().copy(
-        dateOfAdjustment = LocalDate.of(2014, 11, 4),
         type = typeDto,
         minutes = 5,
       ).toNDAdjustmentRequest(
@@ -38,6 +37,7 @@ class AdjustmentMappersTest {
         deliusEventNumber = 5,
         reason = AdjustmentReasonEntity.valid().copy(deliusCode = "REASON1"),
         reference = id,
+        dateOfAdjustment = LocalDate.of(2014, 11, 4),
       )
 
       assertThat(result.crn).isEqualTo("CRN888")


### PR DESCRIPTION
The frontend sends the current timestamp for this property when creating a travel time adjustment. This prevents the `IdempotencyFilter` from determining that the request is logically the same (from a user perspective) and so reissues the request to Delius.

As it is unlikely that a user will ever need to explicitly specify the adjustment date, this property can be removed, and the API can supply this value instead. This then means that multiple submissions of the travel time form result in identical requests, which can be correctly handled as idempotent.