### PR TITLE
CPB-816: Tag `POST /admin/course-completions/{id}/resolution` endpoint as supporting idempotency

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminCourseCompletionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminCourseCompletionController.kt
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.atFirstSecondOfDay
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.atLastSecondOfDay
+import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.SupportsIdempotencyKey
 import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionRecommendationDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionDto
@@ -133,6 +134,7 @@ class AdminCourseCompletionController(val eteService: EteService) {
       ApiResponse(responseCode = "404", description = "Course completion not found", content = [Content(schema = Schema(implementation = ErrorResponse::class))]),
     ],
   )
+  @SupportsIdempotencyKey
   fun postCourseCompletionResolution(
     @PathVariable id: UUID,
     @Valid @RequestBody courseCompletionResolution: CourseCompletionResolutionDto,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminUpwDetailsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminUpwDetailsController.kt
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
@@ -12,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.SupportsIdempotencyKey
 import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UnpaidWorkDetailsIdDto
@@ -78,7 +78,7 @@ class AdminUpwDetailsController(
       ),
     ],
   )
-  @Tag(name = "supportsIdempotencyKey")
+  @SupportsIdempotencyKey
   fun createAdjustment(
     @PathVariable crn: String,
     @PathVariable deliusEventNumber: Int,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/internal/SupportsIdempotencyKey.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/internal/SupportsIdempotencyKey.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal
+
+import io.swagger.v3.oas.annotations.tags.Tag
+
+@Tag(name = "supportsIdempotencyKey")
+annotation class SupportsIdempotencyKey


### PR DESCRIPTION
This endpoint already checks whether the submitted resolution is the same as an already submitted one, and the `IdempotencyFilter` automatically applies whenever the correct header is submitted, so no logical changes need to be applied to officially support idempotency.