### PR TITLE
CPB-1010: Add feature flag for travel time tasks

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -30,6 +30,8 @@ generic-service:
     SPRINGDOC_API_DOCS_ENABLED: true
     SPRINGDOC_SWAGGER_UI_ENABLED: true
 
+    TASKS_TRAVEL_TIME_ENABLED: true
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -25,6 +25,8 @@ generic-service:
 
     SPRINGDOC_API_DOCS_ENABLED: false
     SPRINGDOC_SWAGGER_UI_ENABLED: false
+
+    TASKS_TRAVEL_TIME_ENABLED: false
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -30,6 +30,8 @@ generic-service:
 
     SPRINGDOC_API_DOCS_ENABLED: false
     SPRINGDOC_SWAGGER_UI_ENABLED: false
+
+    TASKS_TRAVEL_TIME_ENABLED: false
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -27,6 +27,8 @@ generic-service:
     SPRINGDOC_API_DOCS_ENABLED: true
     SPRINGDOC_SWAGGER_UI_ENABLED: true
 
+    TASKS_TRAVEL_TIME_ENABLED: true
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/AppointmentTaskEntityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/AppointmentTaskEntityRepository.kt
@@ -15,6 +15,7 @@ interface AppointmentTaskEntityRepository : JpaRepository<AppointmentTaskEntity,
     SELECT task FROM AppointmentTaskEntity task
     JOIN FETCH task.appointment appointment
     WHERE task.taskStatus = 'PENDING'
+    AND (task.taskType IN :taskTypes)
     AND ((cast(:fromDate as date) IS NULL) OR (appointment.date >= :fromDate))
     AND ((cast(:toDate as date) IS NULL) OR (appointment.date <= :toDate))
     AND ((cast(:providerCode as string) IS NULL) OR (appointment.providerCode = :providerCode))
@@ -24,6 +25,7 @@ interface AppointmentTaskEntityRepository : JpaRepository<AppointmentTaskEntity,
     fromDate: LocalDate?,
     toDate: LocalDate?,
     providerCode: String?,
