### PR TITLE
CPB-992: Retry logic for SchedulingDomainEventHandler, to avoid race conditions.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/RetryConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/RetryConfiguration.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.retry.annotation.EnableRetry
+
+@Configuration
+@EnableRetry
+class RetryConfiguration

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/SchedulingDomainEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/scheduling/SchedulingDomainEventHandler.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.service.scheduling
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentEventType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
@@ -36,6 +38,11 @@ class SchedulingDomainEventHandler(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
+  @Retryable(
+    retryFor = [IllegalStateException::class],
+    maxAttempts = 3,
+    backoff = Backoff(delay = 500),
+  )
   fun handleAppointmentEvent(
     eventId: UUID,
     maxProcessingTime: Duration,
@@ -60,6 +67,11 @@ class SchedulingDomainEventHandler(
     appointmentEventService.recordSchedulingRan(eventId, schedulingId)
   }
 
+  @Retryable(
+    retryFor = [IllegalStateException::class],
+    maxAttempts = 3,
+    backoff = Backoff(delay = 500),
+  )
   fun handleAdjustmentEvent(
     eventId: UUID,
     maxProcessingTime: Duration,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/util/MockSentryService.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/util/MockSentryService.kt
@@ -37,7 +37,7 @@ class MockSentryService : SentryService {
 
   fun assertExceptionRaisedWithMessage(regex: String) {
     await()
-      .atMost(1, TimeUnit.SECONDS)
+      .atMost(5, TimeUnit.SECONDS)
       .untilAsserted {
         assertThat(capturedExceptions)
           .anySatisfy {


### PR DESCRIPTION
On Dev, the DLQ gets messages for appointment updates - this could be because of:

Database Replication Lag: In a multi-node environment with a primary-replica database setup, the transaction commits on the primary node, but there can be a millisecond-level delay before the data is visible on the read-replica. If the SQS listener (running on a different instance) attempts to read from a replica before synchronisation is complete, it will fail to find the record.

Visibility Timing: Even in single-node setups, there can be a race condition where the message is received and processed by the consumer faster than the database can finalise the visibility of the new row across all concurrent sessions.

On re-driving the messages on SQS - they go through - therefore we require retry logic