### PR TITLE
CPB-943: Prevent scheduling appointments earlier today

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/SchedulingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/SchedulingService.kt
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.scheduling.inter
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.scheduling.internal.toSchedulingExistingAppointments
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.scheduling.internal.toSchedulingRequirement
 import java.time.Clock
-import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
 /**
@@ -68,7 +68,7 @@ class SchedulingService(
     val requirement = communityPaybackAndDeliusClient.getUnpaidWorkRequirement(crn, eventNumber)
 
     val schedulingRequest = SchedulingRequest(
-      today = LocalDate.now(clock),
+      now = OffsetDateTime.now(clock),
       trigger = trigger,
       requirement = requirement.requirementProgress.toSchedulingRequirement(crn, eventNumber),
       allocations = requirement.allocations.toSchedulingAllocations(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/ScheduleCreator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/ScheduleCreator.kt
@@ -24,7 +24,7 @@ object ScheduleCreator {
     schedulingRequest: SchedulingRequest,
     remainingMinutesToBeScheduled: Duration,
   ): Schedule {
-    val today = schedulingRequest.today
+    val today = schedulingRequest.now.toLocalDate()
     val cutOffDate = today.plusDays(CUT_OFF_LIMIT_DAYS)
     val nonWorkingDates = schedulingRequest.nonWorkingDates
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/ScheduleCreator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/ScheduleCreator.kt
@@ -1,10 +1,13 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.service.scheduling.internal
 
 import org.slf4j.LoggerFactory
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.atFirstSecondOfDay
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.atLastSecondOfDay
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.minutesBetween
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.shortestOf
 import java.time.Duration
 import java.time.LocalDate
+import java.time.OffsetDateTime
 
 object ScheduleCreator {
   private val log = LoggerFactory.getLogger(this::class.java)
@@ -25,7 +28,7 @@ object ScheduleCreator {
     remainingMinutesToBeScheduled: Duration,
   ): Schedule {
     val today = schedulingRequest.now.toLocalDate()
-    val cutOffDate = today.plusDays(CUT_OFF_LIMIT_DAYS)
+    val cutOffDate = today.plusDays(CUT_OFF_LIMIT_DAYS).atLastSecondOfDay()
     val nonWorkingDates = schedulingRequest.nonWorkingDates
 
     val ctx = SchedulingContext(
@@ -34,17 +37,17 @@ object ScheduleCreator {
     )
 
     val startingDay = nonWorkingDates.nextWorkingDayAsOf(today.minusDays(1))
-    var dayBeingConsidered = startingDay
+    var dayBeingConsidered = if (startingDay == today) schedulingRequest.now else startingDay.atFirstSecondOfDay()
     while (
       ctx.moreAppointmentsRequired() &&
       ctx.getAllocations().anyPotentialAppointmentsOnOrAfter(
         alreadyScheduledAppointments = ctx.getScheduledAppointments(),
-        onOrAfter = dayBeingConsidered,
+        onOrAfter = dayBeingConsidered.toLocalDate(),
       )
     ) {
       scheduleDay(ctx, dayBeingConsidered)
 
-      dayBeingConsidered = nonWorkingDates.nextWorkingDayAsOf(dayBeingConsidered)
+      dayBeingConsidered = nonWorkingDates.nextWorkingDayAsOf(dayBeingConsidered.toLocalDate()).atFirstSecondOfDay()
       if (dayBeingConsidered.isAfter(cutOffDate)) {
         log.warn("Scheduling is still being applied after $CUT_OFF_LIMIT_DAYS days - this shouldn't really happen! We won't attempt to schedule anything else.")
         break
@@ -56,15 +59,15 @@ object ScheduleCreator {
 
   private fun scheduleDay(
     ctx: SchedulingContext,
-    day: LocalDate,
+    day: OffsetDateTime,
   ) {
     log.trace("Scheduling day {} ({}) with a remaining short fall of {}", day, day.dayOfWeek, ctx.getRemainingMinutesToBeScheduled())
 
-    if (!ctx.getAllocations().anyPotentialAppointmentsOn(day, ctx.getScheduledAppointments())) {
+    if (!ctx.getAllocations().anyPotentialAppointmentsOn(day.toLocalDate(), ctx.getScheduledAppointments())) {
       return
     }
 
-    val existingAppointmentsToday = ctx.getExistingAppointments().filter { it.date == day }
+    val existingAppointmentsToday = ctx.getExistingAppointments().filter { it.date == day.toLocalDate() }
     /*
      If scheduling is triggered by an appointment change and appointment(s) already exists
      on a day we want to schedule an appointment on, we retain those existing appointments
@@ -79,13 +82,13 @@ object ScheduleCreator {
         ctx.addForcedRetentionAppointment(it)
       }
     } else {
-      val allocationsEarliestTimeFirst = ctx.getAllocations().allocations.sortedBy { it.startTime }
+      val allocationsEarliestTimeFirst = ctx.getAllocations().allocations.sortedBy { it.startTime }.filter { !it.startTime.isBefore(day.toLocalTime()) }
       allocationsEarliestTimeFirst.forEach { allocation ->
         if (
           ctx.moreAppointmentsRequired() &&
-          allocation.nextPotentialAppointmentDateOnOrAfter(day, ctx.getScheduledAppointments()) == day
+          allocation.nextPotentialAppointmentDateOnOrAfter(day.toLocalDate(), ctx.getScheduledAppointments()) == day.toLocalDate()
         ) {
-          scheduleAppointment(ctx, allocation, day)
+          scheduleAppointment(ctx, allocation, day.toLocalDate())
         }
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/SchedulePlanner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/SchedulePlanner.kt
@@ -8,7 +8,7 @@ object SchedulePlanner {
     schedulingRequest: SchedulingRequest,
     schedule: Schedule,
   ): SchedulePlan {
-    val today = schedulingRequest.today
+    val today = schedulingRequest.now.toLocalDate()
     val existingAppointments = schedulingRequest.existingAppointments.appointments
 
     val toCreate = schedule.requiredAppointmentsAsOfToday

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/Scheduler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/Scheduler.kt
@@ -32,7 +32,7 @@ class Scheduler {
     request: SchedulingRequest,
   ): SchedulerOutcome {
     val remainingMinutesAsOfToday = RequirementRemainingMinutesCalculator.calculateRemainingMinutesAsOfToday(
-      request.today,
+      request.now.toLocalDate(),
       request.requirement,
       request.existingAppointments,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/SchedulingDataModels.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/SchedulingDataModels.kt
@@ -4,11 +4,12 @@ import java.time.DayOfWeek
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
+import java.time.OffsetDateTime
 import java.util.UUID
 
 data class SchedulingRequest(
   val id: UUID = UUID.randomUUID(),
-  val today: LocalDate,
+  val now: OffsetDateTime,
   val trigger: SchedulingTrigger,
   val requirement: SchedulingRequirement,
   val allocations: SchedulingAllocations,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/SchedulingRenderer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/internal/SchedulingRenderer.kt
@@ -14,7 +14,7 @@ object SchedulingRenderer {
     request: SchedulingRequest,
     remainingMinutesAsOfToday: Duration,
   ): String {
-    val today = request.today
+    val today = request.now.toLocalDate()
     val trigger = request.trigger
 
     return buildString {
@@ -53,7 +53,7 @@ object SchedulingRenderer {
       append("* Non Working Dates as of Scheduling Date: ")
       appendLine(
         request.nonWorkingDates.dates
-          .filter { it.onOrAfter(request.today) }
+          .filter { it.onOrAfter(request.now.toLocalDate()) }
           .sorted(),
       )
     }
@@ -74,7 +74,7 @@ object SchedulingRenderer {
     schedule: Schedule,
     plan: SchedulePlan,
   ): String {
-    val today = request.today
+    val today = request.now.toLocalDate()
 
     return buildString {
       append(requestSummary("Schedule and Plan", request, remainingMinutesAsOfToday))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/scheduling/SchedulingRequestFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/scheduling/SchedulingRequestFactory.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.scheduling
 
-import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomLocalDate
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomOffsetDateTime
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.scheduling.internal.SchedulingAllocations
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.scheduling.internal.SchedulingExistingAppointments
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.scheduling.internal.SchedulingNonWorkingDates
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.scheduling.inter
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.scheduling.internal.SchedulingTrigger
 
 fun SchedulingRequest.Companion.valid() = SchedulingRequest(
-  today = randomLocalDate(),
+  now = randomOffsetDateTime(),
   trigger = SchedulingTrigger.valid(),
   requirement = SchedulingRequirement.valid(),
   allocations = SchedulingAllocations(emptyList()),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/scheduling/scenarios/SchedulingGuaranteesFutureApptsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/scheduling/scenarios/SchedulingGuaranteesFutureApptsTest.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.scheduling.scenarios
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.scheduling.internal.SchedulingFrequency.WEEKLY
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.scheduling.internal.SchedulingTriggerType
+import java.time.DayOfWeek.MONDAY
+import java.time.DayOfWeek.TUESDAY
+
+class SchedulingGuaranteesFutureApptsTest {
+  @ParameterizedTest
+  @ArgumentsSource(NonAllocationChangeTriggerTypes::class)
+  fun `FUTURE-APPTS-01 If scheduling an appointment today would create it in the past, then it should be skipped`(triggerType: SchedulingTriggerType) {
+    schedulingScenario {
+      scenarioId("FUTURE-APPTS-01")
+      given {
+        requirementHoursAre(8)
+        todayIs(MONDAY)
+        timeIs(10, 30)
+        projectExistsWithCode("PROJ1")
+        projectExistsWithCode("PROJ2")
+        schedulingTriggerTypeIs(triggerType)
+
+        allocation {
+          alias("ALLOC1")
+          projectCode("PROJ1")
+          frequency(WEEKLY)
+          onWeekDay(MONDAY)
+          from("10:00")
+          until("18:00")
+        }
+
+        allocation {
+          alias("ALLOC2")
+          projectCode("PROJ2")
+          frequency(WEEKLY)
+          onWeekDay(TUESDAY)
+          from("16:00")
+          until("20:00")
+        }
+      }
+
+      then {
+        shouldCreateAppointments {
+          appointment {
+            projectCode("PROJ2")
+            allocation("ALLOC2")
+            todayWithOffsetDays(1)
+            from("16:00")
+            until("20:00")
+          }
+
+          appointment {
+            projectCode("PROJ1")
+            allocation("ALLOC1")
+            todayWithOffsetDays(7)
+            from("10:00")
+            until("14:00")
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/scheduling/scenarios/SchedulingScenarioDsl.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/scheduling/scenarios/SchedulingScenarioDsl.kt
@@ -26,6 +26,7 @@ import java.time.DayOfWeek
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
+import java.time.OffsetDateTime
 import java.time.temporal.TemporalAdjusters
 
 @DslMarker
@@ -33,7 +34,7 @@ annotation class SchedulingScenarioDslMarker
 
 @SchedulingScenarioDslMarker
 class SchedulingScenarioBuilder {
-  private var today: LocalDate = LocalDate.now()
+  private var now: OffsetDateTime = OffsetDateTime.now()
   private var requirementLength: Duration? = null
   private val allocations = mutableListOf<SchedulingAllocation>()
   private val existingAppointments = mutableListOf<SchedulingExistingAppointment>()
@@ -52,7 +53,7 @@ class SchedulingScenarioBuilder {
 
   fun then(init: ThenContext.() -> Unit) {
     val request = SchedulingRequest.valid().copy(
-      today = today,
+      now = now,
       trigger = SchedulingTrigger(
         type = triggerType ?: error("Trigger type must be defined"),
         description = "Unit Test: $scenarioId",
@@ -70,7 +71,7 @@ class SchedulingScenarioBuilder {
   @SchedulingScenarioDslMarker
   inner class GivenContext {
     fun todayIs(dayOfWeek: DayOfWeek) {
-      this@SchedulingScenarioBuilder.today = LocalDate.now().with(TemporalAdjusters.nextOrSame(dayOfWeek))
+      this@SchedulingScenarioBuilder.now = OffsetDateTime.now().with(TemporalAdjusters.nextOrSame(dayOfWeek))
     }
 
     fun projectExistsWithCode(code: String, init: ProjectBuilder.() -> Unit = {}) {
@@ -83,7 +84,7 @@ class SchedulingScenarioBuilder {
       val builder = AllocationBuilder()
       builder.apply(init)
       this@SchedulingScenarioBuilder.allocations.add(
-        builder.build(this@SchedulingScenarioBuilder.today, this@SchedulingScenarioBuilder.projects),
+        builder.build(this@SchedulingScenarioBuilder.now, this@SchedulingScenarioBuilder.projects),
       )
     }
 
@@ -92,7 +93,7 @@ class SchedulingScenarioBuilder {
       builder.apply(init)
       this@SchedulingScenarioBuilder.existingAppointments.add(
         builder.build(
-          this@SchedulingScenarioBuilder.today,
+          this@SchedulingScenarioBuilder.now,
           this@SchedulingScenarioBuilder.allocations,
         ),
       )
@@ -100,7 +101,7 @@ class SchedulingScenarioBuilder {
 
     fun nonWorkingDate(offsetDays: Int) {
       this@SchedulingScenarioBuilder.nonWorkingDates.add(
-        this@SchedulingScenarioBuilder.today.plusDays(offsetDays.toLong()),
+        this@SchedulingScenarioBuilder.now.toLocalDate().plusDays(offsetDays.toLong()),
       )
     }
 
@@ -141,7 +142,7 @@ class SchedulingScenarioBuilder {
 
       val insufficient = result as SchedulerOutcome.ExistingAppointmentsInsufficient
       val expectedActions = ExpectedActionsBuilder(
-        this@SchedulingScenarioBuilder.today,
+        this@SchedulingScenarioBuilder.now,
         this@SchedulingScenarioBuilder.projects,
         request.allocations.allocations,
       )
@@ -215,7 +216,7 @@ class AllocationBuilder {
     endDate = days
   }
 
-  fun build(today: LocalDate, projects: Map<String, SchedulingProject>): SchedulingAllocation {
+  fun build(now: OffsetDateTime, projects: Map<String, SchedulingProject>): SchedulingAllocation {
     val project = projects[projectCode] ?: error("Project $projectCode not found")
     return SchedulingAllocation.valid().copy(
       id = alias.hashCode().toLong(),
@@ -223,8 +224,8 @@ class AllocationBuilder {
       project = project,
       frequency = frequency,
       dayOfWeek = dayOfWeek,
-      startDateInclusive = startDate?.let { today.plusDays(it.toLong()) } ?: today,
-      endDateInclusive = endDate?.let { today.plusDays(it.toLong()) },
+      startDateInclusive = startDate?.let { now.toLocalDate().plusDays(it.toLong()) } ?: now.toLocalDate(),
+      endDateInclusive = endDate?.let { now.toLocalDate().plusDays(it.toLong()) },
       startTime = startTime ?: error("Start time must be specified for allocation $alias"),
       endTime = endTime ?: error("End time must be specified for allocation $alias"),
     )
@@ -274,7 +275,7 @@ class AppointmentBuilder {
     creditedTime = null
   }
 
-  fun build(today: LocalDate, allocations: List<SchedulingAllocation>): SchedulingExistingAppointment {
+  fun build(now: OffsetDateTime, allocations: List<SchedulingAllocation>): SchedulingExistingAppointment {
     val allocation = allocationAlias?.let { id ->
       allocations.find { it.id == id.hashCode().toLong() }
     }
@@ -282,7 +283,7 @@ class AppointmentBuilder {
     return SchedulingExistingAppointment(
       id = Long.random(),
       projectCode = projectCode ?: error("Project code must be specified for appointment"),
-      date = today.plusDays(date.toLong()),
+      date = now.toLocalDate().plusDays(date.toLong()),
       startTime = startTime ?: error("Start time must be specified for appointment"),
       endTime = endTime ?: error("End time must be specified for appointment"),
       hasOutcome = hasOutcome,
@@ -293,7 +294,7 @@ class AppointmentBuilder {
 }
 
 class ExpectedActionsBuilder(
-  private val today: LocalDate,
+  private val now: OffsetDateTime,
   private val projects: Map<String, SchedulingProject>,
   private val allocations: List<SchedulingAllocation>,
 ) {
@@ -302,7 +303,7 @@ class ExpectedActionsBuilder(
   fun appointment(init: ExpectedAppointmentBuilder.() -> Unit) {
     val builder = ExpectedAppointmentBuilder()
     builder.apply(init)
-    actions.add(builder.build(today, projects, allocations))
+    actions.add(builder.build(now, projects, allocations))
   }
 }
 
@@ -332,14 +333,14 @@ class ExpectedAppointmentBuilder {
     endTime = LocalTime.parse(time)
   }
 
-  fun build(today: LocalDate, projects: Map<String, SchedulingProject>, allocations: List<SchedulingAllocation>): SchedulingAction.CreateAppointment {
+  fun build(now: OffsetDateTime, projects: Map<String, SchedulingProject>, allocations: List<SchedulingAllocation>): SchedulingAction.CreateAppointment {
     val project = projects[projectCode] ?: error("Project $projectCode not found")
     val allocation = allocations.find { it.id == allocationAlias.hashCode().toLong() }
       ?: error("Allocation $allocationAlias not found")
 
     return SchedulingAction.CreateAppointment(
       toCreate = SchedulingRequiredAppointment(
-        date = today.plusDays(offsetDays.toLong()),
+        date = now.toLocalDate().plusDays(offsetDays.toLong()),
         startTime = startTime ?: error("Start time must be specified for appointment"),
         endTime = endTime ?: error("End time must be specified for appointment"),
         project = project,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/scheduling/scenarios/SchedulingScenarioDsl.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/scheduling/scenarios/SchedulingScenarioDsl.kt
@@ -27,6 +27,7 @@ import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalAdjusters
 
 @DslMarker
@@ -34,7 +35,7 @@ annotation class SchedulingScenarioDslMarker
 
 @SchedulingScenarioDslMarker
 class SchedulingScenarioBuilder {
-  private var now: OffsetDateTime = OffsetDateTime.now()
+  private var now: OffsetDateTime = OffsetDateTime.now().truncatedTo(ChronoUnit.DAYS)
   private var requirementLength: Duration? = null
   private val allocations = mutableListOf<SchedulingAllocation>()
   private val existingAppointments = mutableListOf<SchedulingExistingAppointment>()
@@ -71,7 +72,11 @@ class SchedulingScenarioBuilder {
   @SchedulingScenarioDslMarker
   inner class GivenContext {
     fun todayIs(dayOfWeek: DayOfWeek) {
-      this@SchedulingScenarioBuilder.now = OffsetDateTime.now().with(TemporalAdjusters.nextOrSame(dayOfWeek))
+      this@SchedulingScenarioBuilder.now = this@SchedulingScenarioBuilder.now.with(TemporalAdjusters.nextOrSame(dayOfWeek))
+    }
+
+    fun timeIs(hour: Int, minute: Int) {
+      this@SchedulingScenarioBuilder.now = this@SchedulingScenarioBuilder.now.withHour(hour).withMinute(minute)
     }
 
     fun projectExistsWithCode(code: String, init: ProjectBuilder.() -> Unit = {}) {


### PR DESCRIPTION
In certain situations, it's possible for the scheduler to create an appointment for today that's already started. In this case, scheduling fails as a past appointment requires an outcome.

To prevent this, this changes the scheduler so that if the first day being considered for scheduling is today, it takes the time into account, and filters out any potential allocations that would result in a past appointment.

For all other days under consideration, as the full day is available, the behaviour is unchanged.