### PR TITLE
CPB-963: Add additional telemetry events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentTaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentTaskService.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeGroup
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentTaskCreatedEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentTaskUpdatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentUpdatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.AppointmentTaskMappers
@@ -79,6 +80,7 @@ class AppointmentTaskService(
       task.decisionMadeByUsername = contextService.getUserName()
       task.decisionDescription = "Task completed on adjustment creation"
       appointmentTaskEntityRepository.save(task)
+      publishAppointmentTaskUpdatedEvent(task)
     }
   }
 
@@ -94,6 +96,8 @@ class AppointmentTaskService(
     task.decisionMadeByUsername = contextService.getUserName()
     task.decisionDescription = "Task completed directly"
     appointmentTaskEntityRepository.save(task)
+
+    publishAppointmentTaskUpdatedEvent(task)
   }
 
   private fun createTravelTimeTaskIfRequired(
@@ -129,6 +133,20 @@ class AppointmentTaskService(
         ),
       )
     }
+  }
+
+  private fun publishAppointmentTaskUpdatedEvent(task: AppointmentTaskEntity) {
+    springEventPublisher.publishEvent(
+      AppointmentTaskUpdatedEvent(
+        crn = task.appointment.crn,
+        deliusAppointmentId = task.appointment.deliusId,
+        taskType = task.taskType,
+        taskStatus = task.taskStatus,
+        decision = task.decisionDescription,
+        triggeredAt = OffsetDateTime.now(),
+        triggeredBy = contextService.getUserName(),
+      ),
+    )
   }
 
   fun getPendingAppointmentTasks(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentTaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentTaskService.kt
@@ -20,7 +20,9 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEnt
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeGroup
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentCreatedEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentTaskCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentUpdatedEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.AppointmentTaskMappers
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -32,6 +34,7 @@ class AppointmentTaskService(
   private val contextService: ContextService,
   private val caseVisibilityService: CaseVisibilityService,
   private val appointmentTaskMappers: AppointmentTaskMappers,
+  private val springEventPublisher: SpringEventPublisher,
 ) {
 
   @EventListener
@@ -39,11 +42,13 @@ class AppointmentTaskService(
   fun createTravelTimeTaskOnAppointmentCreation(
     event: AppointmentCreatedEvent,
   ) {
-    createTravelTimeTaskIfRequired(
+    val task = createTravelTimeTaskIfRequired(
       appointment = event.appointmentEntity,
       outcome = event.createDto.contactOutcome,
       project = event.createDto.project,
     )
+
+    publishAppointmentTaskCreatedEventIfRequired(task)
   }
 
   @EventListener
@@ -51,11 +56,13 @@ class AppointmentTaskService(
   fun createTravelTimeTaskOnAppointmentUpdate(
     event: AppointmentUpdatedEvent,
   ) {
-    createTravelTimeTaskIfRequired(
+    val task = createTravelTimeTaskIfRequired(
       appointment = event.appointmentEntity,
       outcome = event.updateDto.contactOutcome,
       project = event.updateDto.project,
     )
+
+    publishAppointmentTaskCreatedEventIfRequired(task)
   }
 
   @EventListener
@@ -93,16 +100,32 @@ class AppointmentTaskService(
     appointment: AppointmentEntity,
     outcome: ContactOutcomeEntity?,
     project: ProjectDto,
-  ) {
+  ): AppointmentTaskEntity? {
     val attended = outcome?.attended == true
     val projectSupportsTravelTime = project.projectType.group?.let { ProjectTypeGroup.fromDto(it).travelTimeSupported } == true
     if (attended && projectSupportsTravelTime) {
-      appointmentTaskEntityRepository.save(
+      return appointmentTaskEntityRepository.save(
         AppointmentTaskEntity(
           id = UUID.randomUUID(),
           appointment = appointment,
           taskType = AppointmentTaskType.ADJUSTMENT_TRAVEL_TIME,
           taskStatus = AppointmentTaskStatus.PENDING,
+        ),
+      )
+    }
+
+    return null
+  }
+
+  private fun publishAppointmentTaskCreatedEventIfRequired(task: AppointmentTaskEntity?) {
+    if (task != null) {
+      springEventPublisher.publishEvent(
+        AppointmentTaskCreatedEvent(
+          crn = task.appointment.crn,
+          deliusAppointmentId = task.appointment.deliusId,
+          taskType = task.taskType,
+          triggeredAt = OffsetDateTime.now(),
+          triggeredBy = contextService.getUserName(),
         ),
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
@@ -21,6 +21,8 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompleti
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventResolutionRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventStatus
 import uk.gov.justice.digital.hmpps.communitypaybackapi.listener.EducationCourseCompletionMessage
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CourseCompletionReceivedEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.EteMappers
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
 import java.time.OffsetDateTime
@@ -34,6 +36,7 @@ class EteService(
   private val appointmentService: AppointmentService,
   private val eteValidationService: EteValidationService,
   private val projectService: ProjectService,
+  private val springEventPublisher: SpringEventPublisher,
   @Value("\${course.completions.available.from:2026-01-01T00:00:00Z}") private val courseCompletionsAvailableFrom: OffsetDateTime,
 ) {
   companion object {
@@ -41,7 +44,19 @@ class EteService(
   }
 
   fun recordCourseCompletionEvent(message: EducationCourseCompletionMessage) {
-    eteCourseCompletionEventEntityRepository.save(eteMapper.toCourseCompletionEventEntity(message))
+    val event = eteCourseCompletionEventEntityRepository.save(eteMapper.toCourseCompletionEventEntity(message))
+
+    springEventPublisher.publishEvent(
+      CourseCompletionReceivedEvent(
+        attempts = event.attempts,
+        courseName = event.courseName,
+        courseType = event.courseType,
+        provider = event.provider,
+        region = event.region,
+        triggeredAt = event.receivedAt,
+        triggeredBy = event.externalReference,
+      ),
+    )
   }
 
   fun getCourseCompletionEvents(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompleti
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventResolutionRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventStatus
 import uk.gov.justice.digital.hmpps.communitypaybackapi.listener.EducationCourseCompletionMessage
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CourseCompletionProcessedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CourseCompletionReceivedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.EteMappers
@@ -36,6 +37,7 @@ class EteService(
   private val appointmentService: AppointmentService,
   private val eteValidationService: EteValidationService,
   private val projectService: ProjectService,
+  private val contextService: ContextService,
   private val springEventPublisher: SpringEventPublisher,
   @Value("\${course.completions.available.from:2026-01-01T00:00:00Z}") private val courseCompletionsAvailableFrom: OffsetDateTime,
 ) {
@@ -138,6 +140,16 @@ class EteService(
       CourseCompletionResolutionTypeDto.CREDIT_TIME -> creditTime(courseCompletionResolution, courseCompletionEvent)
       CourseCompletionResolutionTypeDto.DONT_CREDIT_TIME -> dontCreditTime(courseCompletionResolution, courseCompletionEvent)
     }
+
+    springEventPublisher.publishEvent(
+      CourseCompletionProcessedEvent(
+        crn = courseCompletionResolution.crn,
+        externalReference = courseCompletionEvent.externalReference,
+        resolutionType = courseCompletionResolution.type,
+        triggeredAt = OffsetDateTime.now(),
+        triggeredBy = contextService.getUserName(),
+      ),
+    )
   }
 
   private fun creditTime(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/NDeliusRollbackService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/NDeliusRollbackService.kt
@@ -33,6 +33,8 @@ class NDeliusRollbackService(
 
   @EventListener
   fun captureEvent(event: CommunityPaybackSpringEvent) {
+    if (event is CommunityPaybackSpringEvent.DoesNotSupportRollbackEvent) return
+
     getRequestScopedEvents().add(event)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/DeliusEventTelemetryPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/DeliusEventTelemetryPublisher.kt
@@ -4,6 +4,7 @@ import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentCreatedEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentTaskCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentUpdatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CourseCompletionProcessedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CourseCompletionReceivedEvent
@@ -90,6 +91,21 @@ class DeliusEventTelemetryPublisher(
         "triggeredAt" to event.triggeredAt.toString(),
         "triggeredBy" to event.triggeredBy,
         "eventType" to "PROCESSED",
+      ),
+    )
+  }
+
+  @EventListener
+  fun onAppointmentTaskCreated(event: AppointmentTaskCreatedEvent) {
+    telemetryService.trackEvent(
+      "AppointmentTaskEvent",
+      properties = mapOf(
+        "crn" to event.crn,
+        "deliusAppointmentId" to event.deliusAppointmentId.toString(),
+        "taskType" to event.taskType.name,
+        "triggeredAt" to event.triggeredAt.toString(),
+        "triggeredBy" to event.triggeredBy,
+        "eventType" to "CREATED",
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/DeliusEventTelemetryPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/DeliusEventTelemetryPublisher.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentUpdatedEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CourseCompletionReceivedEvent
 
 @Service
 class DeliusEventTelemetryPublisher(
@@ -57,6 +58,23 @@ class DeliusEventTelemetryPublisher(
         "triggeredAt" to event.trigger.triggeredAt.toString(),
         "triggeredBy" to event.trigger.triggeredBy,
         "eventType" to "CREATED",
+      ),
+    )
+  }
+
+  @EventListener
+  fun onCourseCompletionReceived(event: CourseCompletionReceivedEvent) {
+    telemetryService.trackEvent(
+      "CourseCompletionEvent",
+      properties = mapOf(
+        "attempts" to event.attempts?.toString(),
+        "courseName" to event.courseName,
+        "courseType" to event.courseType,
+        "provider" to event.provider,
+        "region" to event.region,
+        "triggeredAt" to event.triggeredAt.toString(),
+        "triggeredBy" to event.triggeredBy,
+        "eventType" to "RECEIVED",
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/DeliusEventTelemetryPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/DeliusEventTelemetryPublisher.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentUpdatedEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CourseCompletionProcessedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CourseCompletionReceivedEvent
 
 @Service
@@ -75,6 +76,20 @@ class DeliusEventTelemetryPublisher(
         "triggeredAt" to event.triggeredAt.toString(),
         "triggeredBy" to event.triggeredBy,
         "eventType" to "RECEIVED",
+      ),
+    )
+  }
+
+  @EventListener
+  fun onCourseCompletionProcessed(event: CourseCompletionProcessedEvent) {
+    telemetryService.trackEvent(
+      "CourseCompletionEvent",
+      properties = mapOf(
+        "crn" to event.crn,
+        "resolutionType" to event.resolutionType.name,
+        "triggeredAt" to event.triggeredAt.toString(),
+        "triggeredBy" to event.triggeredBy,
+        "eventType" to "PROCESSED",
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/DeliusEventTelemetryPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/DeliusEventTelemetryPublisher.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentTaskCreatedEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentTaskUpdatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentUpdatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CourseCompletionProcessedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CourseCompletionReceivedEvent
@@ -106,6 +107,22 @@ class DeliusEventTelemetryPublisher(
         "triggeredAt" to event.triggeredAt.toString(),
         "triggeredBy" to event.triggeredBy,
         "eventType" to "CREATED",
+      ),
+    )
+  }
+
+  @EventListener
+  fun onAppointmentTaskUpdated(event: AppointmentTaskUpdatedEvent) {
+    telemetryService.trackEvent(
+      "AppointmentTaskEvent",
+      properties = mapOf(
+        "crn" to event.crn,
+        "deliusAppointmentId" to event.deliusAppointmentId.toString(),
+        "taskType" to event.taskType.name,
+        "taskStatus" to event.taskStatus.name,
+        "triggeredAt" to event.triggeredAt.toString(),
+        "triggeredBy" to event.triggeredBy,
+        "eventType" to "UPDATED",
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionTypeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
@@ -68,6 +69,16 @@ sealed interface CommunityPaybackSpringEvent {
     val triggeredBy: String,
   ) : CommunityPaybackSpringEvent,
     DoesNotSupportRollbackEvent {
+    companion object
+  }
+
+  data class CourseCompletionProcessedEvent(
+    val crn: String?,
+    val externalReference: String,
+    val resolutionType: CourseCompletionResolutionTypeDto,
+    val triggeredAt: OffsetDateTime,
+    val triggeredBy: String,
+  ) : CommunityPaybackSpringEvent {
     companion object
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentEventTrigger
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentEventTrigger
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService
+import java.time.OffsetDateTime
 import java.util.UUID
 
 @Service
@@ -54,6 +55,19 @@ sealed interface CommunityPaybackSpringEvent {
     val existingAppointment: AppointmentDto,
     val trigger: AppointmentEventTrigger,
   ) : CommunityPaybackSpringEvent {
+    companion object
+  }
+
+  data class CourseCompletionReceivedEvent(
+    val attempts: Int?,
+    val courseName: String,
+    val courseType: String,
+    val provider: String,
+    val region: String,
+    val triggeredAt: OffsetDateTime,
+    val triggeredBy: String,
+  ) : CommunityPaybackSpringEvent,
+    DoesNotSupportRollbackEvent {
     companion object
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
@@ -27,6 +27,7 @@ class SpringEventPublisher(
 }
 
 sealed interface CommunityPaybackSpringEvent {
+  sealed interface DoesNotSupportRollbackEvent : CommunityPaybackSpringEvent
 
   data class AppointmentCreatedEvent(
     val createDto: AppointmentValidationService.ValidatedAppointment<CreateAppointmentDto>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentReasonEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskStatus
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentEventTrigger
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentEventTrigger
@@ -87,6 +88,18 @@ sealed interface CommunityPaybackSpringEvent {
     val crn: String,
     val deliusAppointmentId: Long,
     val taskType: AppointmentTaskType,
+    val triggeredAt: OffsetDateTime,
+    val triggeredBy: String,
+  ) : CommunityPaybackSpringEvent {
+    companion object
+  }
+
+  data class AppointmentTaskUpdatedEvent(
+    val crn: String,
+    val deliusAppointmentId: Long,
+    val taskType: AppointmentTaskType,
+    val taskStatus: AppointmentTaskStatus,
+    val decision: String?,
     val triggeredAt: OffsetDateTime,
     val triggeredBy: String,
   ) : CommunityPaybackSpringEvent {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentReasonEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentEventTrigger
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentEventTrigger
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService
@@ -76,6 +77,16 @@ sealed interface CommunityPaybackSpringEvent {
     val crn: String?,
     val externalReference: String,
     val resolutionType: CourseCompletionResolutionTypeDto,
+    val triggeredAt: OffsetDateTime,
+    val triggeredBy: String,
+  ) : CommunityPaybackSpringEvent {
+    companion object
+  }
+
+  data class AppointmentTaskCreatedEvent(
+    val crn: String,
+    val deliusAppointmentId: Long,
+    val taskType: AppointmentTaskType,
     val triggeredAt: OffsetDateTime,
     val triggeredBy: String,
   ) : CommunityPaybackSpringEvent {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/DeliusEventTelemetryIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/DeliusEventTelemetryIT.kt
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOut
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEventTriggerType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskStatus
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntity.Companion.CODE_ATTENDED_COMPLIED
@@ -46,6 +47,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.validNoOu
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.persist
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.validPending
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.listener.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.util.DatabasePurgeUtils
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.util.MockTelemetryService
@@ -378,5 +380,30 @@ class DeliusEventTelemetryIT : IntegrationTestBase() {
     assertThat(properties["triggeredAt"]).isNotNull()
     assertThat(properties["triggeredBy"]).isEqualTo("theusername")
     assertThat(properties["eventType"]).isEqualTo("CREATED")
+  }
+
+  @Test
+  fun `should track telemetry when an appointment task is updated`() {
+    val task = AppointmentTaskEntity.validPending().copy(
+      appointment = AppointmentEntity.valid().copy(crn = CRN, deliusId = 1234L).persist(ctx),
+    ).persist(ctx)
+
+    webTestClient.put()
+      .uri("/admin/appointment-tasks/${task.id}/complete")
+      .addAdminUiAuthHeader("theusername")
+      .exchange()
+      .expectStatus()
+      .isOk
+
+    val events = mockTelemetryService.getEventsWithName("AppointmentTaskEvent")
+    assertThat(events).hasSize(1)
+    val properties = events[0].properties
+    assertThat(properties["crn"]).isEqualTo(CRN)
+    assertThat(properties["deliusAppointmentId"]).isEqualTo("1234")
+    assertThat(properties["taskType"]).isEqualTo(AppointmentTaskType.ADJUSTMENT_TRAVEL_TIME.name)
+    assertThat(properties["taskStatus"]).isEqualTo(AppointmentTaskStatus.COMPLETE.name)
+    assertThat(properties["triggeredAt"]).isNotNull()
+    assertThat(properties["triggeredBy"]).isEqualTo("theusername")
+    assertThat(properties["eventType"]).isEqualTo("UPDATED")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/DeliusEventTelemetryIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/DeliusEventTelemetryIT.kt
@@ -20,7 +20,12 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProject
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProjectAndLocation
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProjectType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProvider
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSupervisorSummaries
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSupervisorSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDTeam
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionCreditTimeDetailsDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionTypeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentDto
@@ -28,8 +33,10 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEventTriggerType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntity.Companion.GROUP_PLACEMENT_NATIONAL_PROJECT_CODE
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.unallocated
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.validNoOutcome
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.valid
@@ -267,5 +274,57 @@ class DeliusEventTelemetryIT : IntegrationTestBase() {
       assertThat(properties["triggeredBy"]).isEqualTo(attributes.externalReference)
       assertThat(properties["eventType"]).isEqualTo("RECEIVED")
     }
+  }
+
+  @Test
+  fun `should track telemetry when a course completion is processed`() {
+    val project = NDProject.valid(ctx).copy(code = PROJECT_CODE, actualEndDateExclusive = null)
+    CommunityPaybackAndDeliusMockServer.setupGetProjectResponse(project)
+    CommunityPaybackAndDeliusMockServer.setupGetTeamSupervisorsResponse(
+      forProject = project,
+      supervisorSummaries = NDSupervisorSummaries(listOf(NDSupervisorSummary.unallocated())),
+    )
+
+    val eventEntity = eteCourseCompletionEventEntityRepository.save(
+      EteCourseCompletionEventEntity.valid(ctx).copy(),
+    )
+
+    val resolution = CourseCompletionResolutionDto.valid(ctx).copy(
+      type = CourseCompletionResolutionTypeDto.CREDIT_TIME,
+      crn = CRN,
+      creditTimeDetails = CourseCompletionCreditTimeDetailsDto.valid(ctx).copy(
+        date = LocalDate.of(2021, 1, 30),
+        deliusEventNumber = EVENT_NUMBER,
+        appointmentIdToUpdate = null,
+        projectCode = PROJECT_CODE,
+        minutesToCredit = 90,
+        notes = "Some notes",
+      ),
+    )
+
+    CommunityPaybackAndDeliusMockServer.Aggregates.setupGetDataMocksForCreateAppointment(
+      crn = CRN,
+      eventNumber = EVENT_NUMBER,
+      project = NDProject.valid(ctx).copy(code = PROJECT_CODE, actualEndDateExclusive = null),
+    )
+    CommunityPaybackAndDeliusMockServer.setupPostAppointmentsResponse(projectCode = PROJECT_CODE, appointmentCount = 1)
+
+    webTestClient.post()
+      .uri("/admin/course-completions/${eventEntity.id}/resolution")
+      .addAdminUiAuthHeader("theusername")
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(resolution)
+      .exchange()
+      .expectStatus()
+      .isNoContent
+
+    val events = mockTelemetryService.getEventsWithName("CourseCompletionEvent")
+    assertThat(events).hasSize(1)
+    val properties = events[0].properties
+    assertThat(properties["crn"]).isEqualTo(CRN)
+    assertThat(properties["resolutionType"]).isEqualTo(resolution.type.name)
+    assertThat(properties["triggeredAt"]).isNotNull
+    assertThat(properties["triggeredBy"]).isEqualTo("theusername")
+    assertThat(properties["eventType"]).isEqualTo("PROCESSED")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/DeliusEventTelemetryIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/DeliusEventTelemetryIT.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility.await
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -8,6 +10,8 @@ import org.springframework.http.MediaType
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.context.request.ServletRequestAttributes
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDEvent
@@ -24,18 +28,26 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEventTriggerType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntity.Companion.GROUP_PLACEMENT_NATIONAL_PROJECT_CODE
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.validNoOutcome
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.persist
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.listener.valid
+import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.util.DatabasePurgeUtils
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.util.MockTelemetryService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.wiremock.CommunityPaybackAndDeliusMockServer
+import uk.gov.justice.digital.hmpps.communitypaybackapi.listener.EducationCourseCompletionMessage
+import uk.gov.justice.digital.hmpps.communitypaybackapi.listener.EducationCourseMessageAttributes
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentCreationService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentEventTrigger
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import uk.gov.justice.hmpps.sqs.MissingQueueException
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.util.concurrent.TimeUnit
 
 class DeliusEventTelemetryIT : IntegrationTestBase() {
 
@@ -45,7 +57,21 @@ class DeliusEventTelemetryIT : IntegrationTestBase() {
   @Autowired
   lateinit var appointmentCreationService: AppointmentCreationService
 
+  @Autowired
+  lateinit var jsonMapper: JsonMapper
+
+  @Autowired
+  lateinit var hmppsQueueService: HmppsQueueService
+
+  @Autowired
+  lateinit var eteCourseCompletionEventEntityRepository: EteCourseCompletionEventEntityRepository
+
+  @Autowired
+  lateinit var databasePurgeUtils: DatabasePurgeUtils
+
   companion object {
+    const val QUEUE_NAME = "educationcoursecompletionevents"
+
     const val CRN = "X123456"
     const val EVENT_NUMBER = 1
     const val PROJECT_CODE = "PROJ001"
@@ -59,6 +85,12 @@ class DeliusEventTelemetryIT : IntegrationTestBase() {
   @BeforeEach
   fun setUp() {
     mockTelemetryService.beforeTestMethod()
+    databasePurgeUtils.deleteAllEteData()
+  }
+
+  @AfterEach
+  fun tearDown() {
+    eteCourseCompletionEventEntityRepository.deleteAll()
   }
 
   @Test
@@ -203,5 +235,37 @@ class DeliusEventTelemetryIT : IntegrationTestBase() {
     assertThat(properties["triggeredAt"]).isNotNull()
     assertThat(properties["triggeredBy"]).isEqualTo(task.id.toString())
     assertThat(properties["eventType"]).isEqualTo("CREATED")
+  }
+
+  @Test
+  fun `should track telemetry when a course completion is received`() {
+    val queue = hmppsQueueService.findByQueueId(QUEUE_NAME)
+      ?: throw MissingQueueException("HmppsQueue $QUEUE_NAME not found")
+
+    val attributes = EducationCourseMessageAttributes.valid(ctx).copy()
+    val message = EducationCourseCompletionMessage.valid(ctx).copy(messageAttributes = attributes)
+
+    queue.sqsClient.sendMessage(
+      SendMessageRequest.builder()
+        .messageBody(jsonMapper.writeValueAsString(message))
+        .queueUrl(queue.queueUrl)
+        .build(),
+    )
+
+    await().atMost(10, TimeUnit.SECONDS).untilAsserted {
+      val events = mockTelemetryService.getEventsWithName("CourseCompletionEvent")
+      assertThat(events).hasSize(1)
+      val properties = events[0].properties
+
+      assertThat(properties["attempts"]).isNotNull
+      assertThat(properties["attempts"]).isEqualTo(attributes.attempts.toString())
+      assertThat(properties["courseName"]).isEqualTo(attributes.courseName)
+      assertThat(properties["courseType"]).isEqualTo(attributes.courseType)
+      assertThat(properties["provider"]).isEqualTo(attributes.provider)
+      assertThat(properties["region"]).isEqualTo(attributes.region)
+      assertThat(properties["triggeredAt"]).isNotNull()
+      assertThat(properties["triggeredBy"]).isEqualTo(attributes.externalReference)
+      assertThat(properties["eventType"]).isEqualTo("RECEIVED")
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/DeliusEventTelemetryIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/DeliusEventTelemetryIT.kt
@@ -23,16 +23,20 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProvider
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSupervisorSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSupervisorSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDTeam
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AttendanceDataDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionCreditTimeDetailsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionTypeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEventTriggerType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntity.Companion.CODE_ATTENDED_COMPLIED
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntity.Companion.GROUP_PLACEMENT_NATIONAL_PROJECT_CODE
@@ -53,6 +57,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentEvent
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.MissingQueueException
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.util.concurrent.TimeUnit
 
@@ -326,5 +331,52 @@ class DeliusEventTelemetryIT : IntegrationTestBase() {
     assertThat(properties["triggeredAt"]).isNotNull
     assertThat(properties["triggeredBy"]).isEqualTo("theusername")
     assertThat(properties["eventType"]).isEqualTo("PROCESSED")
+  }
+
+  @Test
+  fun `should track telemetry when an appointment task is created`() {
+    CommunityPaybackAndDeliusMockServer.Aggregates.setupGetDataMocksForUpdateAppointment(
+      existingAppointment = NDAppointment.validNoOutcome(ctx).copy(
+        id = 1234L,
+        project = NDProjectAndLocation.valid().copy(code = "proj123"),
+        date = LocalDate.now(),
+        event = NDEvent.valid().copy(number = EVENT_NUMBER),
+        case = NDCaseSummary.valid().copy(crn = CRN),
+      ),
+      username = "theusername",
+      project = NDProject.valid(ctx).copy(code = "proj123", type = NDProjectType.valid().copy(code = GROUP_PLACEMENT_NATIONAL_PROJECT_CODE)),
+    )
+
+    CommunityPaybackAndDeliusMockServer.setupPutAppointmentResponse(
+      projectCode = "proj123",
+      appointmentId = 1234L,
+    )
+
+    webTestClient.post()
+      .uri("/admin/projects/proj123/appointments/1234/outcome")
+      .addAdminUiAuthHeader("theusername")
+      .bodyValue(
+        UpdateAppointmentOutcomeDto.valid(ctx).copy(
+          deliusId = 1234L,
+          attendanceData = AttendanceDataDto.valid(),
+          contactOutcomeCode = CODE_ATTENDED_COMPLIED,
+          startTime = LocalTime.of(0, 0),
+          endTime = LocalTime.of(1, 0),
+          notes = "Some notes",
+        ),
+      )
+      .exchange()
+      .expectStatus()
+      .isOk()
+
+    val events = mockTelemetryService.getEventsWithName("AppointmentTaskEvent")
+    assertThat(events).hasSize(1)
+    val properties = events[0].properties
+    assertThat(properties["crn"]).isEqualTo(CRN)
+    assertThat(properties["deliusAppointmentId"]).isEqualTo("1234")
+    assertThat(properties["taskType"]).isEqualTo(AppointmentTaskType.ADJUSTMENT_TRAVEL_TIME.name)
+    assertThat(properties["triggeredAt"]).isNotNull()
+    assertThat(properties["triggeredBy"]).isEqualTo("theusername")
+    assertThat(properties["eventType"]).isEqualTo("CREATED")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentTaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentTaskServiceTest.kt
@@ -44,6 +44,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ContextService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AppointmentUpdatedEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.AppointmentTaskMappers
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -64,6 +65,9 @@ class AppointmentTaskServiceTest {
 
   @MockK
   private lateinit var appointmentTaskMappers: AppointmentTaskMappers
+
+  @RelaxedMockK
+  private lateinit var springEventPublisher: SpringEventPublisher
 
   @InjectMockKs
   private lateinit var service: AppointmentTaskService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentServi
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.EteService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.EteValidationService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ProjectService
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.EteMappers
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
 import java.time.LocalDate
@@ -55,6 +56,9 @@ class EteServiceTest {
   @RelaxedMockK
   lateinit var eteValidationService: EteValidationService
 
+  @RelaxedMockK
+  lateinit var springEventPublisher: SpringEventPublisher
+
   private lateinit var eteService: EteService
 
   @BeforeEach
@@ -66,6 +70,7 @@ class EteServiceTest {
       appointmentService,
       eteValidationService,
       projectService,
+      springEventPublisher,
       OffsetDateTime.parse("2026-01-01T00:00:00Z"),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.listener.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.listener.EducationCourseCompletionMessage
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentService
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ContextService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.EteService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.EteValidationService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ProjectService
@@ -57,6 +58,9 @@ class EteServiceTest {
   lateinit var eteValidationService: EteValidationService
 
   @RelaxedMockK
+  lateinit var contextService: ContextService
+
+  @RelaxedMockK
   lateinit var springEventPublisher: SpringEventPublisher
 
   private lateinit var eteService: EteService
@@ -70,6 +74,7 @@ class EteServiceTest {
       appointmentService,
       eteValidationService,
       projectService,
+      contextService,
       springEventPublisher,
       OffsetDateTime.parse("2026-01-01T00:00:00Z"),
     )


### PR DESCRIPTION
This PR introduces some new telemetry events following on from #653:

- `CourseCompletionReceivedEvent`
- `CourseCompletionProcessedEvent`
- `AppointmentTaskCreatedEvent`
- `AppointmentTaskUpdatedEvent`

Additionally, the `NDeliusRollbackService` has been updated to prevent attempting to rollback events that don't support it, such as those triggered by SQS queues.