### PR TITLE
CPB-1065: Implement endpoint to retrieve course completion history in blocks

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminCourseCompletionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminCourseCompletionController.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Min
 import org.springdoc.core.converters.models.PageableAsQueryParam
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -15,6 +16,7 @@ import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -36,6 +38,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 @AdminUiController
+@Validated
 @RequestMapping(
   "/admin",
   produces = [MediaType.APPLICATION_JSON_VALUE],
@@ -176,7 +179,7 @@ class AdminCourseCompletionController(val eteService: EteService) {
   )
   fun getCourseCompletionHistoryBlock(
     @PathVariable id: UUID,
-    @RequestParam(defaultValue = "3") blockSize: Int,
+    @RequestParam(defaultValue = "3") @Min(1) blockSize: Int,
   ): List<EteCourseCompletionEventDto> {
     ensureCourseCompletionExists(id)
     return eteService.getCourseCompletionBlock(id, blockSize)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminCourseCompletionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminCourseCompletionController.kt
@@ -166,5 +166,21 @@ class AdminCourseCompletionController(val eteService: EteService) {
     return eteService.getCourseCompletionRecommendation(id) ?: notFound("Course completion event", id.toString())
   }
 
+  @GetMapping("/course-completions/{id}/history-block", produces = [MediaType.APPLICATION_JSON_VALUE])
+  @Operation(
+    description = "Gets the history of course attempts for this course completion in a block of a specific size.",
+    responses = [
+      ApiResponse(responseCode = "200", description = "List of course completion events in the block"),
+      ApiResponse(responseCode = "404", description = "Course completion not found", content = [Content(schema = Schema(implementation = ErrorResponse::class))]),
+    ],
+  )
+  fun getCourseCompletionHistoryBlock(
+    @PathVariable id: UUID,
+    @RequestParam(defaultValue = "3") blockSize: Int,
+  ): List<EteCourseCompletionEventDto> {
+    ensureCourseCompletionExists(id)
+    return eteService.getCourseCompletionBlock(id, blockSize)
+  }
+
   private fun ensureCourseCompletionExists(id: UUID) = eteService.getCourseCompletionEvent(id) ?: notFound("Course completion event", id.toString())
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionEventEntityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionEventEntityRepository.kt
@@ -55,6 +55,22 @@ interface EteCourseCompletionEventEntityRepository : JpaRepository<EteCourseComp
     toDateTimeExclusive: OffsetDateTime?,
   ): List<EteCourseCompletionEventEntity>
 
+  @Query(
+    """
+    SELECT e FROM EteCourseCompletionEventEntity e
+    WHERE e.pdu.providerCode = :providerCode 
+    AND e.externalReference = :externalReference
+    AND e.attempts BETWEEN :startAttempt AND :endAttempt
+    ORDER BY e.attempts ASC
+  """,
+  )
+  fun findBlock(
+    providerCode: String,
+    externalReference: String,
+    startAttempt: Int,
+    endAttempt: Int,
+  ): List<EteCourseCompletionEventEntity>
+
   enum class ResolutionStatus {
     ANY,
     RESOLVED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionEventEntityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionEventEntityRepository.kt
@@ -55,6 +55,8 @@ interface EteCourseCompletionEventEntityRepository : JpaRepository<EteCourseComp
     toDateTimeExclusive: OffsetDateTime?,
   ): List<EteCourseCompletionEventEntity>
 
+  fun findAllByExternalReferenceOrderByCompletionDateTimeAscAttemptsAsc(externalReference: String): List<EteCourseCompletionEventEntity>
+
   enum class ResolutionStatus {
     ANY,
     RESOLVED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionEventEntityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionEventEntityRepository.kt
@@ -55,8 +55,6 @@ interface EteCourseCompletionEventEntityRepository : JpaRepository<EteCourseComp
     toDateTimeExclusive: OffsetDateTime?,
   ): List<EteCourseCompletionEventEntity>
 
-  fun findAllByExternalReferenceOrderByCompletionDateTimeAscAttemptsAsc(externalReference: String): List<EteCourseCompletionEventEntity>
-
   enum class ResolutionStatus {
     ANY,
     RESOLVED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
@@ -113,6 +113,7 @@ class EteService(
   fun getCourseCompletionEvent(id: UUID) = eteCourseCompletionEventEntityRepository.findByIdOrNull(id)?.toDto()
 
   fun getCourseCompletionBlock(id: UUID, blockSize: Int): List<EteCourseCompletionEventDto> {
+    require(blockSize > 0) { "blockSize must be greater than 0" }
     val event = getEventOrError(id)
     val allEvents = eteCourseCompletionEventEntityRepository.findAllByExternalReferenceOrderByCompletionDateTimeAscAttemptsAsc(event.externalReference)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
@@ -2,7 +2,9 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -115,17 +117,37 @@ class EteService(
   fun getCourseCompletionBlock(id: UUID, blockSize: Int): List<EteCourseCompletionEventDto> {
     require(blockSize > 0) { "blockSize must be greater than 0" }
     val event = getEventOrError(id)
-    val allEvents = eteCourseCompletionEventEntityRepository.findAllByExternalReferenceOrderByCompletionDateTimeAscAttemptsAsc(event.externalReference)
 
-    val index = allEvents.indexOfFirst { it.id == id }
-    if (index == -1) return emptyList()
+    val sort = Sort.by(Sort.Order.asc("completionDateTime"), Sort.Order.asc("attempts"))
 
-    val blockIndex = index / blockSize
-    val start = blockIndex * blockSize
-    val end = minOf(start + blockSize, allEvents.size)
-
-    return allEvents.subList(start, end).map { it.toDto() }
+    var pageNumber = 0
+    var courseCompletions = getCourseCompletionsByBlockSize(event, pageNumber, blockSize, sort)
+    while (!courseCompletions.content.contains(event)) {
+      pageNumber++
+      courseCompletions = getCourseCompletionsByBlockSize(event, pageNumber, blockSize, sort)
+    }
+    return courseCompletions.content.map { it.toDto() }
   }
+
+  private fun getCourseCompletionsByBlockSize(
+    event: EteCourseCompletionEventEntity,
+    pageNumber: Int,
+    blockSize: Int,
+    sort: Sort,
+  ): Page<EteCourseCompletionEventEntity> = eteCourseCompletionEventEntityRepository.findAllWithFilters(
+    providerCode = event.pdu.providerCode,
+    pduId = null,
+    officesCount = 0,
+    offices = emptyList(),
+    resolutionStatus = ResolutionStatus.ANY,
+    courseFailures = CourseFailureFilter.SHOW_ALL,
+    externalReference = event.externalReference,
+    fromDate = null,
+    toDate = null,
+    availableFromDate = null,
+    availableToDate = null,
+    pageable = PageRequest.of(pageNumber, blockSize, sort),
+  )
 
   fun getCourseCompletionRecommendation(id: UUID): CourseCompletionRecommendationDto? {
     val courseCompletionEvent = getEventOrError(id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
@@ -2,9 +2,7 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -117,37 +115,18 @@ class EteService(
   fun getCourseCompletionBlock(id: UUID, blockSize: Int): List<EteCourseCompletionEventDto> {
     require(blockSize > 0) { "blockSize must be greater than 0" }
     val event = getEventOrError(id)
+    val attempts = event.attempts ?: 1
 
-    val sort = Sort.by(Sort.Order.asc("completionDateTime"), Sort.Order.asc("attempts"))
+    val startAttempt = ((attempts - 1) / blockSize) * blockSize + 1
+    val endAttempt = startAttempt + blockSize - 1
 
-    var pageNumber = 0
-    var courseCompletions = getCourseCompletionsByBlockSize(event, pageNumber, blockSize, sort)
-    while (!courseCompletions.content.contains(event)) {
-      pageNumber++
-      courseCompletions = getCourseCompletionsByBlockSize(event, pageNumber, blockSize, sort)
-    }
-    return courseCompletions.content.map { it.toDto() }
+    return eteCourseCompletionEventEntityRepository.findBlock(
+      event.pdu.providerCode,
+      event.externalReference,
+      startAttempt,
+      endAttempt,
+    ).map { it.toDto() }
   }
-
-  private fun getCourseCompletionsByBlockSize(
-    event: EteCourseCompletionEventEntity,
-    pageNumber: Int,
-    blockSize: Int,
-    sort: Sort,
-  ): Page<EteCourseCompletionEventEntity> = eteCourseCompletionEventEntityRepository.findAllWithFilters(
-    providerCode = event.pdu.providerCode,
-    pduId = null,
-    officesCount = 0,
-    offices = emptyList(),
-    resolutionStatus = ResolutionStatus.ANY,
-    courseFailures = CourseFailureFilter.SHOW_ALL,
-    externalReference = event.externalReference,
-    fromDate = null,
-    toDate = null,
-    availableFromDate = null,
-    availableToDate = null,
-    pageable = PageRequest.of(pageNumber, blockSize, sort),
-  )
 
   fun getCourseCompletionRecommendation(id: UUID): CourseCompletionRecommendationDto? {
     val courseCompletionEvent = getEventOrError(id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
@@ -112,6 +112,20 @@ class EteService(
 
   fun getCourseCompletionEvent(id: UUID) = eteCourseCompletionEventEntityRepository.findByIdOrNull(id)?.toDto()
 
+  fun getCourseCompletionBlock(id: UUID, blockSize: Int): List<EteCourseCompletionEventDto> {
+    val event = getEventOrError(id)
+    val allEvents = eteCourseCompletionEventEntityRepository.findAllByExternalReferenceOrderByCompletionDateTimeAscAttemptsAsc(event.externalReference)
+
+    val index = allEvents.indexOfFirst { it.id == id }
+    if (index == -1) return emptyList()
+
+    val blockIndex = index / blockSize
+    val start = blockIndex * blockSize
+    val end = minOf(start + blockSize, allEvents.size)
+
+    return allEvents.subList(start, end).map { it.toDto() }
+  }
+
   fun getCourseCompletionRecommendation(id: UUID): CourseCompletionRecommendationDto? {
     val courseCompletionEvent = getEventOrError(id)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
@@ -1206,12 +1206,60 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
       val externalReference = "EXT-REF-3"
       val pdu = communityCampusPduEntityRepository.findAll().first()
 
-      val courseCompletion1 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-15T17:00:00Z"), attempts = 1, pdu = pdu))
-      val courseCompletion2 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-15T17:15:00Z"), attempts = 2, pdu = pdu))
-      val courseCompletion3 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-15T17:24:00Z"), attempts = 3, pdu = pdu))
-      val courseCompletion4 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-17T12:00:00Z"), attempts = 1, pdu = pdu))
-      val courseCompletion5 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-18T12:00:00Z"), attempts = 2, pdu = pdu))
-      val courseCompletion6 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-19T12:00:00Z"), attempts = 3, pdu = pdu))
+      val courseCompletion1 = eteCourseCompletionEventEntityRepository.save(
+        EteCourseCompletionEventEntity.failed(ctx).copy(
+          id = UUID.randomUUID(),
+          externalReference = externalReference,
+          completionDateTime = OffsetDateTime.parse("2026-06-15T17:00:00Z"),
+          attempts = 1,
+          pdu = pdu,
+        ),
+      )
+      val courseCompletion2 = eteCourseCompletionEventEntityRepository.save(
+        EteCourseCompletionEventEntity.failed(ctx).copy(
+          id = UUID.randomUUID(),
+          externalReference = externalReference,
+          completionDateTime = OffsetDateTime.parse("2026-06-15T17:15:00Z"),
+          attempts = 2,
+          pdu = pdu,
+        ),
+      )
+      val courseCompletion3 = eteCourseCompletionEventEntityRepository.save(
+        EteCourseCompletionEventEntity.failed(ctx).copy(
+          id = UUID.randomUUID(),
+          externalReference = externalReference,
+          completionDateTime = OffsetDateTime.parse("2026-06-15T17:24:00Z"),
+          attempts = 3,
+          pdu = pdu,
+        ),
+      )
+      val courseCompletion4 = eteCourseCompletionEventEntityRepository.save(
+        EteCourseCompletionEventEntity.failed(ctx).copy(
+          id = UUID.randomUUID(),
+          externalReference = externalReference,
+          completionDateTime = OffsetDateTime.parse("2026-06-17T12:00:00Z"),
+          attempts = 1,
+          pdu = pdu,
+        ),
+      )
+      val courseCompletion5 = eteCourseCompletionEventEntityRepository.save(
+        EteCourseCompletionEventEntity.failed(ctx).copy(
+          id = UUID.randomUUID(),
+          externalReference = externalReference,
+          completionDateTime = OffsetDateTime.parse("2026-06-18T12:00:00Z"),
+          attempts = 2,
+          pdu = pdu,
+        ),
+      )
+      val courseCompletion6 = eteCourseCompletionEventEntityRepository.save(
+        EteCourseCompletionEventEntity.passed(ctx).copy(
+          id = UUID.randomUUID(),
+          externalReference = externalReference,
+          completionDateTime = OffsetDateTime.parse("2026-06-19T12:00:00Z"),
+          attempts = 3,
+          pdu = pdu,
+        ),
+      )
 
       val block1 = webTestClient.get()
         .uri("/admin/course-completions/${courseCompletion3.id}/history-block")
@@ -1239,10 +1287,38 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
       val externalReference = "EXT-REF-CUSTOM"
       val pdu = communityCampusPduEntityRepository.findAll().first()
 
-      val courseCompletion1 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-15T17:00:00Z"), pdu = pdu))
-      val courseCompletion2 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-15T17:15:00Z"), pdu = pdu))
-      val courseCompletion3 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-15T17:24:00Z"), pdu = pdu))
-      val courseCompletion4 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-17T12:00:00Z"), pdu = pdu))
+      val courseCompletion1 = eteCourseCompletionEventEntityRepository.save(
+        EteCourseCompletionEventEntity.failed(ctx).copy(
+          id = UUID.randomUUID(),
+          externalReference = externalReference,
+          completionDateTime = OffsetDateTime.parse("2026-06-15T17:00:00Z"),
+          pdu = pdu,
+        ),
+      )
+      val courseCompletion2 = eteCourseCompletionEventEntityRepository.save(
+        EteCourseCompletionEventEntity.failed(ctx).copy(
+          id = UUID.randomUUID(),
+          externalReference = externalReference,
+          completionDateTime = OffsetDateTime.parse("2026-06-15T17:15:00Z"),
+          pdu = pdu,
+        ),
+      )
+      val courseCompletion3 = eteCourseCompletionEventEntityRepository.save(
+        EteCourseCompletionEventEntity.failed(ctx).copy(
+          id = UUID.randomUUID(),
+          externalReference = externalReference,
+          completionDateTime = OffsetDateTime.parse("2026-06-15T17:24:00Z"),
+          pdu = pdu,
+        ),
+      )
+      val courseCompletion4 = eteCourseCompletionEventEntityRepository.save(
+        EteCourseCompletionEventEntity.passed(ctx).copy(
+          id = UUID.randomUUID(),
+          externalReference = externalReference,
+          completionDateTime = OffsetDateTime.parse("2026-06-17T12:00:00Z"),
+          pdu = pdu,
+        ),
+      )
 
       val block = webTestClient.get()
         .uri("/admin/course-completions/${courseCompletion1.id}/history-block?blockSize=2")
@@ -1263,6 +1339,21 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
         .bodyAsObject<List<EteCourseCompletionEventDto>>()
 
       assertThat(block2.map { it.id }).containsExactly(courseCompletion3.id, courseCompletion4.id)
+    }
+
+    @Test
+    fun `should return 400 when block size is less than 1`() {
+      val pdu = communityCampusPduEntityRepository.findAll().first()
+      val event = eteCourseCompletionEventEntityRepository.save(
+        EteCourseCompletionEventEntity.failed(ctx).copy(id = UUID.randomUUID(), pdu = pdu),
+      )
+
+      webTestClient.get()
+        .uri("/admin/course-completions/${event.id}/history-block?blockSize=0")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isBadRequest
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
@@ -1159,4 +1159,110 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
       assertThat(recommendation.crn).isNull()
     }
   }
+
+  @Nested
+  @DisplayName("GET /course-completions/{id}/history-block")
+  inner class GetCourseCompletionHistoryBlockEndpoint {
+
+    @BeforeEach
+    fun setUp() {
+      databasePurgeUtils.deleteAllEteData()
+    }
+
+    @Test
+    fun `should return unauthorized if no token`() {
+      val id = UUID.randomUUID()
+      webTestClient.get()
+        .uri("/admin/course-completions/$id/history-block")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden if no role`() {
+      val id = UUID.randomUUID()
+      webTestClient.get()
+        .uri("/admin/course-completions/$id/history-block")
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `should return 404 when course completion not found`() {
+      val id = UUID.randomUUID()
+      webTestClient.get()
+        .uri("/admin/course-completions/$id/history-block")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @Test
+    fun `should return block of 3 completions by default`() {
+      val externalReference = "EXT-REF-3"
+      val pdu = communityCampusPduEntityRepository.findAll().first()
+
+      val courseCompletion1 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-15T17:00:00Z"), attempts = 1, pdu = pdu))
+      val courseCompletion2 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-15T17:15:00Z"), attempts = 2, pdu = pdu))
+      val courseCompletion3 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-15T17:24:00Z"), attempts = 3, pdu = pdu))
+      val courseCompletion4 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-17T12:00:00Z"), attempts = 1, pdu = pdu))
+      val courseCompletion5 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-18T12:00:00Z"), attempts = 2, pdu = pdu))
+      val courseCompletion6 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-19T12:00:00Z"), attempts = 3, pdu = pdu))
+
+      val block1 = webTestClient.get()
+        .uri("/admin/course-completions/${courseCompletion3.id}/history-block")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<List<EteCourseCompletionEventDto>>()
+
+      assertThat(block1.map { it.id }).containsExactly(courseCompletion1.id, courseCompletion2.id, courseCompletion3.id)
+
+      val block2 = webTestClient.get()
+        .uri("/admin/course-completions/${courseCompletion6.id}/history-block")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<List<EteCourseCompletionEventDto>>()
+
+      assertThat(block2.map { it.id }).containsExactly(courseCompletion4.id, courseCompletion5.id, courseCompletion6.id)
+    }
+
+    @Test
+    fun `should return block of custom size`() {
+      val externalReference = "EXT-REF-CUSTOM"
+      val pdu = communityCampusPduEntityRepository.findAll().first()
+
+      val courseCompletion1 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-15T17:00:00Z"), pdu = pdu))
+      val courseCompletion2 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-15T17:15:00Z"), pdu = pdu))
+      val courseCompletion3 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.failed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-15T17:24:00Z"), pdu = pdu))
+      val courseCompletion4 = eteCourseCompletionEventEntityRepository.save(EteCourseCompletionEventEntity.passed(ctx).copy(id = UUID.randomUUID(), externalReference = externalReference, completionDateTime = OffsetDateTime.parse("2026-06-17T12:00:00Z"), pdu = pdu))
+
+      val block = webTestClient.get()
+        .uri("/admin/course-completions/${courseCompletion1.id}/history-block?blockSize=2")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<List<EteCourseCompletionEventDto>>()
+
+      assertThat(block.map { it.id }).containsExactly(courseCompletion1.id, courseCompletion2.id)
+
+      val block2 = webTestClient.get()
+        .uri("/admin/course-completions/${courseCompletion4.id}/history-block?blockSize=2")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<List<EteCourseCompletionEventDto>>()
+
+      assertThat(block2.map { it.id }).containsExactly(courseCompletion3.id, courseCompletion4.id)
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
@@ -1238,7 +1238,7 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
           id = UUID.randomUUID(),
           externalReference = externalReference,
           completionDateTime = OffsetDateTime.parse("2026-06-17T12:00:00Z"),
-          attempts = 1,
+          attempts = 4,
           pdu = pdu,
         ),
       )
@@ -1247,7 +1247,7 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
           id = UUID.randomUUID(),
           externalReference = externalReference,
           completionDateTime = OffsetDateTime.parse("2026-06-18T12:00:00Z"),
-          attempts = 2,
+          attempts = 5,
           pdu = pdu,
         ),
       )
@@ -1256,7 +1256,7 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
           id = UUID.randomUUID(),
           externalReference = externalReference,
           completionDateTime = OffsetDateTime.parse("2026-06-19T12:00:00Z"),
-          attempts = 3,
+          attempts = 6,
           pdu = pdu,
         ),
       )
@@ -1292,6 +1292,7 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
           id = UUID.randomUUID(),
           externalReference = externalReference,
           completionDateTime = OffsetDateTime.parse("2026-06-15T17:00:00Z"),
+          attempts = 1,
           pdu = pdu,
         ),
       )
@@ -1300,6 +1301,7 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
           id = UUID.randomUUID(),
           externalReference = externalReference,
           completionDateTime = OffsetDateTime.parse("2026-06-15T17:15:00Z"),
+          attempts = 2,
           pdu = pdu,
         ),
       )
@@ -1308,6 +1310,7 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
           id = UUID.randomUUID(),
           externalReference = externalReference,
           completionDateTime = OffsetDateTime.parse("2026-06-15T17:24:00Z"),
+          attempts = 3,
           pdu = pdu,
         ),
       )
@@ -1316,6 +1319,7 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
           id = UUID.randomUUID(),
           externalReference = externalReference,
           completionDateTime = OffsetDateTime.parse("2026-06-17T12:00:00Z"),
+          attempts = 4,
           pdu = pdu,
         ),
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
@@ -342,4 +342,79 @@ class EteServiceTest {
       assertThat(result).isNull()
     }
   }
+
+  @Nested
+  inner class GetCourseCompletionBlock {
+
+    @Test
+    fun `should return correct block for given id and block size`() {
+      val externalReference = "EXT-REF-1"
+      val id100 = UUID.randomUUID()
+      val id101 = UUID.randomUUID()
+      val id102 = UUID.randomUUID()
+      val id125 = UUID.randomUUID()
+
+      val e100 = EteCourseCompletionEventEntity.valid().copy(id = id100, externalReference = externalReference, attempts = 1)
+      val e101 = EteCourseCompletionEventEntity.valid().copy(id = id101, externalReference = externalReference, attempts = 2)
+      val e102 = EteCourseCompletionEventEntity.valid().copy(id = id102, externalReference = externalReference, attempts = 3)
+      val e125 = EteCourseCompletionEventEntity.valid().copy(id = id125, externalReference = externalReference, attempts = 4)
+
+      val allEvents = listOf(e100, e101, e102, e125)
+
+      every { eteCourseCompletionEventEntityRepository.findByIdOrNull(id102) } returns e102
+      every { eteCourseCompletionEventEntityRepository.findAllByExternalReferenceOrderByCompletionDateTimeAscAttemptsAsc(externalReference) } returns allEvents
+
+      val result = eteService.getCourseCompletionBlock(id102, 3)
+
+      assertThat(result.map { it.id }).containsExactly(id100, id101, id102)
+    }
+
+    @Test
+    fun `should return correct block for last element in the list`() {
+      val externalReference = "EXT-REF-1"
+      val id100 = UUID.randomUUID()
+      val id101 = UUID.randomUUID()
+      val id102 = UUID.randomUUID()
+      val id125 = UUID.randomUUID()
+
+      val e100 = EteCourseCompletionEventEntity.valid().copy(id = id100, externalReference = externalReference, attempts = 1)
+      val e101 = EteCourseCompletionEventEntity.valid().copy(id = id101, externalReference = externalReference, attempts = 2)
+      val e102 = EteCourseCompletionEventEntity.valid().copy(id = id102, externalReference = externalReference, attempts = 3)
+      val e125 = EteCourseCompletionEventEntity.valid().copy(id = id125, externalReference = externalReference, attempts = 4)
+
+      val allEvents = listOf(e100, e101, e102, e125)
+
+      every { eteCourseCompletionEventEntityRepository.findByIdOrNull(id125) } returns e125
+      every { eteCourseCompletionEventEntityRepository.findAllByExternalReferenceOrderByCompletionDateTimeAscAttemptsAsc(externalReference) } returns allEvents
+
+      val result = eteService.getCourseCompletionBlock(id125, 3)
+
+      assertThat(result.map { it.id }).containsExactly(id125)
+    }
+
+    @Test
+    fun `should return empty list if event id not found in list of events for external reference`() {
+      val externalReference = "EXT-REF-1"
+      val id = UUID.randomUUID()
+      val event = EteCourseCompletionEventEntity.valid().copy(id = id, externalReference = externalReference)
+
+      every { eteCourseCompletionEventEntityRepository.findByIdOrNull(id) } returns event
+      every { eteCourseCompletionEventEntityRepository.findAllByExternalReferenceOrderByCompletionDateTimeAscAttemptsAsc(externalReference) } returns emptyList()
+
+      val result = eteService.getCourseCompletionBlock(id, 3)
+
+      assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `should throw exception if event not found in repository`() {
+      val id = UUID.randomUUID()
+      every { eteCourseCompletionEventEntityRepository.findByIdOrNull(id) } returns null
+
+      val exception = org.junit.jupiter.api.assertThrows<IllegalStateException> {
+        eteService.getCourseCompletionBlock(id, 3)
+      }
+      assertThat(exception.message).isEqualTo("Can't find course completion event $id")
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
@@ -362,7 +362,22 @@ class EteServiceTest {
       val allEvents = listOf(e100, e101, e102, e125)
 
       every { eteCourseCompletionEventEntityRepository.findByIdOrNull(id102) } returns e102
-      every { eteCourseCompletionEventEntityRepository.findAllByExternalReferenceOrderByCompletionDateTimeAscAttemptsAsc(externalReference) } returns allEvents
+      every {
+        eteCourseCompletionEventEntityRepository.findAllWithFilters(
+          providerCode = e102.pdu.providerCode,
+          pduId = null,
+          officesCount = 0,
+          offices = emptyList(),
+          resolutionStatus = ResolutionStatus.ANY,
+          courseFailures = CourseFailureFilter.SHOW_ALL,
+          externalReference = externalReference,
+          fromDate = null,
+          toDate = null,
+          availableFromDate = null,
+          availableToDate = null,
+          pageable = any(),
+        )
+      } returns PageImpl(allEvents.subList(0, 3))
 
       val result = eteService.getCourseCompletionBlock(id102, 3)
 
@@ -385,7 +400,22 @@ class EteServiceTest {
       val allEvents = listOf(e100, e101, e102, e125)
 
       every { eteCourseCompletionEventEntityRepository.findByIdOrNull(id125) } returns e125
-      every { eteCourseCompletionEventEntityRepository.findAllByExternalReferenceOrderByCompletionDateTimeAscAttemptsAsc(externalReference) } returns allEvents
+      every {
+        eteCourseCompletionEventEntityRepository.findAllWithFilters(
+          providerCode = e125.pdu.providerCode,
+          pduId = null,
+          officesCount = 0,
+          offices = emptyList(),
+          resolutionStatus = ResolutionStatus.ANY,
+          courseFailures = CourseFailureFilter.SHOW_ALL,
+          externalReference = externalReference,
+          fromDate = null,
+          toDate = null,
+          availableFromDate = null,
+          availableToDate = null,
+          pageable = any(),
+        )
+      } returns PageImpl(allEvents.subList(0, 3)) andThen PageImpl(allEvents.subList(3, 4))
 
       val result = eteService.getCourseCompletionBlock(id125, 3)
 
@@ -399,11 +429,26 @@ class EteServiceTest {
       val event = EteCourseCompletionEventEntity.valid().copy(id = id, externalReference = externalReference)
 
       every { eteCourseCompletionEventEntityRepository.findByIdOrNull(id) } returns event
-      every { eteCourseCompletionEventEntityRepository.findAllByExternalReferenceOrderByCompletionDateTimeAscAttemptsAsc(externalReference) } returns emptyList()
+      every {
+        eteCourseCompletionEventEntityRepository.findAllWithFilters(
+          providerCode = event.pdu.providerCode,
+          pduId = null,
+          officesCount = 0,
+          offices = emptyList(),
+          resolutionStatus = ResolutionStatus.ANY,
+          courseFailures = CourseFailureFilter.SHOW_ALL,
+          externalReference = externalReference,
+          fromDate = null,
+          toDate = null,
+          availableFromDate = null,
+          availableToDate = null,
+          pageable = any(),
+        )
+      } returns PageImpl(listOf(event))
 
       val result = eteService.getCourseCompletionBlock(id, 3)
 
-      assertThat(result).isEmpty()
+      assertThat(result.map { it.id }).containsExactly(id)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
@@ -363,25 +363,49 @@ class EteServiceTest {
 
       every { eteCourseCompletionEventEntityRepository.findByIdOrNull(id102) } returns e102
       every {
-        eteCourseCompletionEventEntityRepository.findAllWithFilters(
+        eteCourseCompletionEventEntityRepository.findBlock(
           providerCode = e102.pdu.providerCode,
-          pduId = null,
-          officesCount = 0,
-          offices = emptyList(),
-          resolutionStatus = ResolutionStatus.ANY,
-          courseFailures = CourseFailureFilter.SHOW_ALL,
           externalReference = externalReference,
-          fromDate = null,
-          toDate = null,
-          availableFromDate = null,
-          availableToDate = null,
-          pageable = any(),
+          startAttempt = 1,
+          endAttempt = 3,
         )
-      } returns PageImpl(allEvents.subList(0, 3))
+      } returns listOf(e100, e101, e102)
 
       val result = eteService.getCourseCompletionBlock(id102, 3)
 
       assertThat(result.map { it.id }).containsExactly(id100, id101, id102)
+    }
+
+    @Test
+    fun `should return correct block when an attempt is missing`() {
+      val externalReference = "EXT-REF-1"
+      val id101 = UUID.randomUUID()
+      val id102 = UUID.randomUUID()
+      val id103 = UUID.randomUUID()
+
+      val e101 = EteCourseCompletionEventEntity.valid().copy(id = id101, externalReference = externalReference, attempts = 2)
+      val e102 = EteCourseCompletionEventEntity.valid().copy(id = id102, externalReference = externalReference, attempts = 3)
+      val e103 = EteCourseCompletionEventEntity.valid().copy(id = id103, externalReference = externalReference, attempts = 4)
+
+      // Attempt 1 is missing.
+      // Block for attempts 1-3 should contain only e101 and e102.
+
+      every { eteCourseCompletionEventEntityRepository.findByIdOrNull(id101) } returns e101
+
+      every {
+        eteCourseCompletionEventEntityRepository.findBlock(
+          providerCode = e101.pdu.providerCode,
+          externalReference = externalReference,
+          startAttempt = 1,
+          endAttempt = 3,
+        )
+      } returns listOf(e101, e102)
+
+      val result = eteService.getCourseCompletionBlock(id101, 3)
+
+      // Currently, it will return [e101, e102, e103] because Page 0 (size 3) contains all 3.
+      // But it should return [e101, e102].
+      assertThat(result.map { it.id }).containsExactly(id101, id102)
     }
 
     @Test
@@ -401,21 +425,13 @@ class EteServiceTest {
 
       every { eteCourseCompletionEventEntityRepository.findByIdOrNull(id125) } returns e125
       every {
-        eteCourseCompletionEventEntityRepository.findAllWithFilters(
+        eteCourseCompletionEventEntityRepository.findBlock(
           providerCode = e125.pdu.providerCode,
-          pduId = null,
-          officesCount = 0,
-          offices = emptyList(),
-          resolutionStatus = ResolutionStatus.ANY,
-          courseFailures = CourseFailureFilter.SHOW_ALL,
           externalReference = externalReference,
-          fromDate = null,
-          toDate = null,
-          availableFromDate = null,
-          availableToDate = null,
-          pageable = any(),
+          startAttempt = 4,
+          endAttempt = 6,
         )
-      } returns PageImpl(allEvents.subList(0, 3)) andThen PageImpl(allEvents.subList(3, 4))
+      } returns listOf(e125)
 
       val result = eteService.getCourseCompletionBlock(id125, 3)
 
@@ -430,25 +446,38 @@ class EteServiceTest {
 
       every { eteCourseCompletionEventEntityRepository.findByIdOrNull(id) } returns event
       every {
-        eteCourseCompletionEventEntityRepository.findAllWithFilters(
+        eteCourseCompletionEventEntityRepository.findBlock(
           providerCode = event.pdu.providerCode,
-          pduId = null,
-          officesCount = 0,
-          offices = emptyList(),
-          resolutionStatus = ResolutionStatus.ANY,
-          courseFailures = CourseFailureFilter.SHOW_ALL,
           externalReference = externalReference,
-          fromDate = null,
-          toDate = null,
-          availableFromDate = null,
-          availableToDate = null,
-          pageable = any(),
+          startAttempt = 1,
+          endAttempt = 3,
         )
-      } returns PageImpl(listOf(event))
+      } returns listOf(event)
 
       val result = eteService.getCourseCompletionBlock(id, 3)
 
       assertThat(result.map { it.id }).containsExactly(id)
+    }
+
+    @Test
+    fun `should return correct block even if attempts is null`() {
+      val externalReference = "EXT-REF-1"
+      val id = UUID.randomUUID()
+      val event = EteCourseCompletionEventEntity.valid().copy(id = id, externalReference = externalReference, attempts = null)
+
+      every { eteCourseCompletionEventEntityRepository.findByIdOrNull(id) } returns event
+      every {
+        eteCourseCompletionEventEntityRepository.findBlock(
+          providerCode = event.pdu.providerCode,
+          externalReference = externalReference,
+          startAttempt = 1,
+          endAttempt = 3,
+        )
+      } returns listOf(event.copy(attempts = 1)) // Simulate it being found or treated as 1
+
+      val result = eteService.getCourseCompletionBlock(id, 3)
+
+      assertThat(result).isNotEmpty
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
@@ -416,5 +416,14 @@ class EteServiceTest {
       }
       assertThat(exception.message).isEqualTo("Can't find course completion event $id")
     }
+
+    @Test
+    fun `should throw exception if block size is less than 1`() {
+      val id = UUID.randomUUID()
+      val exception = org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+        eteService.getCourseCompletionBlock(id, 0)
+      }
+      assertThat(exception.message).isEqualTo("blockSize must be greater than 0")
+    }
   }
 }


### PR DESCRIPTION
- New endpoint `GET /admin/course-completions/{id}/history-block` created.
- Optional query parameter `blockSize` (defaulting to 3) to control the block size.
- The endpoint retrieves all completions for the same course (identified by `externalReference`).
- Completions are ordered by `completionDateTime` (ascending) and `attempts` (ascending).
- The returned list is a "block" of completions of size `blockSize` that contains the requested completion ID.

**Example Scenarios:**
**Scenario 1: Attempts 1 (F), 2 (F), 3 (F), 4 (P)**
Requesting ID for Attempt 3 with `blockSize=3` returns Attempts 1, 2, 3.
Requesting ID for Attempt 4 with `blockSize=3` returns Attempt 4.

**Scenario 2: Attempts 1 (F), 2 (F)**
Requesting ID for Attempt 2 with `blockSize=3` returns Attempts 1, 2.

**Scenario 3: Attempts 1 (F), 2 (F), 3 (F), 1 (F), 2 (F), 3 (P) [where 1-3 are different sets of attempts for same course].**
Requesting ID for Attempt 3 (first set) returns 1, 2, 3.
Requesting ID for Attempt 3 (second set) returns 1, 2, 3 from the second set.

**Returns 404 if the completion ID does not exist.**

**No pagination required.**