### PR TITLE
CPB-996: Retry configuration for WebClientRequestExceptions with Timeout causes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/WebClientConfiguration.kt
@@ -11,6 +11,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.bodyToMono
 import org.springframework.web.reactive.function.client.support.WebClientAdapter
 import org.springframework.web.service.invoker.HttpServiceProxyFactory
@@ -147,7 +148,7 @@ fun WebClient.retryGet(maxAttempts: Long, backoff: Duration): WebClient = this.m
     if (request.method() == HttpMethod.GET) {
       responseMono.retryWhen(
         Retry.backoff(maxAttempts, backoff)
-          .filter { it.isTimeoutException() },
+          .filter { it is WebClientRequestException && it.isTimeoutException() },
       )
     } else {
       responseMono

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/WebClientConfiguration.kt
@@ -141,24 +141,22 @@ inline fun <reified T> WebClient.logErrorResponses(enabled: Boolean): WebClient 
     .build()
 }
 
-fun WebClient.retryGet(maxAttempts: Long, backoff: Duration): WebClient {
-  return this.mutate()
-    .filter { request, next ->
-      val responseMono = next.exchange(request)
-      if (request.method() == HttpMethod.GET) {
-        responseMono.retryWhen(
-          Retry.backoff(maxAttempts, backoff)
-            .filter { it.isTimeoutException() },
-        )
-      } else {
-        responseMono
-      }
+fun WebClient.retryGet(maxAttempts: Long, backoff: Duration): WebClient = this.mutate()
+  .filter { request, next ->
+    val responseMono = next.exchange(request)
+    if (request.method() == HttpMethod.GET) {
+      responseMono.retryWhen(
+        Retry.backoff(maxAttempts, backoff)
+          .filter { it.isTimeoutException() },
+      )
+    } else {
+      responseMono
     }
-    .build()
-}
+  }
+  .build()
 
-private fun Throwable.isTimeoutException(): Boolean = this.hasExactCauseType<ReadTimeoutException>()
-  || this.hasExactCauseType<ConnectTimeoutException>()
+private fun Throwable.isTimeoutException(): Boolean = this.hasExactCauseType<ReadTimeoutException>() ||
+  this.hasExactCauseType<ConnectTimeoutException>()
 
 private inline fun <reified T : Throwable> Throwable.hasExactCauseType(): Boolean {
   var current: Throwable? = this

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/WebClientConfiguration.kt
@@ -1,10 +1,13 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.config
 
+import io.netty.channel.ConnectTimeoutException
+import io.netty.handler.timeout.ReadTimeoutException
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.DependsOn
+import org.springframework.http.HttpMethod
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction
 import org.springframework.web.reactive.function.client.WebClient
@@ -12,6 +15,7 @@ import org.springframework.web.reactive.function.client.bodyToMono
 import org.springframework.web.reactive.function.client.support.WebClientAdapter
 import org.springframework.web.service.invoker.HttpServiceProxyFactory
 import org.springframework.web.service.invoker.createClient
+import reactor.util.retry.Retry
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.ArnsClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.ProbationAccessControlClient
@@ -41,6 +45,8 @@ class WebClientConfiguration(
 
   companion object {
     const val API_CLIENT_ID: String = "api-client"
+    const val DEFAULT_RETRY_MAX_ATTEMPTS: Long = 3
+    val DEFAULT_RETRY_BACKOFF_DURATION: Duration = Duration.ofMillis(100)
   }
 
   // HMPPS Auth health ping is required if your service calls HMPPS Auth to get a token to call other services
@@ -58,6 +64,7 @@ class WebClientConfiguration(
       url = communityPaybackAndDeliusUrl,
       timeout = communityPaybackAndDeliusTimeout,
     )
+    .retryGet(DEFAULT_RETRY_MAX_ATTEMPTS, DEFAULT_RETRY_BACKOFF_DURATION)
     .logErrorResponses<CommunityPaybackAndDeliusClient>(logDownstreamErrorResponses)
 
   @Bean
@@ -78,6 +85,7 @@ class WebClientConfiguration(
       url = arnsUrl,
       timeout = arnsTimeout,
     )
+    .retryGet(DEFAULT_RETRY_MAX_ATTEMPTS, DEFAULT_RETRY_BACKOFF_DURATION)
     .logErrorResponses<ArnsClient>(logDownstreamErrorResponses)
 
   @Bean
@@ -98,6 +106,7 @@ class WebClientConfiguration(
       url = probationAccessControlUrl,
       timeout = probationAccessControlTimeout,
     )
+    .retryGet(DEFAULT_RETRY_MAX_ATTEMPTS, DEFAULT_RETRY_BACKOFF_DURATION)
     .logErrorResponses<ProbationAccessControlClient>(logDownstreamErrorResponses)
 
   @Bean
@@ -130,4 +139,34 @@ inline fun <reified T> WebClient.logErrorResponses(enabled: Boolean): WebClient 
       },
     )
     .build()
+}
+
+fun WebClient.retryGet(maxAttempts: Long, backoff: Duration): WebClient {
+  return this.mutate()
+    .filter { request, next ->
+      val responseMono = next.exchange(request)
+      if (request.method() == HttpMethod.GET) {
+        responseMono.retryWhen(
+          Retry.backoff(maxAttempts, backoff)
+            .filter { it.isTimeoutException() },
+        )
+      } else {
+        responseMono
+      }
+    }
+    .build()
+}
+
+private fun Throwable.isTimeoutException(): Boolean = this.hasExactCauseType<ReadTimeoutException>()
+  || this.hasExactCauseType<ConnectTimeoutException>()
+
+private inline fun <reified T : Throwable> Throwable.hasExactCauseType(): Boolean {
+  var current: Throwable? = this
+  while (current != null) {
+    if (current.javaClass == T::class.java) {
+      return true
+    }
+    current = current.cause
+  }
+  return false
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/config/WebClientRetryIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/config/WebClientRetryIT.kt
@@ -1,0 +1,110 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.integration.config
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.client.WireMock.verify
+import com.github.tomakehurst.wiremock.stubbing.Scenario
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.TestPropertySource
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCreateAppointments
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProviderSummaries
+import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.IntegrationTestBase
+
+@TestPropertySource(
+  properties = [
+    "client.community-payback-and-delius.timeout=500ms",
+  ],
+)
+class WebClientRetryIT : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var communityPaybackAndDeliusClient: CommunityPaybackAndDeliusClient
+
+  @Test
+  fun `GET request is retried on timeout`() {
+    val username = "some-user"
+    val scenarioName = "Retry Scenario"
+
+    // 1st attempt: timeout
+    stubFor(
+      get(WireMock.urlPathEqualTo("/community-payback-and-delius/providers"))
+        .withQueryParam("username", WireMock.equalTo(username))
+        .inScenario(scenarioName)
+        .whenScenarioStateIs(Scenario.STARTED)
+        .willReturn(aResponse().withFixedDelay(1000)) // longer than 500ms timeout
+        .willSetStateTo("First Timeout"),
+    )
+
+    // 2nd attempt: timeout
+    stubFor(
+      get(WireMock.urlPathEqualTo("/community-payback-and-delius/providers"))
+        .withQueryParam("username", WireMock.equalTo(username))
+        .inScenario(scenarioName)
+        .whenScenarioStateIs("First Timeout")
+        .willReturn(aResponse().withFixedDelay(1000))
+        .willSetStateTo("Second Timeout"),
+    )
+
+    // 3rd attempt: success
+    stubFor(
+      get(WireMock.urlPathEqualTo("/community-payback-and-delius/providers"))
+        .withQueryParam("username", WireMock.equalTo(username))
+        .inScenario(scenarioName)
+        .whenScenarioStateIs("Second Timeout")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody("""{"providers": []}"""),
+        ),
+    )
+
+    val response = communityPaybackAndDeliusClient.getProviders(username)
+
+    assertThat(response).isEqualTo(NDProviderSummaries(emptyList()))
+
+    verify(3, getRequestedFor(WireMock.urlPathEqualTo("/community-payback-and-delius/providers")))
+  }
+
+  @Test
+  fun `GET request eventually fails after max retries`() {
+    val username = "some-user"
+
+    stubFor(
+      get(WireMock.urlPathEqualTo("/community-payback-and-delius/providers"))
+        .withQueryParam("username", WireMock.equalTo(username))
+        .willReturn(aResponse().withFixedDelay(1000)),
+    )
+
+    assertThrows<Exception> {
+      communityPaybackAndDeliusClient.getProviders(username)
+    }
+
+    verify(4, getRequestedFor(WireMock.urlPathEqualTo("/community-payback-and-delius/providers")))
+  }
+
+  @Test
+  fun `POST request is NOT retried on timeout`() {
+    val projectCode = "P1"
+
+    stubFor(
+      post("/community-payback-and-delius/projects/$projectCode/appointments")
+        .willReturn(aResponse().withFixedDelay(1000)),
+    )
+
+    assertThrows<Exception> {
+      communityPaybackAndDeliusClient.createAppointments(projectCode, NDCreateAppointments(emptyList()))
+    }
+
+    verify(1, postRequestedFor(urlEqualTo("/community-payback-and-delius/projects/$projectCode/appointments")))
+  }
+}


### PR DESCRIPTION
On production, we received the following type alerts on Sentry, for GETs:
- WebClientRequestException: lambda$wrapException$0 (This would be a read timeout exception)
- WebClientRequestException: recvAddress(..) failed with error(-104): Connection reset by peer

The above would happen every so often, the retry config should help stop these occurring.
