### PR TITLE
Fix occasional test failures in `AdminCourseCompletionIT` with 400 response

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/Randoms.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/Randoms.kt
@@ -5,7 +5,9 @@ import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 import kotlin.random.Random
 
 fun Boolean.Companion.random() = Random.nextBoolean()
@@ -21,7 +23,7 @@ fun randomOffsetDateTime(): OffsetDateTime = OffsetDateTime.of(randomLocalDate()
 fun randomDuration(): Duration = Duration.ofHours(Long.random(0, 12)).plusMinutes(Long.random(0, 60))
 fun randomHourMinuteDuration(): HourMinuteDuration = HourMinuteDuration(randomDuration())
 
-fun LocalDate.withRandomTime(from: LocalTime = LocalTime.MIN, to: LocalTime = LocalTime.MAX): OffsetDateTime = OffsetDateTime.of(this, LocalTime.MIN, ZoneOffset.UTC).withRandomTime(from, to)
+fun LocalDate.withRandomTime(from: LocalTime = LocalTime.MIN, to: LocalTime = LocalTime.MAX): OffsetDateTime = ZonedDateTime.of(this, LocalTime.MIN, ZoneId.of("Europe/London")).toOffsetDateTime().withRandomTime(from, to)
 
 fun OffsetDateTime.withRandomTime(from: LocalTime = LocalTime.MIN, to: LocalTime = LocalTime.MAX): OffsetDateTime {
   val second = Int.random(from.toSecondOfDay(), to.toSecondOfDay())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/entity/EteCourseCompletionEventEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/entity/EteCourseCompletionEventEntityFactory.kt
@@ -27,7 +27,7 @@ fun EteCourseCompletionEventEntity.Companion.valid() = EteCourseCompletionEventE
   courseType = String.random(20),
   provider = String.random(5),
   status = EteCourseCompletionEventStatus.entries.random(),
-  completionDateTime = randomLocalDate().withRandomTime(from = LocalTime.of(12, 0), to = LocalTime.MAX),
+  completionDateTime = randomLocalDate().withRandomTime(from = LocalTime.of(6, 0), to = LocalTime.of(21, 0)),
   totalTimeMinutes = Random.nextLong(10, 100),
   attempts = 1,
   expectedTimeMinutes = Random.nextLong(30, 240),


### PR DESCRIPTION
Occasionally, tests that `POST` to the `/admin/course-completions/{id}/resolution` endpoint will fail with a 400 Bad Request response.

This seems to be because of an edge case around how course completions around midnight are handled, resulting in the expected appointment details having incorrect times.

To resolve this, the `EteCourseCompletionEventEntity.valid()` test factory method has been updated to pick a completion timestamp far enough away from midnight that this problem will be avoided (specifically, between 6am and 9pm, chosen to roughly reflect times that real course completions are mostly likely to be submitted).

Additionally, the `LocalDate.withRandomTime` test utility function has been updated to correctly supply a timestamp with the Europe/London timezone rather than UTC.