### PR TITLE
CPB-993: Change course completion search endpoint to specify how failures should be filtered

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminCourseCompletionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminCourseCompletionController.kt
@@ -28,8 +28,8 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.notF
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionRecommendationDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionEventDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionEventStatusDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionResolutionStatusDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionShowCourseFailuresDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.EteService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDate
@@ -76,11 +76,19 @@ class AdminCourseCompletionController(val eteService: EteService) {
     @Parameter(description = "If not defined both resolved and unresolved completions will be returned")
     resolutionStatus: EteCourseCompletionResolutionStatusDto?,
     @RequestParam
-    @Parameter(description = "Filter results by course completion outcome (either 'Passed' or 'Failed'). If not provided, defaults to 'Passed'.")
-    status: EteCourseCompletionEventStatusDto?,
-    @RequestParam
-    @Parameter(description = "Filter results by the attempt number if provided.")
-    attempts: Int?,
+    @Parameter(
+      description = """
+        If present, determines when failed course completions are shown:
+        
+        - `No`: Failed course completions will not be shown.
+        - `Yes`: All course completions will be shown, including failed ones.
+        - `OnlyWhenMaxAttemptsReached`: Failed course completions are only shown when it was the last allowed attempt
+          at the course in Community Campus.
+        
+        If not present, the default value is `No`.
+      """,
+    )
+    showCourseFailures: EteCourseCompletionShowCourseFailuresDto?,
     @RequestParam
     @Parameter(description = "Filter by the external reference supplied by Community Campus.")
     externalReference: String?,
@@ -95,8 +103,7 @@ class AdminCourseCompletionController(val eteService: EteService) {
     pduId,
     office,
     resolutionStatus = resolutionStatus,
-    completionStatus = status ?: EteCourseCompletionEventStatusDto.Passed,
-    attempts,
+    showCourseFailures = showCourseFailures,
     externalReference,
     dateFrom?.atFirstSecondOfDay(),
     dateTo?.atLastSecondOfDay(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CourseCompletionEventDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CourseCompletionEventDto.kt
@@ -74,3 +74,9 @@ enum class EteCourseCompletionResolutionStatusDto {
   Resolved,
   Unresolved,
 }
+
+enum class EteCourseCompletionShowCourseFailuresDto {
+  No,
+  Yes,
+  OnlyWhenMaxAttemptsReached,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionEventEntityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionEventEntityRepository.kt
@@ -15,12 +15,11 @@ interface EteCourseCompletionEventEntityRepository : JpaRepository<EteCourseComp
     """
     SELECT e FROM EteCourseCompletionEventEntity e
     LEFT JOIN e.resolution r
-    WHERE e.status = :completionStatus
-    AND e.pdu.providerCode = :providerCode 
+    WHERE e.pdu.providerCode = :providerCode 
     AND ((CAST(:pduId AS uuid) IS NULL) OR (e.pdu.id = :pduId))
     AND (:officesCount = 0 OR e.office IN :offices)
     AND ((:#{#resolutionStatus.name()} = 'ANY') OR (:#{#resolutionStatus.name()} = 'RESOLVED' AND r IS NOT NULL) OR (:#{#resolutionStatus.name()} = 'UNRESOLVED' AND r IS NULL))
-    AND (:attempts IS NULL OR e.attempts = :attempts)
+    AND (e.status = 'PASSED' OR (:#{#courseFailures.name()} = 'SHOW_ALL') OR (:#{#courseFailures.name()} = 'SHOW_ONLY_WHEN_MAX_ATTEMPTS_REACHED' AND MOD(e.attempts, 3) = 0))
     AND (:externalReference IS NULL OR e.externalReference = :externalReference)
     AND (cast(:fromDate as timestamp) IS NULL OR e.completionDateTime >= :fromDate)
     AND (cast(:toDate as timestamp) IS NULL OR e.completionDateTime <= :toDate)
@@ -34,8 +33,7 @@ interface EteCourseCompletionEventEntityRepository : JpaRepository<EteCourseComp
     officesCount: Int,
     offices: List<String>,
     resolutionStatus: ResolutionStatus,
-    completionStatus: EteCourseCompletionEventStatus,
-    attempts: Int?,
+    courseFailures: CourseFailureFilter,
     externalReference: String?,
     fromDate: OffsetDateTime?,
     toDate: OffsetDateTime?,
@@ -61,5 +59,11 @@ interface EteCourseCompletionEventEntityRepository : JpaRepository<EteCourseComp
     ANY,
     RESOLVED,
     UNRESOLVED,
+  }
+
+  enum class CourseFailureFilter {
+    HIDE,
+    SHOW_ALL,
+    SHOW_ONLY_WHEN_MAX_ATTEMPTS_REACHED,
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
@@ -12,14 +12,14 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionReso
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionTypeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionEventDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionEventStatusDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionResolutionStatusDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionShowCourseFailuresDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEventTriggerType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository.CourseFailureFilter
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository.ResolutionStatus
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventResolutionRepository
-import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventStatus
 import uk.gov.justice.digital.hmpps.communitypaybackapi.listener.EducationCourseCompletionMessage
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CourseCompletionProcessedEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent.CourseCompletionReceivedEvent
@@ -75,8 +75,7 @@ class EteService(
     pduId: UUID?,
     offices: List<String>?,
     resolutionStatus: EteCourseCompletionResolutionStatusDto?,
-    completionStatus: EteCourseCompletionEventStatusDto,
-    attempts: Int?,
+    showCourseFailures: EteCourseCompletionShowCourseFailuresDto?,
     externalReference: String?,
     fromDate: OffsetDateTime?,
     toDate: OffsetDateTime?,
@@ -96,11 +95,11 @@ class EteService(
         EteCourseCompletionResolutionStatusDto.Unresolved -> ResolutionStatus.UNRESOLVED
         null -> ResolutionStatus.ANY
       },
-      completionStatus = when (completionStatus) {
-        EteCourseCompletionEventStatusDto.Passed -> EteCourseCompletionEventStatus.PASSED
-        EteCourseCompletionEventStatusDto.Failed -> EteCourseCompletionEventStatus.FAILED
+      courseFailures = when (showCourseFailures) {
+        null, EteCourseCompletionShowCourseFailuresDto.No -> CourseFailureFilter.HIDE
+        EteCourseCompletionShowCourseFailuresDto.Yes -> CourseFailureFilter.SHOW_ALL
+        EteCourseCompletionShowCourseFailuresDto.OnlyWhenMaxAttemptsReached -> CourseFailureFilter.SHOW_ONLY_WHEN_MAX_ATTEMPTS_REACHED
       },
-      attempts,
       externalReference,
       fromDate,
       toDate,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
@@ -201,14 +201,14 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
     }
 
     @Test
-    fun `should exclude failed completions when completion status of 'passed' requested`() {
+    fun `should exclude failed completions when show course failures is not requested`() {
       val pdu = communityCampusPduEntityRepository.findByNameIgnoreCase("Dyfed Powys")!!
 
       val completionPassed = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu))
       eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(pdu = pdu))
 
       val pagedCourseCompletions = webTestClient.get()
-        .uri("/admin/providers/${pdu.providerCode}/course-completions?status=Passed")
+        .uri("/admin/providers/${pdu.providerCode}/course-completions?showCourseFailures=No")
         .addAdminUiAuthHeader()
         .exchange()
         .expectStatus()
@@ -219,21 +219,43 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
     }
 
     @Test
-    fun `should exclude passed completions when completion status of 'failed' requested`() {
+    fun `should show all completions when show course failures requested`() {
       val pdu = communityCampusPduEntityRepository.findByNameIgnoreCase("Dyfed Powys")!!
 
-      eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu))
-      val completionFailed = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(pdu = pdu))
+      val completionPassed = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu))
+      val completionFailed1 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(pdu = pdu, attempts = 1))
+      val completionFailed2 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(pdu = pdu, attempts = 2))
+      val completionFailed3 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(pdu = pdu, attempts = 3))
 
       val pagedCourseCompletions = webTestClient.get()
-        .uri("/admin/providers/${pdu.providerCode}/course-completions?status=Failed")
+        .uri("/admin/providers/${pdu.providerCode}/course-completions?showCourseFailures=Yes")
         .addAdminUiAuthHeader()
         .exchange()
         .expectStatus()
         .isOk
         .bodyAsObject<PagedModel<EteCourseCompletionEventDto>>()
 
-      assertThat(pagedCourseCompletions.content.map { it.id }).containsExactly(completionFailed.id)
+      assertThat(pagedCourseCompletions.content.map { it.id }).containsExactlyInAnyOrder(completionPassed.id, completionFailed1.id, completionFailed2.id, completionFailed3.id)
+    }
+
+    @Test
+    fun `should show only failures on the third attempt when 'OnlyWhenMaxAttemptsReached' requested`() {
+      val pdu = communityCampusPduEntityRepository.findByNameIgnoreCase("Dyfed Powys")!!
+
+      val completionPassed = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu))
+      eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(pdu = pdu, attempts = 1))
+      eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(pdu = pdu, attempts = 2))
+      val completionFailed3 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(pdu = pdu, attempts = 3))
+
+      val pagedCourseCompletions = webTestClient.get()
+        .uri("/admin/providers/${pdu.providerCode}/course-completions?showCourseFailures=OnlyWhenMaxAttemptsReached")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<PagedModel<EteCourseCompletionEventDto>>()
+
+      assertThat(pagedCourseCompletions.content.map { it.id }).containsExactlyInAnyOrder(completionPassed.id, completionFailed3.id)
     }
 
     @Test
@@ -399,25 +421,6 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
         .bodyAsObject<PagedModel<EteCourseCompletionEventDto>>()
 
       assertThat(result.content.map { it.id }).containsExactlyInAnyOrder(firstAttemptCompletion.id, secondAttemptCompletion.id, thirdAttemptCompletion.id)
-    }
-
-    @Test
-    fun `should only return results with the requested attempt count`() {
-      val pdu = communityCampusPduEntityRepository.findAll().first()
-
-      eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu, attempts = 1))
-      eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu, attempts = 2))
-      val thirdAttemptCompletion = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(pdu = pdu, attempts = 3))
-
-      val result = webTestClient.get()
-        .uri("/admin/providers/${pdu.providerCode}/course-completions?attempts=3")
-        .addAdminUiAuthHeader()
-        .exchange()
-        .expectStatus()
-        .isOk
-        .bodyAsObject<PagedModel<EteCourseCompletionEventDto>>()
-
-      assertThat(result.content.map { it.id }).containsExactlyInAnyOrder(thirdAttemptCompletion.id)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
@@ -14,12 +14,12 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.atFirstSecondOfDay
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.atLastSecondOfDay
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionEventStatusDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionShowCourseFailuresDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository.CourseFailureFilter
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository.ResolutionStatus
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventResolutionRepository
-import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventStatus
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.listener.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.listener.EducationCourseCompletionMessage
@@ -147,8 +147,7 @@ class EteServiceTest {
           officesCount = 2,
           offices = offices,
           resolutionStatus = ResolutionStatus.ANY,
-          completionStatus = EteCourseCompletionEventStatus.PASSED,
-          attempts = attempts,
+          courseFailures = CourseFailureFilter.SHOW_ONLY_WHEN_MAX_ATTEMPTS_REACHED,
           externalReference = externalReference,
           fromDate = fromDate,
           toDate = toDate,
@@ -169,8 +168,7 @@ class EteServiceTest {
         pduId = pduId,
         offices = offices,
         resolutionStatus = null,
-        completionStatus = EteCourseCompletionEventStatusDto.Passed,
-        attempts = attempts,
+        showCourseFailures = EteCourseCompletionShowCourseFailuresDto.OnlyWhenMaxAttemptsReached,
         externalReference = externalReference,
         fromDate = fromDate,
         toDate = toDate,
@@ -188,8 +186,7 @@ class EteServiceTest {
           officesCount = 2,
           offices = offices,
           resolutionStatus = ResolutionStatus.ANY,
-          completionStatus = EteCourseCompletionEventStatus.PASSED,
-          attempts = attempts,
+          courseFailures = CourseFailureFilter.SHOW_ONLY_WHEN_MAX_ATTEMPTS_REACHED,
           externalReference = externalReference,
           fromDate = fromDate,
           toDate = toDate,
@@ -207,7 +204,7 @@ class EteServiceTest {
 
       every {
         eteCourseCompletionEventEntityRepository.findAllWithFilters(
-          any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+          any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
         )
       } returns PageImpl(emptyList())
 
@@ -216,8 +213,7 @@ class EteServiceTest {
         pduId = null,
         offices = null,
         resolutionStatus = null,
-        completionStatus = EteCourseCompletionEventStatusDto.Passed,
-        attempts = null,
+        showCourseFailures = EteCourseCompletionShowCourseFailuresDto.OnlyWhenMaxAttemptsReached,
         externalReference = null,
         fromDate = null,
         toDate = null,
@@ -231,8 +227,7 @@ class EteServiceTest {
           officesCount = 0,
           offices = emptyList(),
           resolutionStatus = ResolutionStatus.ANY,
-          completionStatus = EteCourseCompletionEventStatus.PASSED,
-          attempts = null,
+          courseFailures = CourseFailureFilter.SHOW_ONLY_WHEN_MAX_ATTEMPTS_REACHED,
           externalReference = null,
           fromDate = null,
           toDate = null,
@@ -250,7 +245,7 @@ class EteServiceTest {
 
       every {
         eteCourseCompletionEventEntityRepository.findAllWithFilters(
-          any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+          any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
         )
       } returns PageImpl(emptyList())
 
@@ -259,8 +254,7 @@ class EteServiceTest {
         pduId = null,
         offices = null,
         resolutionStatus = null,
-        completionStatus = EteCourseCompletionEventStatusDto.Passed,
-        attempts = null,
+        showCourseFailures = EteCourseCompletionShowCourseFailuresDto.OnlyWhenMaxAttemptsReached,
         externalReference = null,
         fromDate = null,
         toDate = null,
@@ -274,8 +268,7 @@ class EteServiceTest {
           officesCount = 0,
           offices = emptyList(),
           resolutionStatus = ResolutionStatus.ANY,
-          completionStatus = EteCourseCompletionEventStatus.PASSED,
-          attempts = null,
+          courseFailures = CourseFailureFilter.SHOW_ONLY_WHEN_MAX_ATTEMPTS_REACHED,
           externalReference = null,
           fromDate = null,
           toDate = null,
@@ -295,7 +288,7 @@ class EteServiceTest {
 
       every {
         eteCourseCompletionEventEntityRepository.findAllWithFilters(
-          any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+          any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
         )
       } returns PageImpl(emptyList())
 
@@ -304,8 +297,7 @@ class EteServiceTest {
         pduId = null,
         offices = null,
         resolutionStatus = null,
-        completionStatus = EteCourseCompletionEventStatusDto.Passed,
-        attempts = null,
+        showCourseFailures = EteCourseCompletionShowCourseFailuresDto.OnlyWhenMaxAttemptsReached,
         externalReference = null,
         fromDate = null,
         toDate = null,
@@ -319,8 +311,7 @@ class EteServiceTest {
           officesCount = 0,
           offices = emptyList(),
           resolutionStatus = ResolutionStatus.ANY,
-          completionStatus = EteCourseCompletionEventStatus.PASSED,
-          attempts = null,
+          courseFailures = CourseFailureFilter.SHOW_ONLY_WHEN_MAX_ATTEMPTS_REACHED,
           externalReference = null,
           fromDate = null,
           toDate = null,


### PR DESCRIPTION
Currently, the `GET /admin/providers/{providerCode}/course-completions` endpoint has optional `status` and `attempts` query parameters that can be used to filter the returned results by course outcome and how many attempts were made. These filters do not accurately represent the behaviours that are needed by the frontend to correctly present course completions, and are not currently used.

This changes the endpoint to remove these query parameters and replace them with `showCourseFailures`, which can take one of the following values:

- `No`: Failed course completions will not be shown.
- `Yes`: All course completions will be shown, including failed ones.
- `OnlyWhenMaxAttemptsReached`: Failed course completions are only shown when it was the last allowed attempt at the course in Community Campus.

If not present, the default value is `No`, which preserves the existing behaviour (showing only passed course completions).