### PR TITLE
CPB-991: Remove project information from course completion recommendation endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminCourseCompletionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminCourseCompletionController.kt
@@ -153,9 +153,9 @@ class AdminCourseCompletionController(val eteService: EteService) {
 
   @GetMapping("/course-completions/{id}/recommended-selection", produces = [MediaType.APPLICATION_JSON_VALUE])
   @Operation(
-    description = "Get recommendations for course completion detail based on the course completion id.",
+    description = "Gets the recommended CRN for this course completion based on previous course completions with the same user email.",
     responses = [
-      ApiResponse(responseCode = "200", description = "Recommendations for CRN, Project Code and UPW Team."),
+      ApiResponse(responseCode = "200", description = "Recommendation of a CRN for this course completion"),
       ApiResponse(responseCode = "404", description = "Course completion not found", content = [Content(schema = Schema(implementation = ErrorResponse::class))]),
     ],
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CourseCompletionRecommendationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CourseCompletionRecommendationDto.kt
@@ -2,5 +2,4 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
 
 data class CourseCompletionRecommendationDto(
   val crn: String?,
-  val project: ProjectDto?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
@@ -36,7 +36,6 @@ class EteService(
   private val eteCourseCompletionEventResolutionRepository: EteCourseCompletionEventResolutionRepository,
   private val appointmentService: AppointmentService,
   private val eteValidationService: EteValidationService,
-  private val projectService: ProjectService,
   private val contextService: ContextService,
   private val springEventPublisher: SpringEventPublisher,
 
@@ -117,22 +116,13 @@ class EteService(
     val courseCompletionEvent = getEventOrError(id)
 
     val email = courseCompletionEvent.email
-    val courseName = courseCompletionEvent.courseName
-    val office = courseCompletionEvent.office
 
     val crn: String? =
       eteCourseCompletionEventResolutionRepository
         .findFirstByEteCourseCompletionEventEmailOrderByCreatedAtDesc(email)
         ?.crn
 
-    val projectCode: String? =
-      eteCourseCompletionEventResolutionRepository
-        .findFirstByEteCourseCompletionEventOfficeAndEteCourseCompletionEventCourseNameOrderByCreatedAtDesc(office, courseName)
-        ?.projectCode
-
-    val project = projectCode?.let { projectService.getProject(it) }
-
-    return CourseCompletionRecommendationDto(crn, project)
+    return CourseCompletionRecommendationDto(crn)
   }
 
   @Transactional

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
@@ -1144,8 +1144,6 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
         .bodyAsObject<CourseCompletionRecommendationDto>()
 
       assertThat(recommendation.crn).isEqualTo(crn)
-      assertThat(recommendation.project?.projectCode).isEqualTo(projectCode)
-      assertThat(recommendation.project?.teamCode).isEqualTo(teamCode)
     }
 
     @Test
@@ -1163,8 +1161,6 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
         .bodyAsObject<CourseCompletionRecommendationDto>()
 
       assertThat(recommendation.crn).isNull()
-      assertThat(recommendation.project?.projectCode).isNull()
-      assertThat(recommendation.project?.teamCode).isNull()
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
@@ -27,7 +27,6 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentServi
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ContextService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.EteService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.EteValidationService
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ProjectService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.EteMappers
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
@@ -46,9 +45,6 @@ class EteServiceTest {
 
   @RelaxedMockK
   lateinit var appointmentService: AppointmentService
-
-  @RelaxedMockK
-  lateinit var projectService: ProjectService
 
   @RelaxedMockK
   lateinit var eteMappers: EteMappers
@@ -79,7 +75,6 @@ class EteServiceTest {
       eteCourseCompletionEventResolutionRepository,
       appointmentService,
       eteValidationService,
-      projectService,
       contextService,
       springEventPublisher,
       defaultDateFrom,
@@ -129,7 +124,6 @@ class EteServiceTest {
         eteCourseCompletionEventResolutionRepository,
         appointmentService,
         eteValidationService,
-        projectService,
         contextService,
         springEventPublisher,
         null,


### PR DESCRIPTION
Currently this endpoint is not used but will be soon to supply CRN recommendations for course completions. However, the project recommendations are not needed for this functionality, so has been removed.