### PR TITLE
CPB-994: Improve notes included in NDelius when processing a course completion

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/EteMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/EteMappers.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers
 
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.formatForUser
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.toLocalDateTimeEuropeLondon
@@ -15,6 +17,9 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOut
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.CommunityCampusPduEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository.CourseFailureFilter
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository.ResolutionStatus
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventResolutionEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventStatus
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionResolution
@@ -30,6 +35,7 @@ class EteMappers(
   private val contextService: ContextService,
   private val contactOutcomeEntityRepository: ContactOutcomeEntityRepository,
   private val communityCampusPduEntityRepository: CommunityCampusPduEntityRepository,
+  private val eteCourseCompletionEventEntityRepository: EteCourseCompletionEventEntityRepository,
 ) {
 
   companion object {
@@ -89,16 +95,22 @@ class EteMappers(
     userNotes: String?,
     courseCompletionEvent: EteCourseCompletionEventEntity,
   ) = buildString {
-    val completionDateLocal = courseCompletionEvent.completionDateTime.toLocalDateTimeEuropeLondon()
+    for (event in getAllAttemptsForCourseCompletionEvent(courseCompletionEvent)) {
+      val completionDateLocal = event.completionDateTime.toLocalDateTimeEuropeLondon()
 
-    append("'")
-    append(courseCompletionEvent.courseName)
-    append("' was completed on ")
-    append(courseCompletionEvent.provider)
-    append(" at ")
-    append(completionDateLocal.toLocalDate().formatForUser())
-    append(" on ")
-    appendLine(completionDateLocal.toLocalTime().formatForUser())
+      append("'")
+      append(event.courseName)
+      append("' was completed on ")
+      append(event.provider)
+      append(" at ")
+      append(completionDateLocal.toLocalTime().formatForUser())
+      append(" on ")
+      append(completionDateLocal.toLocalDate().formatForUser())
+      append(" and resulted in a ")
+      append(event.status.formatForUser())
+      append(" on attempt ")
+      appendLine(event.attempts)
+    }
 
     if (userNotes?.isNotBlank() == true) {
       appendLine(userNotes)
@@ -199,6 +211,21 @@ class EteMappers(
       receivedAt = OffsetDateTime.now(),
     )
   }
+
+  private fun getAllAttemptsForCourseCompletionEvent(courseCompletionEvent: EteCourseCompletionEventEntity) = eteCourseCompletionEventEntityRepository.findAllWithFilters(
+    providerCode = courseCompletionEvent.pdu.providerCode,
+    pduId = null,
+    officesCount = 0,
+    offices = listOf(),
+    resolutionStatus = ResolutionStatus.UNRESOLVED,
+    courseFailures = CourseFailureFilter.SHOW_ALL,
+    externalReference = courseCompletionEvent.externalReference,
+    fromDate = null,
+    toDate = null,
+    availableFromDate = null,
+    availableToDate = null,
+    pageable = Pageable.unpaged(Sort.by(Sort.Order.asc("createdAt"))),
+  ).toList()
 }
 
 fun EteCourseCompletionEventEntity.toDto() = EteCourseCompletionEventDto(
@@ -222,3 +249,8 @@ fun EteCourseCompletionEventEntity.toDto() = EteCourseCompletionEventDto(
   importedOn = receivedAt.toLocalDateTime(),
   resolved = resolution != null,
 )
+
+fun EteCourseCompletionEventStatus.formatForUser(): String = when (this) {
+  EteCourseCompletionEventStatus.PASSED -> "pass"
+  EteCourseCompletionEventStatus.FAILED -> "fail"
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/EteMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/EteMappersTest.kt
@@ -7,6 +7,7 @@ import io.mockk.junit5.MockKExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.data.domain.PageImpl
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.toLocalTimeEuropeLondon
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentBehaviourDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
@@ -27,6 +29,9 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.CommunityCampusPd
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository.CourseFailureFilter
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository.ResolutionStatus
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventResolutionEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventStatus
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionResolution
@@ -43,6 +48,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 
@@ -58,6 +64,9 @@ class EteMappersTest {
   @RelaxedMockK
   private lateinit var communityCampusPduEntityRepository: CommunityCampusPduEntityRepository
 
+  @RelaxedMockK
+  private lateinit var eteCourseCompletionEventEntityRepository: EteCourseCompletionEventEntityRepository
+
   @InjectMockKs
   private lateinit var mapper: EteMappers
 
@@ -67,6 +76,27 @@ class EteMappersTest {
     const val PROJECT_CODE = "PROJ123"
     const val DELIUS_APPOINTMENT_ID = 5L
     const val DELIUS_EVENT_NUMBER = 52
+  }
+
+  fun setupGetAllAttemptsForCourseCompletionEvent(vararg courseCompletionEvents: EteCourseCompletionEventEntity) {
+    val courseCompletionEvent = courseCompletionEvents.last()
+
+    every {
+      eteCourseCompletionEventEntityRepository.findAllWithFilters(
+        providerCode = courseCompletionEvent.pdu.providerCode,
+        pduId = null,
+        officesCount = 0,
+        offices = emptyList(),
+        resolutionStatus = ResolutionStatus.UNRESOLVED,
+        courseFailures = CourseFailureFilter.SHOW_ALL,
+        externalReference = courseCompletionEvent.externalReference,
+        fromDate = null,
+        toDate = null,
+        availableFromDate = null,
+        availableToDate = null,
+        pageable = any(),
+      )
+    } returns PageImpl(courseCompletionEvents.toList())
   }
 
   @Nested
@@ -87,7 +117,13 @@ class EteMappersTest {
       courseName = "The course name",
       provider = "Provider1",
       completionDateTime = OffsetDateTime.parse("2021-05-04T12:15:00.000+01:00"),
+      status = EteCourseCompletionEventStatus.PASSED,
     )
+
+    @BeforeEach
+    fun setup() {
+      setupGetAllAttemptsForCourseCompletionEvent(baselineCourseCompletionEvent)
+    }
 
     @ParameterizedTest
     @CsvSource(
@@ -117,7 +153,7 @@ class EteMappersTest {
       assertThat(result.date).isEqualTo(baselineCourseCompletionResolution.creditTimeDetails.date)
       assertThat(result.notes).isEqualTo(
         """
-        |'The course name' was completed on Provider1 at 04/05/2021 on 12:15
+        |'The course name' was completed on Provider1 at 12:15 on 04/05/2021 and resulted in a pass on attempt 1
         |the provided notes
         """.trimMargin(),
       )
@@ -196,10 +232,10 @@ class EteMappersTest {
     @ParameterizedTest
     @CsvSource(
       value = [
-        "2020-01-02T12:15:15.125+00:00,'The course name' was completed on Provider1 at 02/01/2020 on 12:15",
-        "2020-01-02T12:15:00.000Z,'The course name' was completed on Provider1 at 02/01/2020 on 12:15",
-        "2021-05-04T12:15:00.000+01:00,'The course name' was completed on Provider1 at 04/05/2021 on 12:15",
-        "2021-05-04T12:15:00.000Z,'The course name' was completed on Provider1 at 04/05/2021 on 13:15",
+        "2020-01-02T12:15:15.125+00:00,'The course name' was completed on Provider1 at 12:15 on 02/01/2020 and resulted in a pass on attempt 1",
+        "2020-01-02T12:15:00.000Z,'The course name' was completed on Provider1 at 12:15 on 02/01/2020 and resulted in a pass on attempt 1",
+        "2021-05-04T12:15:00.000+01:00,'The course name' was completed on Provider1 at 12:15 on 04/05/2021 and resulted in a pass on attempt 1",
+        "2021-05-04T12:15:00.000Z,'The course name' was completed on Provider1 at 13:15 on 04/05/2021 and resulted in a pass on attempt 1",
       ],
       quoteCharacter = '"',
     )
@@ -207,16 +243,57 @@ class EteMappersTest {
       completionDateTime: OffsetDateTime,
       expectedNote: String,
     ) {
+      val courseCompletionEvent = baselineCourseCompletionEvent.copy(
+        completionDateTime = completionDateTime,
+      )
+
+      setupGetAllAttemptsForCourseCompletionEvent(courseCompletionEvent)
+
       val result = mapper.toCreateAppointmentDto(
         courseCompletionResolution = baselineCourseCompletionResolution.copy(
           creditTimeDetails = baselineCourseCompletionResolution.creditTimeDetails!!.copy(notes = null),
         ),
-        courseCompletionEvent = baselineCourseCompletionEvent.copy(
-          completionDateTime = completionDateTime,
-        ),
+        courseCompletionEvent = courseCompletionEvent,
       )
 
       assertThat(result.notes).isEqualTo(expectedNote)
+    }
+
+    @Test
+    fun `should use all course completion attempts to build notes`() {
+      val courseCompletionAttempt1 = baselineCourseCompletionEvent.copy(
+        completionDateTime = OffsetDateTime.of(2025, 11, 20, 13, 35, 0, 0, ZoneOffset.UTC),
+        status = EteCourseCompletionEventStatus.FAILED,
+        attempts = 1,
+      )
+      val courseCompletionAttempt2 = baselineCourseCompletionEvent.copy(
+        completionDateTime = OffsetDateTime.of(2025, 11, 21, 11, 20, 0, 0, ZoneOffset.UTC),
+        status = EteCourseCompletionEventStatus.FAILED,
+        attempts = 2,
+      )
+      val courseCompletionAttempt3 = baselineCourseCompletionEvent.copy(
+        completionDateTime = OffsetDateTime.of(2025, 11, 22, 14, 10, 0, 0, ZoneOffset.UTC),
+        status = EteCourseCompletionEventStatus.PASSED,
+        attempts = 3,
+      )
+
+      setupGetAllAttemptsForCourseCompletionEvent(courseCompletionAttempt1, courseCompletionAttempt2, courseCompletionAttempt3)
+
+      val result = mapper.toCreateAppointmentDto(
+        courseCompletionResolution = baselineCourseCompletionResolution.copy(
+          creditTimeDetails = baselineCourseCompletionResolution.creditTimeDetails!!.copy(notes = "the provided notes"),
+        ),
+        courseCompletionEvent = courseCompletionAttempt3,
+      )
+
+      assertThat(result.notes).isEqualTo(
+        """
+        |'The course name' was completed on Provider1 at 13:35 on 20/11/2025 and resulted in a fail on attempt 1
+        |'The course name' was completed on Provider1 at 11:20 on 21/11/2025 and resulted in a fail on attempt 2
+        |'The course name' was completed on Provider1 at 14:10 on 22/11/2025 and resulted in a pass on attempt 3
+        |the provided notes
+        """.trimMargin(),
+      )
     }
   }
 
@@ -240,7 +317,13 @@ class EteMappersTest {
       courseName = "The course name",
       provider = "Provider1",
       completionDateTime = OffsetDateTime.parse("2021-05-04T12:15:00.000+01:00"),
+      status = EteCourseCompletionEventStatus.PASSED,
     )
+
+    @BeforeEach
+    fun setup() {
+      setupGetAllAttemptsForCourseCompletionEvent(baselineCourseCompletionEvent)
+    }
 
     @ParameterizedTest
     @CsvSource(
@@ -274,7 +357,7 @@ class EteMappersTest {
       assertThat(result.supervisorOfficerCode).isEqualTo(existingAppointment.supervisorOfficerCode)
       assertThat(result.notes).isEqualTo(
         """
-        |'The course name' was completed on Provider1 at 04/05/2021 on 12:15
+        |'The course name' was completed on Provider1 at 12:15 on 04/05/2021 and resulted in a pass on attempt 1
         |the provided notes
         """.trimMargin(),
       )
@@ -338,10 +421,10 @@ class EteMappersTest {
     @ParameterizedTest
     @CsvSource(
       value = [
-        "2020-01-02T12:15:00.000+00:00,'The course name' was completed on Provider1 at 02/01/2020 on 12:15",
-        "2020-01-02T12:15:00.000Z,'The course name' was completed on Provider1 at 02/01/2020 on 12:15",
-        "2021-05-04T12:15:00.000+01:00,'The course name' was completed on Provider1 at 04/05/2021 on 12:15",
-        "2021-05-04T12:15:00.000Z,'The course name' was completed on Provider1 at 04/05/2021 on 13:15",
+        "2020-01-02T12:15:00.000+00:00,'The course name' was completed on Provider1 at 12:15 on 02/01/2020 and resulted in a pass on attempt 1",
+        "2020-01-02T12:15:00.000Z,'The course name' was completed on Provider1 at 12:15 on 02/01/2020 and resulted in a pass on attempt 1",
+        "2021-05-04T12:15:00.000+01:00,'The course name' was completed on Provider1 at 12:15 on 04/05/2021 and resulted in a pass on attempt 1",
+        "2021-05-04T12:15:00.000Z,'The course name' was completed on Provider1 at 13:15 on 04/05/2021 and resulted in a pass on attempt 1",
       ],
       quoteCharacter = '"',
     )
@@ -349,17 +432,59 @@ class EteMappersTest {
       completionDateTime: OffsetDateTime,
       expectedNote: String,
     ) {
+      val courseCompletionEvent = baselineCourseCompletionEvent.copy(
+        completionDateTime = completionDateTime,
+      )
+
+      setupGetAllAttemptsForCourseCompletionEvent(courseCompletionEvent)
+
       val result = mapper.toUpdateAppointmentDto(
         courseCompletionResolution = baselineCourseCompletionOutcome.copy(
           creditTimeDetails = baselineCourseCompletionOutcome.creditTimeDetails!!.copy(notes = null),
         ),
-        courseCompletionEvent = baselineCourseCompletionEvent.copy(
-          completionDateTime = completionDateTime,
-        ),
+        courseCompletionEvent = courseCompletionEvent,
         existingAppointment = baselineExistingAppointment,
       )
 
       assertThat(result.notes).isEqualTo(expectedNote)
+    }
+
+    @Test
+    fun `should use all course completion attempts to build notes`() {
+      val courseCompletionAttempt1 = baselineCourseCompletionEvent.copy(
+        completionDateTime = OffsetDateTime.of(2025, 11, 20, 13, 35, 0, 0, ZoneOffset.UTC),
+        status = EteCourseCompletionEventStatus.FAILED,
+        attempts = 1,
+      )
+      val courseCompletionAttempt2 = baselineCourseCompletionEvent.copy(
+        completionDateTime = OffsetDateTime.of(2025, 11, 21, 11, 20, 0, 0, ZoneOffset.UTC),
+        status = EteCourseCompletionEventStatus.FAILED,
+        attempts = 2,
+      )
+      val courseCompletionAttempt3 = baselineCourseCompletionEvent.copy(
+        completionDateTime = OffsetDateTime.of(2025, 11, 22, 14, 10, 0, 0, ZoneOffset.UTC),
+        status = EteCourseCompletionEventStatus.PASSED,
+        attempts = 3,
+      )
+
+      setupGetAllAttemptsForCourseCompletionEvent(courseCompletionAttempt1, courseCompletionAttempt2, courseCompletionAttempt3)
+
+      val result = mapper.toUpdateAppointmentDto(
+        courseCompletionResolution = baselineCourseCompletionOutcome.copy(
+          creditTimeDetails = baselineCourseCompletionOutcome.creditTimeDetails!!.copy(notes = "the provided notes"),
+        ),
+        courseCompletionEvent = courseCompletionAttempt3,
+        existingAppointment = baselineExistingAppointment,
+      )
+
+      assertThat(result.notes).isEqualTo(
+        """
+        |'The course name' was completed on Provider1 at 13:35 on 20/11/2025 and resulted in a fail on attempt 1
+        |'The course name' was completed on Provider1 at 11:20 on 21/11/2025 and resulted in a fail on attempt 2
+        |'The course name' was completed on Provider1 at 14:10 on 22/11/2025 and resulted in a pass on attempt 3
+        |the provided notes
+        """.trimMargin(),
+      )
     }
   }
 

--- a/tools/scripts/send-course-completion-event
+++ b/tools/scripts/send-course-completion-event
@@ -1,0 +1,164 @@
+#!/bin/bash
+
+print_help () {
+  echo "send-course-completion-event [f:l:c:PFn:x:h]"
+  echo "  Posts a course completion event to the LocalStack SQS queue."
+  echo
+  echo "Usage:"
+  echo "  -f <first name>   If not provided a random first name is picked"
+  echo "  -l <last name>    If not provided a random last name is picked"
+  echo "  -c <course name>  If not provided a random course name is picked"
+  echo
+  echo "  -P                Flag the course as being passed (default)"
+  echo "  -F                Flag the course as being failed"
+  echo "  -n <attempt>      The attempt number. If not provided 1 is used"
+  echo "  -x <reference>    The external reference. Randomly picked if not provided"
+  echo
+  echo "  -h                Display this help message"
+}
+
+while getopts "f:l:c:PFn:x:h" opt; do
+  case $opt in
+    f)
+      firstName="$OPTARG"
+      ;;
+    l)
+      lastName="$OPTARG"
+      ;;
+    c)
+      courseName="$OPTARG"
+      ;;
+    P)
+      status="Completed"
+      ;;
+    F)
+      status="Failed"
+      ;;
+    n)
+      attemptNumber="$OPTARG"
+      ;;
+    x)
+      externalReference="$OPTARG"
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      print_help
+      exit 1
+      ;;
+    h)
+      print_help
+      exit 0
+      ;;
+  esac
+done
+
+uuid () {
+  uuidgen | tr '[:upper:]' '[:lower:]'
+}
+
+rng () {
+  # Get four random bytes
+  echo $(od -vAn -N4 -tu4 < /dev/urandom)
+}
+
+now () {
+  echo $(date +%s)
+}
+
+randomFromList () {
+  items=("$@")
+  index=$((($(rng) % $#)))
+  echo ${items[$index]}
+}
+
+randomDob () {
+  # 18 - 80 years old
+  years=$((($(rng) % 52) + 18))
+  days=$(($(rng) % 365))
+
+  d=$((($years * 31536000) + (days * 86400)))
+  epoch=$(($(now) - $d))
+  echo $(date -r "$epoch" +%F)
+}
+
+messageId="$(uuid)"
+
+if [ -z $firstName ]; then
+  firstName="$(randomFromList "Alec" "Becky" "Charles" "Dianne" "Eric" "Fiona" "Gary" "Hetty")"
+fi
+
+if [ -z $lastName ]; then
+  lastName="$(randomFromList "Anderson" "Bridges" "Chorley" "Dreyfus" "Etherton" "Fanshaw" "Gardener" "Hill")"
+fi
+
+dateOfBirth="$(randomDob)"
+
+if [ -z $courseName ]; then
+  courseName="How To $(randomFromList "Butter Toast" "Suck Eggs" "Bake Bread" "Roll Cheese")"
+fi
+
+completedOn="$(date +%FT%T%z)"
+
+if [ -z $status ]; then
+  status="Completed"
+fi
+
+totalTimeMinutes="$(($(rng) % 120))"
+
+if [ -z $attemptNumber ]; then
+  attemptNumber="1"
+fi
+
+if [ -z $externalReference ]; then
+  externalReference="$(uuid)"
+fi
+
+message=$(cat <<EOF
+{
+  "messageId": "$messageId",
+  "eventType": "educationCourseCompletionCreated",
+  "messageAttributes": {
+    "firstName": "$firstName",
+    "lastName": "$lastName",
+    "dateOfBirth": "$dateOfBirth",
+    "region": "East of England",
+    "pdu": "North Essex",
+    "office": "Chelmsford",
+    "email": "$firstName.$lastName@example.org",
+    "courseName": "$courseName",
+    "courseType": "Online",
+    "provider": "Example Online Course Provider Ltd",
+    "completionDateTime": "$completedOn",
+    "status": "$status",
+    "totalTimeMinutes": $totalTimeMinutes,
+    "attempts": $attemptNumber,
+    "expectedTimeMinutes": 120,
+    "externalReference": "$externalReference"
+  }
+}
+EOF
+)
+
+echo -e "Posting event to LocalStack SQS:\n\n$message\n"
+
+# Stringify the message JSON
+message=${message//\\/\\\\}
+message=${message//\"/\\\"}
+message=${message//$'\n'/\\n}
+
+payload=$(cat <<EOF
+{
+  "QueueUrl": "http://sqs.eu-west-2.localhost.localstack.cloud:4566/000000000000/cp_stack_course_completion_events/",
+  "MessageBody": "$message"
+}
+EOF
+)
+
+response=$(curl -s -H 'X-Amz-Target: AmazonSQS.SendMessage' --json "$payload" 'localhost:4566')
+
+if [ $? ]; then
+  echo -e "Event successfully sent! Response was:\n\n$response"
+else
+  echo -e "Event failed to send! Response was:\n\n$response" >&2
+  exit 1
+fi


### PR DESCRIPTION
Currently, when processing a course completion, the notes added to NDelius only include the timestamp of the most recent attempt and the course name and provider. This is not enough information to track the full journey in the case of multiple attempts.

This changes the notes so that the outcome (whether the course was passed or failed) and the attempt number is included when constructing these system messages. It also extends this to every course completion event received with the same external reference as the triggering event, which has the effect of recording previously failed attempts.

An example in NDelius of the notes generated when a course is passed on the third attempt can be seen below:
<img width="1590" height="264" alt="" src="https://github.com/user-attachments/assets/c2334024-b2e3-4c26-a333-44a5599c4f99" />

Additionally, a new script has been added at `tools/scripts/send-course-completion-event` which can be used to post course completion events to the LocalStack SQS queue for course completions. This script can be used for manual testing of course completions, and accepts several of the properties as arguments (details of this can be read by running `tools/scripts/send-course-completion-event -h`).