### PR TITLE
CPB-942: Fix unnecessary HTML encoding when saving to Delius

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/SanitizingStringDeserializer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/SanitizingStringDeserializer.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.common
 
+import org.owasp.html.Encoding
 import org.owasp.html.PolicyFactory
 import org.owasp.html.Sanitizers
 import tools.jackson.core.JsonParser
@@ -17,5 +18,5 @@ class SanitizingStringDeserializer : StdScalarDeserializer<String>(String::class
   override fun deserialize(
     p: JsonParser,
     ctxt: DeserializationContext,
-  ): String? = POLICY.sanitize(p.valueAsString)
+  ): String? = Encoding.decodeHtml(POLICY.sanitize(p.valueAsString), false)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/common/SanitizingStringDeserializerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/common/SanitizingStringDeserializerTest.kt
@@ -19,6 +19,18 @@ class SanitizingStringDeserializerTest {
     assertThat(result.notes).isEqualTo("a note with some script")
   }
 
+  @Test
+  fun `does not HTML encode the resulting string`() {
+    val result = jacksonObjectMapper().readValue(
+      """
+        {"notes": "don't encode the single quote or these <>@&"}
+      """.trimIndent(),
+      MyRequestDto::class.java,
+    )
+
+    assertThat(result.notes).isEqualTo("don't encode the single quote or these <>@&")
+  }
+
   data class MyRequestDto(
     @field:JsonDeserialize(using = SanitizingStringDeserializer::class)
     val notes: String,


### PR DESCRIPTION
The API sanitises user-supplied string inputs to prevent possible XSS or other vulnerabilities. As a side effect of this, any special characters (such as `'`, `&`, etc.) get HTML-encoded before being sent to Delius. This then gets sanitised and encoded again, resulting in the incorrect display of the HTML-encoded result rather than the original string (e.g. `don't encode` becomes `don&#39;t encode`).

This can be mitigated by decoding the sanitised string within the `SanitizingStringDeserializer`, which returns the string to the intended untransformed state.