### PR TITLE
CPB-964: Add 'Partner Supervised Placement' project type

### DIFF
--- a/src/main/resources/db/migration/20260515092650__add_partner_supervised_placement_project_type.sql
+++ b/src/main/resources/db/migration/20260515092650__add_partner_supervised_placement_project_type.sql
@@ -1,0 +1,2 @@
+INSERT INTO project_types (id, code, name, project_type_group)
+VALUES (gen_random_uuid(), 'PSP', 'Partner Supervised Placement', 'INDIVIDUAL');

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminProvidersIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminProvidersIT.kt
@@ -478,7 +478,7 @@ class AdminProvidersIT : IntegrationTestBase() {
       CommunityPaybackAndDeliusMockServer.setupGetProjectsResponse(
         providerCode = "PC01",
         teamCode = "999",
-        projectTypeCodes = listOf("ES", "ICP", "PIP2"),
+        projectTypeCodes = listOf("ES", "ICP", "PIP2", "PSP"),
         response = listOf(project1, project2),
       )
 
@@ -506,7 +506,7 @@ class AdminProvidersIT : IntegrationTestBase() {
       CommunityPaybackAndDeliusMockServer.setupGetProjectsResponse(
         providerCode = "PC01",
         teamCode = "999",
-        projectTypeCodes = listOf("ES", "ICP", "PIP2"),
+        projectTypeCodes = listOf("ES", "ICP", "PIP2", "PSP"),
         response = listOf(project1, project2),
         pageNumber = 0,
         pageSize = 25,


### PR DESCRIPTION
This adds the Partner Supervised Placement (PSP) project type to the Community Payback database. Currently, when trying to find an individual placement, these types of projects are not included in the results, but are expected to be present.