### PR TITLE
CPB-1018: Add Snyk scan to GitHub workflows

### DIFF
--- a/.github/workflows/security_snyk_scan.yml
+++ b/.github/workflows/security_snyk_scan.yml
@@ -1,0 +1,26 @@
+name: Security Snyk dependency check
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 9 * * MON-FRI" # Every weekday
+jobs:
+  security-snyk-check:
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    name: Project security Snyk dependency check
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_snyk_scan.yml@v2
+    with:
+      channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
+      subproject: ''
+      severity: 'HIGH,CRITICAL'
+      scan_type: 'image' # or 'fs'
+      location: '.'
+      slack_include_summary: true
+      snyk_policy_path: '' # Optional path to a custom Snyk policy file
+    secrets:
+      HMPPS_SNYK_CLIENT_SECRET: ${{ secrets.HMPPS_SNYK_CLIENT_SECRET }}
+      HMPPS_SNYK_CLIENT_ID: ${{ secrets.HMPPS_SNYK_CLIENT_ID }}
+      HMPPS_SRE_SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}


### PR DESCRIPTION
HMPPS has changed its recommended dependency scanning tool from Trivy to Snyk. This introduces a GitHub workflow to run a Snyk scan as found here: https://github.com/ministryofjustice/hmpps-template-kotlin/blob/main/.github/workflows/security_snyk_scan.yml