### PR TITLE
CPB-997: Sort results from `/admin/providers/{providerCode}/teams/{teamCode}/supervisors` endpoint alphabetically

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/ProviderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/ProviderService.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PickUpLocationsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
 
@@ -20,9 +19,7 @@ class ProviderService(
   fun getTeamUnallocatedSupervisor(teamId: TeamId) = getTeamSupervisors(teamId).supervisors.firstOrNull { it.unallocated } ?: error("Can't find unallocated supervisor for team '$teamId'")
 
   fun getPickupLocations(teamId: TeamId) = try {
-    PickUpLocationsDto(
-      communityPaybackAndDeliusClient.getTeamLocations(teamId.teamCode).locations.sortedBy { it.description }.map { it.toDto() },
-    )
+    communityPaybackAndDeliusClient.getTeamLocations(teamId.teamCode).toDto()
   } catch (_: WebClientResponseException.NotFound) {
     null
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/ProviderMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/ProviderMappers.kt
@@ -25,7 +25,7 @@ fun NDProviderTeamSummary.toDto() = ProviderTeamSummaryDto(this.code, this.descr
 
 fun NDSupervisorSummaries.toDto() = SupervisorSummariesDto(
   this.supervisors
-    .sortedBy { "${it.name.surname}${it.name.forename}".lowercase() }
+    .sortedWith(compareBy({ it.name.forename.lowercase() }, { it.name.surname.lowercase() }))
     .map { it.toDto() },
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/ProviderMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/ProviderMappers.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers
 
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDGrade
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPickUpLocationsResponse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProviderSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProviderSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProviderTeamSummaries
@@ -10,6 +11,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSupervisorSumma
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSupervisorSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.GradeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.NameDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PickUpLocationsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProviderSummariesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProviderSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProviderTeamSummariesDto
@@ -39,6 +41,10 @@ fun NDSupervisorSummary.toDto() = SupervisorSummaryDto(
   fullName = this.name.toDtoValue() + (this.grade?.let { " ${it.toDtoValue()}" } ?: ""),
   grade = this.grade?.toDto(),
   unallocated = this.unallocated,
+)
+
+fun NDPickUpLocationsResponse.toDto() = PickUpLocationsDto(
+  this.locations.sortedBy { it.description }.map { it.toDto() },
 )
 
 fun NDGrade.toDto() = GradeDto(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/ProviderMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/ProviderMappersTest.kt
@@ -3,7 +3,10 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.mappers
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.description
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDGrade
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPickUpLocation
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPickUpLocationsResponse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProviderSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProviderSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProviderTeamSummaries
@@ -164,6 +167,56 @@ class ProviderMappersTest {
       assertThat(teamSummariesDto.providers[1].name).isEqualTo("LMN team")
       assertThat(teamSummariesDto.providers[2].code).isEqualTo("ZYX987")
       assertThat(teamSummariesDto.providers[2].name).isEqualTo("ZYX team")
+    }
+  }
+
+  @Nested
+  inner class PickUpLocationsMapper {
+    fun `should map using toDto() correctly`() {
+      val pickUpLocations = NDPickUpLocationsResponse(
+        listOf(
+          NDPickUpLocation(
+            code = "CDE345",
+            description = "Charlie House",
+            streetName = null,
+            buildingName = null,
+            addressNumber = null,
+            townCity = null,
+            county = null,
+            postCode = null,
+          ),
+          NDPickUpLocation(
+            code = "ABC123",
+            description = "Alpha House",
+            streetName = null,
+            buildingName = null,
+            addressNumber = null,
+            townCity = null,
+            county = null,
+            postCode = null,
+          ),
+          NDPickUpLocation(
+            code = "BCD234",
+            description = "Bravo House",
+            streetName = null,
+            buildingName = null,
+            addressNumber = null,
+            townCity = null,
+            county = null,
+            postCode = null,
+          ),
+        ),
+      )
+
+      val pickUpLocationsDto = pickUpLocations.toDto()
+
+      assertThat(pickUpLocationsDto.locations).hasSize(3)
+      assertThat(pickUpLocationsDto.locations[0].deliusCode).isEqualTo("ABC123")
+      assertThat(pickUpLocationsDto.locations[0].description).isEqualTo("Alpha House")
+      assertThat(pickUpLocationsDto.locations[1].deliusCode).isEqualTo("BCD234")
+      assertThat(pickUpLocationsDto.locations[1].description).isEqualTo("Bravo House")
+      assertThat(pickUpLocationsDto.locations[2].deliusCode).isEqualTo("CDE345")
+      assertThat(pickUpLocationsDto.locations[2].description).isEqualTo("Charlie House")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/ProviderMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/ProviderMappersTest.kt
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDGrade
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProviderSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProviderSummary
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProviderTeamSummaries
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProviderTeamSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSupervisorName
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSupervisorSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSupervisorSummary
@@ -24,9 +26,9 @@ class ProviderMappersTest {
     fun `should map using toDto() correctly`() {
       val providersSummaries = NDProviderSummaries(
         listOf(
-          NDProviderSummary(code = "ABC123", "East of England"),
-          NDProviderSummary(code = "DEF123", "North East Region"),
           NDProviderSummary(code = "GHI123", "North West Region"),
+          NDProviderSummary(code = "DEF123", "North East Region"),
+          NDProviderSummary(code = "ABC123", "East of England"),
         ),
       )
       val providerSummariesDto = providersSummaries.toDto()
@@ -138,6 +140,30 @@ class ProviderMappersTest {
       val supervisorSummariesDto = supervisorSummaries.toDto()
 
       assertThat(supervisorSummariesDto.supervisors).isEmpty()
+    }
+  }
+
+  @Nested
+  inner class TeamSummariesMapper {
+    @Test
+    fun `should map using toDto() correctly`() {
+      val teamSummaries = NDProviderTeamSummaries(
+        listOf(
+          NDProviderTeamSummary("LMN456", "LMN team"),
+          NDProviderTeamSummary("ZYX987", "ZYX team"),
+          NDProviderTeamSummary("ABC123", "ABC team"),
+        ),
+      )
+
+      val teamSummariesDto = teamSummaries.toDto()
+
+      assertThat(teamSummariesDto.providers).hasSize(3)
+      assertThat(teamSummariesDto.providers[0].code).isEqualTo("ABC123")
+      assertThat(teamSummariesDto.providers[0].name).isEqualTo("ABC team")
+      assertThat(teamSummariesDto.providers[1].code).isEqualTo("LMN456")
+      assertThat(teamSummariesDto.providers[1].name).isEqualTo("LMN team")
+      assertThat(teamSummariesDto.providers[2].code).isEqualTo("ZYX987")
+      assertThat(teamSummariesDto.providers[2].name).isEqualTo("ZYX team")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/ProviderMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/ProviderMappersTest.kt
@@ -90,15 +90,15 @@ class ProviderMappersTest {
       val supervisorSummariesDto = supervisorSummaries.toDto()
 
       assertThat(supervisorSummariesDto.supervisors).hasSize(3)
-      assertThat(supervisorSummariesDto.supervisors[0].code).isEqualTo("FF01")
-      assertThat(supervisorSummariesDto.supervisors[0].fullName).isEqualTo("Fred Flintstone [PO - PO Description]")
-      assertThat(supervisorSummariesDto.supervisors[0].unallocated).isFalse
-      assertThat(supervisorSummariesDto.supervisors[1].code).isEqualTo("WF01")
-      assertThat(supervisorSummariesDto.supervisors[1].fullName).isEqualTo("wilma flintstone [S1 - S1 Description]")
+      assertThat(supervisorSummariesDto.supervisors[0].code).isEqualTo("BR01")
+      assertThat(supervisorSummariesDto.supervisors[0].fullName).isEqualTo("Barney Rubble")
+      assertThat(supervisorSummariesDto.supervisors[0].unallocated).isTrue
+      assertThat(supervisorSummariesDto.supervisors[1].code).isEqualTo("FF01")
+      assertThat(supervisorSummariesDto.supervisors[1].fullName).isEqualTo("Fred Flintstone [PO - PO Description]")
       assertThat(supervisorSummariesDto.supervisors[1].unallocated).isFalse
-      assertThat(supervisorSummariesDto.supervisors[2].code).isEqualTo("BR01")
-      assertThat(supervisorSummariesDto.supervisors[2].fullName).isEqualTo("Barney Rubble")
-      assertThat(supervisorSummariesDto.supervisors[2].unallocated).isTrue
+      assertThat(supervisorSummariesDto.supervisors[2].code).isEqualTo("WF01")
+      assertThat(supervisorSummariesDto.supervisors[2].fullName).isEqualTo("wilma flintstone [S1 - S1 Description]")
+      assertThat(supervisorSummariesDto.supervisors[2].unallocated).isFalse
     }
 
     @Test


### PR DESCRIPTION
This endpoint was missed from the original set in CPB-997 (implemented in #696) but also needs correctly sorting alphabetically.