### PR TITLE
CPB-972: Add date to `CreateAdjustmentDto`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CreateAdjustmentDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CreateAdjustmentDto.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Min
+import java.time.LocalDate
 import java.util.UUID
 
 data class CreateAdjustmentDto(
@@ -12,6 +13,8 @@ data class CreateAdjustmentDto(
   @param:Schema(description = "Adjustment minutes, must be greater than 0")
   val minutes: Int,
   val adjustmentReasonId: UUID,
+  @param:Schema(description = "The date that should be recorded for the adjustment (e.g. the date of the appointment, or the current date).")
+  val adjustmentDate: LocalDate?,
 ) {
   companion object
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentEventEntityFactory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentEventEntityFactory.kt
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventEn
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventTriggerType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
-import java.time.LocalDate
 import java.time.OffsetDateTime
 
 @Service
@@ -15,7 +14,6 @@ class AdjustmentEventEntityFactory {
 
   fun buildAdjustmentCreated(
     details: AdjustmentCreatedEvent,
-    adjustmentDate: LocalDate,
   ) = AdjustmentEventEntity(
     id = details.id,
     eventType = AdjustmentEventType.CREATE,
@@ -29,7 +27,7 @@ class AdjustmentEventEntityFactory {
       CreateAdjustmentTypeDto.Negative -> AdjustmentEventAdjustmentType.NEGATIVE
     },
     adjustmentMinutes = details.createDto.minutes,
-    adjustmentDate = adjustmentDate,
+    adjustmentDate = details.adjustmentDate,
     adjustmentReason = details.reason,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentEventService.kt
@@ -8,8 +8,6 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventEn
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toAdjustmentCreatedDomainEvent
-import java.time.Clock
-import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -18,7 +16,6 @@ class AdjustmentEventService(
   private val adjustmentEventEntityRepository: AdjustmentEventEntityRepository,
   private val adjustmentEventEntityFactory: AdjustmentEventEntityFactory,
   private val domainEventService: DomainEventService,
-  private val clock: Clock,
 ) {
   fun getCreatedDomainEventDetails(id: UUID) = adjustmentEventEntityRepository.findByIdOrNullForDomainEventDetails(id, AdjustmentEventType.CREATE)?.toAdjustmentCreatedDomainEvent()
 
@@ -27,7 +24,7 @@ class AdjustmentEventService(
   @EventListener
   fun persistAndPublishCreateAdjustmentDomainEvent(event: AdjustmentCreatedEvent) {
     val persistedEvent = adjustmentEventEntityRepository.save(
-      adjustmentEventEntityFactory.buildAdjustmentCreated(event, LocalDate.now(clock)),
+      adjustmentEventEntityFactory.buildAdjustmentCreated(event),
     )
 
     domainEventService.publishOnTransactionCommit(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentService.kt
@@ -44,7 +44,7 @@ class AdjustmentService(
           deliusEventNumber = deliusEventNumber,
           reason = validatedAdjustment.reason,
           reference = adjustmentId,
-          dateOfAdjustment = LocalDate.now(clock),
+          dateOfAdjustment = validatedAdjustment.createAdjustment.adjustmentDate ?: LocalDate.now(clock),
         ),
       ),
     ).single().id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentService.kt
@@ -35,6 +35,7 @@ class AdjustmentService(
     val validatedAdjustment = adjustmentValidationService.validateCreate(createAdjustment, upwDetailsId, username)
     val adjustmentId = adjustmentIdGenerator.generateId()
     val (crn, deliusEventNumber) = upwDetailsId
+    val adjustmentDate = validatedAdjustment.createAdjustment.adjustmentDate ?: LocalDate.now(clock)
 
     val deliusAdjustmentId = communityPaybackAndDeliusClient.postAdjustments(
       username,
@@ -44,7 +45,7 @@ class AdjustmentService(
           deliusEventNumber = deliusEventNumber,
           reason = validatedAdjustment.reason,
           reference = adjustmentId,
-          dateOfAdjustment = validatedAdjustment.createAdjustment.adjustmentDate ?: LocalDate.now(clock),
+          dateOfAdjustment = adjustmentDate,
         ),
       ),
     ).single().id
@@ -61,6 +62,7 @@ class AdjustmentService(
           triggerType = AdjustmentEventTriggerType.APPOINTMENT_TASK,
           triggeredBy = validatedAdjustment.task.id.toString(),
         ),
+        adjustmentDate = adjustmentDate,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentValidationService.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentReasonE
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskEntityRepository
 import java.time.Duration
+import java.time.LocalDate
 
 @Suppress("ThrowsCount")
 @Service
@@ -40,6 +41,10 @@ class AdjustmentValidationService(
       val requestedDuration = Duration.ofMinutes(requestedMinutes.toLong())
       val maxMinutesDuration = Duration.ofMinutes(maxMinutesAllowed.toLong())
       badRequest("Requested adjustment of '${requestedDuration.formatForUser()}' exceeds the maximum allowed time '${maxMinutesDuration.formatForUser()}' for adjustment reason '${reason.name}'")
+    }
+
+    if (createAdjustment.adjustmentDate != null && createAdjustment.adjustmentDate.isAfter(LocalDate.now())) {
+      badRequest("Adjustment date must not be in the future")
     }
 
     validateMinutesToCredit(createAdjustment, unpaidWorkDetails)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/SpringEventPublisher.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentTaskTy
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentEventTrigger
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentEventTrigger
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -48,6 +49,7 @@ sealed interface CommunityPaybackSpringEvent {
     val deliusAdjustmentId: Long,
     val trigger: AdjustmentEventTrigger,
     val id: UUID,
+    val adjustmentDate: LocalDate,
   ) : CommunityPaybackSpringEvent {
     companion object
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/Randoms.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/Randoms.kt
@@ -14,6 +14,7 @@ fun Long.Companion.random(from: Long = 0, to: Long = Long.MAX_VALUE) = Random.ne
 fun String.Companion.random(length: Int = 50) = String(CharArray(length) { (('A'..'Z') + ('a'..'z') + ('0'..'9')).random() })
 
 fun randomLocalDate(): LocalDate = LocalDate.now().plusDays(Long.random(0, 2000))
+fun randomPastLocalDate(): LocalDate = LocalDate.now().minusDays(Long.random(0, 2000))
 fun randomLocalTime(): LocalTime = LocalTime.ofSecondOfDay(Long.random(0, 60 * 60 * 12))
 fun randomLocalDateTime(): java.time.LocalDateTime = java.time.LocalDateTime.of(randomLocalDate(), randomLocalTime())
 fun randomOffsetDateTime(): OffsetDateTime = OffsetDateTime.of(randomLocalDate(), randomLocalTime(), ZoneOffset.UTC)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/CreateAdjustmentDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/CreateAdjustmentDtoFactory.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentTypeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentReasonEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomPastLocalDate
 import java.util.UUID
 
 fun CreateAdjustmentDto.Companion.valid() = CreateAdjustmentDto(
@@ -13,6 +14,7 @@ fun CreateAdjustmentDto.Companion.valid() = CreateAdjustmentDto(
   type = CreateAdjustmentTypeDto.entries.random(),
   minutes = Int.random(1, 180),
   adjustmentReasonId = UUID.randomUUID(),
+  adjustmentDate = randomPastLocalDate(),
 )
 
 fun CreateAdjustmentDto.Companion.valid(ctx: ApplicationContext) = CreateAdjustmentDto.valid().copy(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/event/AdjustmentCreatedEventFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/event/AdjustmentCreatedEventFactory.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomPastLocalDate
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentEventTrigger
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.AdjustmentCreatedEvent
 import java.time.OffsetDateTime
@@ -19,6 +20,7 @@ fun AdjustmentCreatedEvent.Companion.valid() = AdjustmentCreatedEvent(
   deliusAdjustmentId = Long.random(),
   trigger = AdjustmentEventTrigger.valid(),
   id = UUID.randomUUID(),
+  adjustmentDate = randomPastLocalDate(),
 )
 
 fun AdjustmentEventTrigger.Companion.valid() = AdjustmentEventTrigger(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentEventEntityFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentEventEntityFactoryTest.kt
@@ -41,8 +41,8 @@ class AdjustmentEventEntityFactoryTest {
           triggeredBy = "task id",
         ),
         id = id,
+        adjustmentDate = LocalDate.of(1971, 8, 23),
       ),
-      adjustmentDate = LocalDate.of(1971, 8, 23),
     )
 
     assertThat(result.eventType).isEqualTo(AdjustmentEventType.CREATE)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentServiceTest.kt
@@ -115,6 +115,7 @@ class AdjustmentServiceTest {
               triggerType = AdjustmentEventTriggerType.APPOINTMENT_TASK,
               triggeredBy = appointmentTask.id.toString(),
             ),
+            adjustmentDate = dateOfAdjustment,
           ),
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentServiceTest.kt
@@ -66,10 +66,12 @@ class AdjustmentServiceTest {
       val reason = AdjustmentReasonEntity.valid().copy(maxMinutesAllowed = 50)
       val appointmentTask = AppointmentTaskEntity.valid()
       val id = UUID.randomUUID()
+      val dateOfAdjustment = LocalDate.now().minusDays(3)
 
       val request = CreateAdjustmentDto.valid().copy(
         adjustmentReasonId = reason.id,
         minutes = 50,
+        adjustmentDate = dateOfAdjustment,
       )
 
       val validatedAdjustment = AdjustmentValidationService.ValidatedCreateAdjustment(request, reason, appointmentTask)
@@ -88,7 +90,7 @@ class AdjustmentServiceTest {
               deliusEventNumber = EVENT_NUMBER,
               reason = reason,
               reference = id,
-              dateOfAdjustment = LocalDate.now(clock),
+              dateOfAdjustment = dateOfAdjustment,
             ),
           ),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentValidationServiceTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentValidationService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.OffenderService
+import java.time.LocalDate
 import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
@@ -133,6 +134,26 @@ class AdjustmentValidationServiceTest {
         )
       }.isInstanceOf(BadRequestException::class.java)
         .hasMessage("Credited minutes of '3 hours 0 minutes' exceeds the remaining time required of '2 hours 0 minutes'")
+    }
+
+    @Test
+    fun `If adjustment date is in the future then return bad request exception`() {
+      every { offenderService.ensureUnpaidWorkDetailsExist(any(), any()) } returns UnpaidWorkDetailsDto.valid().copy(
+        requiredMinutes = 100,
+        completedMinutes = 0,
+        adjustments = 0,
+      )
+
+      assertThatThrownBy {
+        service.validateCreate(
+          createAdjustment = baselineRequest.copy(
+            adjustmentDate = LocalDate.now().plusDays(1),
+          ),
+          upwDetailsId = UNPAID_WORK_DETAILS,
+          username = USERNAME,
+        )
+      }.isInstanceOf(BadRequestException::class.java)
+        .hasMessage("Adjustment date must not be in the future")
     }
 
     @Test


### PR DESCRIPTION
Travel time is handled differently across regional case admin teams: for example, some regions use the date of the appointment. As a result, the ability for users to supply an adjustment date when submitting travel time adjustments is now needed. To do this, the API needs to be able to accept this date.

This PR introduces `adjustmentDate` as a property to the `CreateAdjustmentDto` class, and updates the behaviour of the API to use this value if provided instead of using the current date. It also adds validation to make sure that this date is not in the future.