+    taskTypes: List<AppointmentTaskType>,
     pageable: Pageable,
   ): Page<AppointmentTaskEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentTaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentTaskService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 
 import jakarta.transaction.Transactional
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.event.EventListener
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
@@ -36,6 +37,7 @@ class AppointmentTaskService(
   private val caseVisibilityService: CaseVisibilityService,
   private val appointmentTaskMappers: AppointmentTaskMappers,
   private val springEventPublisher: SpringEventPublisher,
+  @Value("\${tasks.travel-time.enabled:false}") private val enableTravelTimeTasks: Boolean,
 ) {
 
   @EventListener
@@ -43,6 +45,10 @@ class AppointmentTaskService(
   fun createTravelTimeTaskOnAppointmentCreation(
     event: AppointmentCreatedEvent,
   ) {
+    if (!enableTravelTimeTasks) {
+      return
+    }
+
     val task = createTravelTimeTaskIfRequired(
       appointment = event.appointmentEntity,
       outcome = event.createDto.contactOutcome,
@@ -57,6 +63,10 @@ class AppointmentTaskService(
   fun createTravelTimeTaskOnAppointmentUpdate(
     event: AppointmentUpdatedEvent,
   ) {
+    if (!enableTravelTimeTasks) {
+      return
+    }
+
     val task = createTravelTimeTaskIfRequired(
       appointment = event.appointmentEntity,
       outcome = event.updateDto.contactOutcome,
@@ -71,6 +81,10 @@ class AppointmentTaskService(
   fun closeTravelTimeTaskOnAdjustmentCreation(
     event: AdjustmentCreatedEvent,
   ) {
+    if (!enableTravelTimeTasks) {
+      return
+    }
+
     val trigger = event.trigger
     if (trigger.triggerType == AdjustmentEventTriggerType.APPOINTMENT_TASK) {
       val taskId = UUID.fromString(trigger.triggeredBy)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentTaskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentTaskService.kt
@@ -173,6 +173,7 @@ class AppointmentTaskService(
       fromDate = fromDate,
       toDate = toDate,
       providerCode = providerCode,
+      taskTypes = getConfiguredTaskTypes(),
       pageable = pageable,
     )
 
@@ -194,4 +195,7 @@ class AppointmentTaskService(
       pagedTasks.totalElements,
     )
   }
+
+  private fun getConfiguredTaskTypes(): List<AppointmentTaskType> = mutableListOf<AppointmentTaskType>()
+    .apply { if (enableTravelTimeTasks) this += AppointmentTaskType.ADJUSTMENT_TRAVEL_TIME }
 }

--- a/src/main/resources/application-localdev.yml
+++ b/src/main/resources/application-localdev.yml
@@ -15,3 +15,7 @@ logging:
     #reactor.netty.http.client.HttpClientConnect: DEBUG
   request:
     include-headers: true
+
+tasks:
+  travel-time:
+    enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -92,3 +92,7 @@ hmpps:
     # see https://github.com/ministryofjustice/hmpps-spring-boot-sqs
     # maxReceiveCount = 3
     defaultErrorVisibilityTimeout: 10, 60
+
+tasks:
+  travel-time:
+    enabled: false

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentTaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentTaskServiceTest.kt
@@ -363,6 +363,28 @@ class AppointmentTaskServiceTest {
 
   @Nested
   inner class GetPendingAppointmentTasks {
+    @Test
+    fun `does not return travel time tasks when they are disabled in the config`() {
+      setupService(enableTravelTimeTasks = false)
+
+      val pageable = PageRequest.of(0, 10)
+
+      val result = service.getPendingAppointmentTasks(pageable = pageable)
+
+      assertThat(result.content).hasSize(0)
+
+      verify {
+        appointmentTaskEntityRepository.findPendingTasksWithFiltersAndAppointments(
+          fromDate = null,
+          toDate = null,
+          providerCode = null,
+          taskTypes = emptyList(),
+          pageable = pageable,
+        )
+      }
+
+      verify(exactly = 0) { appointmentTaskMappers.toDto(any(), any()) }
+    }
 
     @Test
     fun `returns paginated appointment task summaries without filters`() {
@@ -391,6 +413,7 @@ class AppointmentTaskServiceTest {
           fromDate = null,
           toDate = null,
           providerCode = null,
+          taskTypes = listOf(AppointmentTaskType.ADJUSTMENT_TRAVEL_TIME),
           pageable = pageable,
         )
       } returns PageImpl(listOf(taskEntity), pageable, 1L)
@@ -435,6 +458,7 @@ class AppointmentTaskServiceTest {
           fromDate = fromDate,
           toDate = toDate,
           providerCode = providerCode,
+          taskTypes = listOf(AppointmentTaskType.ADJUSTMENT_TRAVEL_TIME),
           pageable = pageable,
         )
       } returns PageImpl(listOf(taskEntity), pageable, 1L)
@@ -462,6 +486,7 @@ class AppointmentTaskServiceTest {
           fromDate = null,
           toDate = null,
           providerCode = null,
+          taskTypes = listOf(AppointmentTaskType.ADJUSTMENT_TRAVEL_TIME),
           pageable = pageable,
         )
       } returns PageImpl(emptyList(), pageable, 0L)
@@ -519,6 +544,7 @@ class AppointmentTaskServiceTest {
           fromDate = null,
           toDate = null,
           providerCode = null,
+          taskTypes = listOf(AppointmentTaskType.ADJUSTMENT_TRAVEL_TIME),
           pageable = pageable,
         )
       } returns PageImpl(
@@ -570,6 +596,7 @@ class AppointmentTaskServiceTest {
           fromDate = fromDate,
           toDate = null,
           providerCode = null,
+          taskTypes = listOf(AppointmentTaskType.ADJUSTMENT_TRAVEL_TIME),
           pageable = pageable,
         )
       } returns PageImpl(listOf(taskEntity), pageable, 1L)
@@ -609,6 +636,7 @@ class AppointmentTaskServiceTest {
           fromDate = null,
           toDate = null,
           providerCode = null,
+          taskTypes = listOf(AppointmentTaskType.ADJUSTMENT_TRAVEL_TIME),
           pageable = pageable,
         )
       } returns PageImpl(listOf(taskEntity), pageable, 1L)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentTaskServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentTaskServiceTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service
 
 import io.mockk.every
-import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
@@ -69,7 +68,6 @@ class AppointmentTaskServiceTest {
   @RelaxedMockK
   private lateinit var springEventPublisher: SpringEventPublisher
 
-  @InjectMockKs
   private lateinit var service: AppointmentTaskService
 
   private companion object {
@@ -83,6 +81,19 @@ class AppointmentTaskServiceTest {
         taskId = (args[0] as AppointmentTaskEntity).id,
       )
     }
+
+    setupService(enableTravelTimeTasks = true)
+  }
+
+  private fun setupService(enableTravelTimeTasks: Boolean) {
+    service = AppointmentTaskService(
+      appointmentTaskEntityRepository,
+      contextService,
+      caseVisibilityService,
+      appointmentTaskMappers,
+      springEventPublisher,
+      enableTravelTimeTasks,
+    )
   }
 
   @Nested
@@ -125,6 +136,24 @@ class AppointmentTaskServiceTest {
           project = ProjectDto.valid().copy(projectType = ProjectTypeDto.valid().copy(group = projectTypeGroup)),
         ),
       )
+
+      service.createTravelTimeTaskOnAppointmentCreation(event)
+
+      verify(exactly = 0) { appointmentTaskEntityRepository.save(any()) }
+    }
+
+    @Test
+    fun `travel time tasks are disabled in the config, do nothing`() {
+      setupService(enableTravelTimeTasks = false)
+
+      val event = AppointmentCreatedEvent.valid().copy(
+        createDto = ValidatedAppointment.validCreateAppointment().copy(
+          contactOutcome = ContactOutcomeEntity.valid().copy(attended = true),
+          project = ProjectDto.valid().copy(projectType = ProjectTypeDto.valid().copy(group = ProjectTypeGroupDto.GROUP)),
+        ),
+      )
+
+      every { appointmentTaskEntityRepository.save(any()) } returnsArgument 0
 
       service.createTravelTimeTaskOnAppointmentCreation(event)
 
@@ -201,6 +230,24 @@ class AppointmentTaskServiceTest {
       verify(exactly = 0) { appointmentTaskEntityRepository.save(any()) }
     }
 
+    @Test
+    fun `travel time tasks are disabled in the config, do nothing`() {
+      setupService(enableTravelTimeTasks = false)
+
+      val event = AppointmentUpdatedEvent.valid().copy(
+        updateDto = ValidatedAppointment.validUpdateAppointment().copy(
+          contactOutcome = ContactOutcomeEntity.valid().copy(attended = true),
+          project = ProjectDto.valid().copy(projectType = ProjectTypeDto.valid().copy(group = ProjectTypeGroupDto.GROUP)),
+        ),
+      )
+
+      every { appointmentTaskEntityRepository.save(any()) } returnsArgument 0
+
+      service.createTravelTimeTaskOnAppointmentUpdate(event)
+
+      verify(exactly = 0) { appointmentTaskEntityRepository.save(any()) }
+    }
+
     @ParameterizedTest
     @CsvSource("GROUP", "INDIVIDUAL")
     fun `only create task if outcome is attended and project group type supports travel time`(
@@ -227,6 +274,28 @@ class AppointmentTaskServiceTest {
 
   @Nested
   inner class CompleteTravelTimeTaskOnAdjustmentCreation {
+    @Test
+    fun `travel time tasks are disabled in the config, do nothing`() {
+      setupService(enableTravelTimeTasks = false)
+
+      val task = AppointmentTaskEntity.validPending()
+      val triggeredAt = OffsetDateTime.now()
+
+      every { appointmentTaskEntityRepository.findByIdOrNull(task.id) } returns task
+      every { contextService.getUserName() } returns "currentUsername"
+      every { appointmentTaskEntityRepository.save(any()) } returnsArgument 0
+
+      service.closeTravelTimeTaskOnAdjustmentCreation(
+        AdjustmentCreatedEvent.valid().copy(
+          trigger = AdjustmentEventTrigger.valid().copy(
+            triggeredAt = triggeredAt,
+            triggeredBy = task.id.toString(),
+          ),
+        ),
+      )
+
+      verify(exactly = 0) { appointmentTaskEntityRepository.save(any()) }
+    }
 
     @Test
     fun `complete task linked to the adjustment`() {

--- a/src/test/resources/application-integrationtest.yml
+++ b/src/test/resources/application-integrationtest.yml
@@ -96,3 +96,7 @@ client:
     url: http://localhost:${wiremock.server.port}/community-payback-and-delius
   probation-access-control:
     url: http://localhost:${wiremock.server.port}/probation-access-control
+
+tasks:
+  travel-time:
+    enabled: true


### PR DESCRIPTION
Currently travel time tasks are automatically created for appointments processed in the Community Payback service. However, this feature needs redesigning and so it's necessary to disable it in higher environments until the team is more confident in it.

This PR introduces a feature flag for travel time tasks through the `tasks.travel-time.enabled` configuration property. If not set or set to `false`, it:
- skips creating travel time tasks for `AppointmentCreatedEvent`s and `AppointmentUpdatedEvent`s
- skips closing travel time tasks for `AdjustmentCreatedEvent`s
- excludes travel time tasks from the results returned by the `GET /admin/appointment-tasks/pending` endpoint.

This PR also sets the configuration like so:

| Environment | `tasks.travel-time.enabled` |
|---|---|
| local | true |
| dev | true |
| test | true |
| integrationtest | true |
| preprod | false |
| prod | false |

This allows the existing behaviour to be preserved in development to allow the feature to be further refined.