### PR TITLE
CPB-997: Alphabetical sorting of results for various endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminProviderController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminProviderController.kt
@@ -192,7 +192,7 @@ class AdminProviderController(
         description = "Only projectName. numberOfAppointmentsOverdue and oldestOverdueAppointmentInDays fields are supported for sorting",
       ),
     )
-    @PageableDefault(size = 100, sort = ["name"], direction = Sort.Direction.DESC) pageable: Pageable,
+    @PageableDefault(size = 100, sort = ["name"], direction = Sort.Direction.ASC) pageable: Pageable,
     @PathVariable providerCode: String,
     @PathVariable teamCode: String,
     @RequestParam projectTypeGroup: ProjectTypeGroupDto,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/ProviderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/ProviderService.kt
@@ -21,7 +21,7 @@ class ProviderService(
 
   fun getPickupLocations(teamId: TeamId) = try {
     PickUpLocationsDto(
-      communityPaybackAndDeliusClient.getTeamLocations(teamId.teamCode).locations.map { it.toDto() },
+      communityPaybackAndDeliusClient.getTeamLocations(teamId.teamCode).locations.sortedBy { it.description }.map { it.toDto() },
     )
   } catch (_: WebClientResponseException.NotFound) {
     null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/ProviderMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/ProviderMappers.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProviderTeamSummaryD
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SupervisorSummariesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SupervisorSummaryDto
 
-fun NDProviderSummaries.toDto() = ProviderSummariesDto(this.providers.map { it.toDto() })
+fun NDProviderSummaries.toDto() = ProviderSummariesDto(this.providers.sortedBy { it.description }.map { it.toDto() })
 fun NDProviderSummary.toDto() = ProviderSummaryDto(this.code, this.description)
 
 fun NDProviderTeamSummaries.toDto() = ProviderTeamSummariesDto(this.teams.sortedBy { it.description }.map { it.toDto() })

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/ProviderMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/ProviderMappers.kt
@@ -20,7 +20,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SupervisorSummaryDto
 fun NDProviderSummaries.toDto() = ProviderSummariesDto(this.providers.map { it.toDto() })
 fun NDProviderSummary.toDto() = ProviderSummaryDto(this.code, this.description)
 
-fun NDProviderTeamSummaries.toDto() = ProviderTeamSummariesDto(this.teams.map { it.toDto() })
+fun NDProviderTeamSummaries.toDto() = ProviderTeamSummariesDto(this.teams.sortedBy { it.description }.map { it.toDto() })
 fun NDProviderTeamSummary.toDto() = ProviderTeamSummaryDto(this.code, this.description)
 
 fun NDSupervisorSummaries.toDto() = SupervisorSummariesDto(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
@@ -200,7 +200,7 @@ object CommunityPaybackAndDeliusMockServer {
     response: List<NDProjectOutcomeStats>,
     pageNumber: Int = 0,
     pageSize: Int = 100,
-    sortString: String = "name,desc",
+    sortString: String = "name,asc",
   ) {
     val url = buildString {
       append("/community-payback-and-delius/providers/$providerCode/teams/$teamCode/projects?")


### PR DESCRIPTION
This PR updates the following endpoints to return results sorted by name/description alphabetically:
- `GET /admin/providers/{providerCode}/teams`
- `GET /admin/providers`
- `GET /admin/providers/{providerCode}/teams/{teamCode}/pickUpLocations`
- `GET /admin/providers/{providerCode}/teams/{teamCode}/projects`

The following endpoints are referenced in CPB-997 but are already sorted alphabetically, so have not been changed:
- `GET /common/references/project-types`
- `GET /common/references/community-campus-pdus`
- `GET /common/references/contact-outcomes`