### PR TITLE
Fix sporadic test failures with course completion events

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/Randoms.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/Randoms.kt
@@ -19,3 +19,12 @@ fun randomLocalDateTime(): java.time.LocalDateTime = java.time.LocalDateTime.of(
 fun randomOffsetDateTime(): OffsetDateTime = OffsetDateTime.of(randomLocalDate(), randomLocalTime(), ZoneOffset.UTC)
 fun randomDuration(): Duration = Duration.ofHours(Long.random(0, 12)).plusMinutes(Long.random(0, 60))
 fun randomHourMinuteDuration(): HourMinuteDuration = HourMinuteDuration(randomDuration())
+
+fun LocalDate.withRandomTime(from: LocalTime = LocalTime.MIN, to: LocalTime = LocalTime.MAX): OffsetDateTime = OffsetDateTime.of(this, LocalTime.MIN, ZoneOffset.UTC).withRandomTime(from, to)
+
+fun OffsetDateTime.withRandomTime(from: LocalTime = LocalTime.MIN, to: LocalTime = LocalTime.MAX): OffsetDateTime {
+  val second = Int.random(from.toSecondOfDay(), to.toSecondOfDay())
+  val time = LocalTime.ofSecondOfDay(second.toLong()).atOffset(this.offset)
+
+  return this.toLocalDate().atTime(time)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/entity/EteCourseCompletionEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/entity/EteCourseCompletionEventEntityFactory.kt
@@ -9,6 +9,8 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompleti
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomLocalDate
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomOffsetDateTime
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.withRandomTime
+import java.time.LocalTime
 import java.util.UUID
 import kotlin.random.Random
 
@@ -25,7 +27,7 @@ fun EteCourseCompletionEventEntity.Companion.valid() = EteCourseCompletionEventE
   courseType = String.random(20),
   provider = String.random(5),
   status = EteCourseCompletionEventStatus.entries.random(),
-  completionDateTime = randomOffsetDateTime(),
+  completionDateTime = randomLocalDate().withRandomTime(from = LocalTime.of(12, 0), to = LocalTime.MAX),
   totalTimeMinutes = Random.nextLong(10, 100),
   attempts = 1,
   expectedTimeMinutes = Random.nextLong(30, 240),


### PR DESCRIPTION
Tests involving course completion events will sometimes randomly fail during the validation logic. This happens when the completion timestamp is early enough in the day that the amount of time to credit would put the start time before midnight.

This can be fixed by restricting the generated timestamp to be only in the afternoon, so that it is always possible to credit the required amount of time.