### PR TITLE
CPB-966: When crediting time for course completions, use the start time as 00:01 if it rolls into the previous day.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/EteMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/EteMappers.kt
@@ -33,7 +33,7 @@ class EteMappers(
 ) {
 
   companion object {
-    val APPOINTMENT_START_TIME: LocalTime = LocalTime.of(0, 0)
+    val DEFAULT_APPOINTMENT_START_TIME: LocalTime = LocalTime.of(0, 1)
   }
 
   fun toCreateAppointmentDto(
@@ -41,14 +41,15 @@ class EteMappers(
     courseCompletionEvent: EteCourseCompletionEventEntity,
   ): CreateAppointmentDto {
     val creditTime = courseCompletionResolution.creditTimeDetails!!
+    val appointmentTimesPair = calculateAppointmentTimes(creditTime.minutesToCredit, courseCompletionEvent)
     return CreateAppointmentDto(
       crn = courseCompletionResolution.crn!!,
       deliusEventNumber = creditTime.deliusEventNumber,
       allocationId = null,
       projectCode = creditTime.projectCode,
       date = creditTime.date,
-      startTime = calculateStartTime(creditTime.minutesToCredit, courseCompletionEvent),
-      endTime = courseCompletionEvent.completionDateTime.toLocalTimeEuropeLondon(),
+      startTime = appointmentTimesPair.first,
+      endTime = appointmentTimesPair.second,
       pickUpLocationCode = null,
       pickUpTime = null,
       contactOutcomeCode = creditTime.contactOutcomeCode,
@@ -68,13 +69,13 @@ class EteMappers(
     val creditTime = requireNotNull(courseCompletionResolution.creditTimeDetails) {
       "Missing credit time details"
     }
-
+    val appointmentTimesPair = calculateAppointmentTimes(creditTime.minutesToCredit, courseCompletionEvent)
     return UpdateAppointmentOutcomeDto(
       deliusId = existingAppointment.id,
       deliusVersionToUpdate = existingAppointment.version,
       date = courseCompletionResolution.creditTimeDetails.date,
-      startTime = calculateStartTime(creditTime.minutesToCredit, courseCompletionEvent),
-      endTime = courseCompletionEvent.completionDateTime.toLocalTimeEuropeLondon(),
+      startTime = appointmentTimesPair.first,
+      endTime = appointmentTimesPair.second,
       contactOutcomeCode = creditTime.contactOutcomeCode,
       attendanceData = createAttendanceData(),
       supervisorOfficerCode = existingAppointment.supervisorOfficerCode,
@@ -104,14 +105,14 @@ class EteMappers(
     }
   }.trimEnd()
 
-  private fun calculateStartTime(minutesToCredit: Long, courseCompletionEvent: EteCourseCompletionEventEntity): LocalTime {
+  private fun calculateAppointmentTimes(minutesToCredit: Long, courseCompletionEvent: EteCourseCompletionEventEntity): Pair<LocalTime, LocalTime> {
     val endTime = courseCompletionEvent.completionDateTime.toLocalTimeEuropeLondon()
     val creditLimit = ChronoUnit.MINUTES.between(LocalTime.MIDNIGHT, endTime)
-    if (minutesToCredit > creditLimit) {
-      error("Cannot credit more than $creditLimit minutes")
+    return if (minutesToCredit > creditLimit) {
+      Pair(DEFAULT_APPOINTMENT_START_TIME, DEFAULT_APPOINTMENT_START_TIME.plusMinutes(minutesToCredit))
+    } else {
+      Pair(endTime.minusMinutes(minutesToCredit), endTime)
     }
-
-    return endTime.minusMinutes(minutesToCredit)
   }
 
   fun createAttendanceData() = AttendanceDataDto(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/EteMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/EteMappersTest.kt
@@ -38,6 +38,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.listener.EducationCourse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.listener.EducationCourseMessageAttributes
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ContextService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.EteMappers
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.EteMappers.Companion.DEFAULT_APPOINTMENT_START_TIME
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -143,7 +144,7 @@ class EteMappersTest {
     }
 
     @ParameterizedTest
-    @ValueSource(longs = [30, 60, 120, 180, 240])
+    @ValueSource(longs = [30, 60, 90, 120, 180, 240])
     fun `should calculate start time as the number of credited minutes before the end time`(minutesToCredit: Long) {
       val result = mapper.toCreateAppointmentDto(
         courseCompletionResolution = baselineCourseCompletionResolution.copy(
@@ -178,17 +179,18 @@ class EteMappersTest {
     }
 
     @Test
-    fun `should error if crediting minutes that would roll into previous day`() {
-      assertThatThrownBy {
-        mapper.toCreateAppointmentDto(
-          courseCompletionResolution = baselineCourseCompletionResolution.copy(
-            creditTimeDetails = CourseCompletionCreditTimeDetailsDto.valid().copy(
-              minutesToCredit = (60L * 12L) + 16L,
-            ),
+    fun `should use start time as 00 01 and end time = start time + credit minutes, if crediting minutes would roll into previous day`() {
+      val minutesToCredit = (60L * 12L) + 16L
+      val result = mapper.toCreateAppointmentDto(
+        courseCompletionResolution = baselineCourseCompletionResolution.copy(
+          creditTimeDetails = CourseCompletionCreditTimeDetailsDto.valid().copy(
+            minutesToCredit = (60L * 12L) + 16L,
           ),
-          courseCompletionEvent = baselineCourseCompletionEvent,
-        )
-      }.hasMessage("Cannot credit more than 735 minutes")
+        ),
+        courseCompletionEvent = baselineCourseCompletionEvent,
+      )
+      assertThat(result.startTime).isEqualTo(DEFAULT_APPOINTMENT_START_TIME)
+      assertThat(result.endTime).isEqualTo(DEFAULT_APPOINTMENT_START_TIME.plusMinutes(minutesToCredit))
     }
 
     @ParameterizedTest
@@ -314,21 +316,23 @@ class EteMappersTest {
 
       val expectedStartTime = baselineCourseCompletionEvent.completionDateTime.toLocalTimeEuropeLondon().minusMinutes(minutesToCredit)
       assertThat(result.startTime).isEqualTo(expectedStartTime)
+      assertThat(result.endTime).isEqualTo(baselineCourseCompletionEvent.completionDateTime.toLocalTimeEuropeLondon())
     }
 
     @Test
-    fun `should error if crediting minutes that would roll into previous day`() {
-      assertThatThrownBy {
-        mapper.toUpdateAppointmentDto(
-          courseCompletionResolution = baselineCourseCompletionOutcome.copy(
-            creditTimeDetails = baselineCourseCompletionOutcome.creditTimeDetails!!.copy(
-              minutesToCredit = (60L * 12L) + 16L,
-            ),
+    fun `should use start time as 00 01 and end time = start time + credit minutes, if crediting minutes would roll into previous day`() {
+      val minutesToCredit = (60L * 12L) + 16L
+      val result = mapper.toUpdateAppointmentDto(
+        courseCompletionResolution = baselineCourseCompletionOutcome.copy(
+          creditTimeDetails = baselineCourseCompletionOutcome.creditTimeDetails!!.copy(
+            minutesToCredit = minutesToCredit,
           ),
-          courseCompletionEvent = baselineCourseCompletionEvent,
-          existingAppointment = baselineExistingAppointment,
-        )
-      }.hasMessage("Cannot credit more than 735 minutes")
+        ),
+        courseCompletionEvent = baselineCourseCompletionEvent,
+        existingAppointment = baselineExistingAppointment,
+      )
+      assertThat(result.startTime).isEqualTo(DEFAULT_APPOINTMENT_START_TIME)
+      assertThat(result.endTime).isEqualTo(DEFAULT_APPOINTMENT_START_TIME.plusMinutes(minutesToCredit))
     }
 
     @ParameterizedTest


### PR DESCRIPTION
When crediting time for course completions, use the start time as 00:01 if it rolls into the previous day.

If the course completion ended at 15:30, and the time credited was 60mins, then the start time should be 14:30.
If the course completion ended at 01:00, and the time credited was 90mins, then this would throw and error as it would attempt to roll in the previous day, now if this occurs:
start time will default to: 00:01 
end time = 01:31 (start time + 90mins)

