### PR TITLE
CPB-944: Ensure notes cannot accept HTML input

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/SanitizingStringDeserializer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/SanitizingStringDeserializer.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.common
 
 import org.owasp.html.Encoding
+import org.owasp.html.HtmlChangeListener
+import org.owasp.html.HtmlPolicyBuilder
 import org.owasp.html.PolicyFactory
-import org.owasp.html.Sanitizers
 import tools.jackson.core.JsonParser
+import tools.jackson.databind.DatabindException
 import tools.jackson.databind.DeserializationContext
 import tools.jackson.databind.deser.std.StdScalarDeserializer
 
@@ -12,11 +14,24 @@ import tools.jackson.databind.deser.std.StdScalarDeserializer
  */
 class SanitizingStringDeserializer : StdScalarDeserializer<String>(String::class.java) {
   companion object {
-    val POLICY: PolicyFactory = Sanitizers.FORMATTING.and(Sanitizers.LINKS)
+    // Disallows everything
+    val POLICY: PolicyFactory = HtmlPolicyBuilder().toFactory()
   }
 
   override fun deserialize(
     p: JsonParser,
     ctxt: DeserializationContext,
-  ): String? = Encoding.decodeHtml(POLICY.sanitize(p.valueAsString), false)
+  ): String? = Encoding.decodeHtml(
+    POLICY.sanitize(p.valueAsString, ThrowingHtmlChangeListener(), p),
+    false,
+  )
+}
+
+class ThrowingHtmlChangeListener : HtmlChangeListener<JsonParser> {
+  override fun discardedTag(ctx: JsonParser?, elementName: String): Unit = throw DatabindException.from(ctx, "Tag '<$elementName>' is not allowed")
+
+  override fun discardedAttributes(ctx: JsonParser?, elementName: String, vararg attributeNames: String?): Unit = throw DatabindException.from(
+    ctx,
+    "Attributes [${attributeNames.joinToString(", ") { "'$it'" }}] are not allowed on tag '<$elementName>'",
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CommunityPaybackApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/CommunityPaybackApiExceptionHandler.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.MissingServletRequestParameterException
@@ -34,6 +35,7 @@ class CommunityPaybackApiExceptionHandler(
     BadRequestException::class,
     MethodArgumentNotValidException::class,
     MethodArgumentTypeMismatchException::class,
+    HttpMessageNotReadableException::class,
   )
   fun validationError(e: Exception): ResponseEntity<ErrorResponse> = ResponseEntity
     .status(BAD_REQUEST)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CourseCompletionResolutionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CourseCompletionResolutionDto.kt
@@ -35,6 +35,7 @@ data class CourseCompletionCreditTimeDetailsDto(
 }
 
 data class CourseCompletionDontCreditTimeDetailsDto(
+  @field:JsonDeserialize(using = SanitizingStringDeserializer::class)
   val notes: String?,
 ) {
   companion object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
@@ -204,7 +204,7 @@ class AdminAppointmentIT : IntegrationTestBase() {
     }
 
     @Test
-    fun `Should update upstream, raise domain event create travel time task & sanitise notes`() {
+    fun `Should update upstream, raise domain event, create travel time task`() {
       appointmentTaskEntityRepository.deleteAll()
       appointmentEventEntityRepository.deleteAll()
 
@@ -235,7 +235,6 @@ class AdminAppointmentIT : IntegrationTestBase() {
             contactOutcomeCode = CODE_ATTENDED_COMPLIED,
             startTime = LocalTime.of(0, 0),
             endTime = LocalTime.of(1, 0),
-            notes = "A note with some script <script>here()</script>",
           ),
         )
         .exchange()
@@ -250,7 +249,6 @@ class AdminAppointmentIT : IntegrationTestBase() {
       domainEventAsserter.assertEventCount("community-payback.appointment.updated", 1)
 
       assertThat(appointmentTaskEntityRepository.findAll()).hasSize(1)
-      assertThat(appointmentEventEntityRepository.findAll()[0].notes).isEqualTo("A note with some script ")
     }
   }
 
@@ -321,7 +319,7 @@ class AdminAppointmentIT : IntegrationTestBase() {
     }
 
     @Test
-    fun `Should update upstream, raise domain event, create travel time task and sanitise notes`() {
+    fun `Should update upstream, raise domain event, create travel time task`() {
       appointmentTaskEntityRepository.deleteAll()
 
       CommunityPaybackAndDeliusMockServer.Aggregates.setupGetDataMocksForUpdateAppointment(
@@ -351,7 +349,6 @@ class AdminAppointmentIT : IntegrationTestBase() {
             contactOutcomeCode = CODE_ATTENDED_COMPLIED,
             startTime = LocalTime.of(0, 0),
             endTime = LocalTime.of(1, 0),
-            notes = "A note with some script <script>here()</script>",
           ),
         )
         .exchange()
@@ -366,7 +363,6 @@ class AdminAppointmentIT : IntegrationTestBase() {
       domainEventAsserter.assertEventCount("community-payback.appointment.updated", 1)
 
       assertThat(appointmentTaskEntityRepository.findAll()).hasSize(1)
-      assertThat(appointmentEventEntityRepository.findAll()[0].notes).isEqualTo("A note with some script ")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
@@ -745,7 +745,7 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
     }
 
     @Test
-    fun `if type is CREDIT_TIME, should create appointment when appointmentIdToUpdate is null, with sanitized notes`() {
+    fun `if type is CREDIT_TIME, should create appointment when appointmentIdToUpdate is null`() {
       val eventEntity = eteCourseCompletionEventEntityRepository.save(
         EteCourseCompletionEventEntity.valid(ctx).copy(),
       )
@@ -759,7 +759,6 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
           appointmentIdToUpdate = null,
           projectCode = PROJECT_CODE,
           minutesToCredit = 90,
-          notes = "A note with some script <script>here()</script>",
         ),
       )
 
@@ -794,11 +793,10 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
 
       val resolutionEntity = eteCourseCompletionEventEntityRepository.findByIdOrNull(eventEntity.id)!!.resolution!!
       assertThat(resolutionEntity.resolution).isEqualTo(EteCourseCompletionResolution.CREDIT_TIME)
-      assertThat(resolutionEntity.notes).isEqualTo("A note with some script ")
     }
 
     @Test
-    fun `if type is CREDIT_TIME, should update appointment when appointmentIdToUpdate is present, with sanitized notes`() {
+    fun `if type is CREDIT_TIME, should update appointment when appointmentIdToUpdate is present`() {
       val appointmentId = 12345L
 
       CommunityPaybackAndDeliusMockServer.Aggregates.setupGetDataMocksForUpdateAppointment(
@@ -832,7 +830,6 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
           appointmentIdToUpdate = appointmentId,
           projectCode = PROJECT_CODE,
           minutesToCredit = 30,
-          notes = "A note with some script <script>here()</script>",
         ),
       )
 
@@ -857,7 +854,6 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
 
       val resolutionEntity = eteCourseCompletionEventEntityRepository.findByIdOrNull(eventEntity.id)!!.resolution!!
       assertThat(resolutionEntity.resolution).isEqualTo(EteCourseCompletionResolution.CREDIT_TIME)
-      assertThat(resolutionEntity.notes).isEqualTo("A note with some script ")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/ResourceSecurityIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/ResourceSecurityIT.kt
@@ -27,6 +27,7 @@ class ResourceSecurityIT : IntegrationTestBase() {
     "POST /it/idempotency/success",
     "POST /it/idempotency/client-error",
     "POST /it/idempotency/use-body-as-status-code",
+    "POST /it/sanitizing-strings/item",
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/SanitizingStringDeserializerIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/SanitizingStringDeserializerIT.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.integration
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import tools.jackson.databind.annotation.JsonDeserialize
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.SanitizingStringDeserializer
+
+@RestController
+@RequestMapping(
+  "/it/sanitizing-strings",
+  produces = [MediaType.APPLICATION_JSON_VALUE],
+)
+class SanitizingStringDeserializerTestEndpoints {
+  @PostMapping("/item")
+  fun postItem(@RequestBody item: ItemDto) = ResponseEntity.status(HttpStatus.CREATED).body(item)
+}
+
+data class ItemDto(
+  @field:JsonDeserialize(using = SanitizingStringDeserializer::class)
+  val value: String,
+)
+
+class SanitizingStringDeserializerIT : IntegrationTestBase() {
+  @Test
+  fun `strings containing HTML tags should return a 400 Bad Request response`() {
+    webTestClient.post()
+      .uri("it/sanitizing-strings/item")
+      .addAdminUiAuthHeader("theusername")
+      .bodyValue(ItemDto("<h1>Big text</h1>"))
+      .exchange()
+      .expectStatus().isEqualTo(400)
+  }
+
+  @Test
+  fun `strings without HTML tags should successfully deserialize`() {
+    webTestClient.post()
+      .uri("it/sanitizing-strings/item")
+      .addAdminUiAuthHeader("theusername")
+      .bodyValue(ItemDto("Regular text"))
+      .exchange()
+      .expectStatus().isEqualTo(HttpStatus.CREATED)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/common/SanitizingStringDeserializerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/common/SanitizingStringDeserializerTest.kt
@@ -1,22 +1,35 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.common
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import tools.jackson.databind.DatabindException
 import tools.jackson.databind.annotation.JsonDeserialize
 import tools.jackson.module.kotlin.jacksonObjectMapper
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.SanitizingStringDeserializer
 
 class SanitizingStringDeserializerTest {
-  @Test
-  fun `sanitise html`() {
-    val result = jacksonObjectMapper().readValue(
-      """
-        {"notes": "a note with some script<script>alert('hello')</script>"}
-      """.trimIndent(),
-      MyRequestDto::class.java,
-    )
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      "a note with some script<script>alert('hello')</script>,Tag '<script>' is not allowed",
+      "a note with a <a href='https://example.com/'>link</a>,Tag '<a>' is not allowed",
+      "a note with <h1>big text</h1>,Tag '<h1>' is not allowed",
+    ],
+  )
+  fun `validates that html tags are not present`(notes: String, expectedMessage: String) {
+    val ex = assertThrows(DatabindException::class.java) {
+      jacksonObjectMapper().readValue(
+        """
+          {"notes": "$notes"}
+        """.trimIndent(),
+        MyRequestDto::class.java,
+      )
+    }
 
-    assertThat(result.notes).isEqualTo("a note with some script")
+    assertThat(ex).hasMessageStartingWith(expectedMessage)
   }
 
   @Test


### PR DESCRIPTION
Currently, the API's approach to user-supplied text is to allow HTML for formatting and links, and to sanitise inputs that violate this rule. However, the ITHC policy suggests that no HTML should be accepted at all. Additionally, rather than sanitising violating inputs, reporting this as a validation error to the user is more appropriate.

This PR updates the API's approach to HTML sanitisation so that it rejects any attempt to include HTML in user-supplied text. To do this, the following changes have been made to the `SanitizingStringDeserializer` class:
- The policy used has been changed to be maximally strict
- An `HtmlChangeListener` is now used when sanitising which throws a Jackson `DatabindException` when a disallowed HTML tag or annotation is encountered.

This change has made visible a bug where JSON parsing failures return a 500 Internal Server Error response instead of the more correct 400 Bad Request. This has been fixed by updating the validation error handler in `CommunityPaybackApiExceptionHandler` to include `HttpMessageNotReadableException`. An integration test has been added to make sure that strings deserialised with `SanitizingStringDeserializer` return 400 Bad Request in this scenario, preventing future regressions in this behaviour.

Finally, `CourseCompletionDontCreditTimeDetailsDto` has been updated so that its notes field also performs this validation, as this was missing.