### PR TITLE
CPB-987: Prevent adjustments being created with a date before the sentence date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AdjustmentValidationService.kt
@@ -47,6 +47,10 @@ class AdjustmentValidationService(
       badRequest("Adjustment date must not be in the future")
     }
 
+    if (createAdjustment.adjustmentDate != null && createAdjustment.adjustmentDate.isBefore(unpaidWorkDetails.sentenceDate)) {
+      badRequest("Adjustment date must not be before the sentence date")
+    }
+
     validateMinutesToCredit(createAdjustment, unpaidWorkDetails)
 
     return ValidatedCreateAdjustment(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDCaseDetailFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDCaseDetailFactory.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDMainOffence
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDUpwDetails
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomLocalDate
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomPastLocalDate
 import kotlin.random.Random
 
 fun NDCaseDetailsSummary.Companion.valid() = NDCaseDetailsSummary(
@@ -16,7 +17,7 @@ fun NDCaseDetailsSummary.Companion.valid() = NDCaseDetailsSummary(
 
 fun NDUpwDetails.Companion.valid() = NDUpwDetails(
   eventNumber = Random.nextInt(1, 6),
-  sentenceDate = randomLocalDate(),
+  sentenceDate = randomPastLocalDate(),
   requiredMinutes = Random.nextLong(100, 301),
   completedMinutes = Random.nextLong(150, 250),
   adjustments = Random.nextLong(25, 51),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/CaseDetailsSummaryDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/CaseDetailsSummaryDtoFactory.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UnpaidWorkDetailsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomLocalDate
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomPastLocalDate
 import kotlin.Long
 
 fun CaseDetailsSummaryDto.Companion.valid() = CaseDetailsSummaryDto(
@@ -18,7 +19,7 @@ fun CaseDetailsSummaryDto.Companion.valid() = CaseDetailsSummaryDto(
 
 fun UnpaidWorkDetailsDto.Companion.valid() = UnpaidWorkDetailsDto(
   eventNumber = Int.random(),
-  sentenceDate = randomLocalDate(),
+  sentenceDate = randomPastLocalDate(),
   requiredMinutes = Long.random(3600, 7200),
   completedMinutes = Long.random(0, 3600),
   adjustments = Long.random(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/CreateAdjustmentDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/CreateAdjustmentDtoFactory.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAdjustmentTypeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentReasonEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
-import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomPastLocalDate
+import java.time.LocalDate
 import java.util.UUID
 
 fun CreateAdjustmentDto.Companion.valid() = CreateAdjustmentDto(
@@ -14,7 +14,7 @@ fun CreateAdjustmentDto.Companion.valid() = CreateAdjustmentDto(
   type = CreateAdjustmentTypeDto.entries.random(),
   minutes = Int.random(1, 180),
   adjustmentReasonId = UUID.randomUUID(),
-  adjustmentDate = randomPastLocalDate(),
+  adjustmentDate = LocalDate.now(),
 )
 
 fun CreateAdjustmentDto.Companion.valid(ctx: ApplicationContext) = CreateAdjustmentDto.valid().copy(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AdjustmentValidationServiceTest.kt
@@ -157,6 +157,25 @@ class AdjustmentValidationServiceTest {
     }
 
     @Test
+    fun `If adjustment date is before the sentence date then return bad request exception`() {
+      every { offenderService.ensureUnpaidWorkDetailsExist(any(), any()) } returns UnpaidWorkDetailsDto.valid().copy(
+        requiredMinutes = 100,
+        completedMinutes = 0,
+        adjustments = 0,
+        sentenceDate = LocalDate.now().minusMonths(1),
+      )
+
+      assertThatThrownBy {
+        service.validateCreate(
+          createAdjustment = baselineRequest.copy(adjustmentDate = LocalDate.now().minusMonths(1).minusDays(1)),
+          upwDetailsId = UNPAID_WORK_DETAILS,
+          username = USERNAME,
+        )
+      }.isInstanceOf(BadRequestException::class.java)
+        .hasMessage("Adjustment date must not be before the sentence date")
+    }
+
+    @Test
     fun success() {
       every { offenderService.ensureUnpaidWorkDetailsExist(any(), any()) } returns UnpaidWorkDetailsDto.valid().copy(
         requiredMinutes = 100,


### PR DESCRIPTION
Trying to create an adjustment in NDelius when the adjustment date is before the sentence date fails with a validation error.

Currently the API does not treat this situation as an error. This PR updates the validation logic for creating adjustments to match the behaviour in NDelius in this respect.