### PR TITLE
CPB-1072: Implement eligibility checking for the Incentive Scheme

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
@@ -602,11 +602,13 @@ data class NDUpwDetails(
   val adjustments: Long,
   val completedEteMinutes: Long,
   val eventOutcome: String,
+  val eventOutcomeCode: String,
   val upwStatus: String?,
   val referralDate: LocalDate,
   val convictionDate: LocalDate?,
   val court: NDCodeDescription?,
   val mainOffence: NDMainOffence,
+  val unpaidWorkRequirements: List<NDRequirementSubType>,
 ) {
   companion object
 }
@@ -616,6 +618,12 @@ data class NDMainOffence(
   val count: Int,
   val code: String,
   val description: String,
+) {
+  companion object
+}
+
+data class NDRequirementSubType(
+  val subType: NDCodeDescription?,
 ) {
   companion object
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/IncentiveSchemeEligibilityScopeEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/IncentiveSchemeEligibilityScopeEntity.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.Immutable
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Immutable
+@Entity
+@Table(name = "incentive_scheme_eligibility_scopes")
+data class IncentiveSchemeEligibilityScopeEntity(
+  @Id
+  val id: UUID,
+  val code: String,
+  val description: String,
+  @Enumerated(EnumType.STRING)
+  val scope: IncentiveSchemeEligibilityScope,
+  val isEligible: Boolean,
+  @CreationTimestamp
+  val createdAt: OffsetDateTime = OffsetDateTime.now(),
+  @UpdateTimestamp
+  val updatedAt: OffsetDateTime = OffsetDateTime.now(),
+)
+
+enum class IncentiveSchemeEligibilityScope {
+  OUTCOME,
+  REQUIREMENT_SUBTYPE,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/IncentiveSchemeEligibilityScopeEntityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/IncentiveSchemeEligibilityScopeEntityRepository.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface IncentiveSchemeEligibilityScopeEntityRepository : JpaRepository<IncentiveSchemeEligibilityScopeEntity, UUID> {
+  @Query(
+    """
+      SELECT COUNT(*) > 0
+      FROM IncentiveSchemeEligibilityScopeEntity es
+      WHERE es.scope = :scope
+      AND es.code = :code
+      AND es.isEligible = true
+    """,
+  )
+  fun isEligible(scope: IncentiveSchemeEligibilityScope, code: String): Boolean
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/incentivescheme/internal/IncentiveSchemeEligibilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/incentivescheme/internal/IncentiveSchemeEligibilityService.kt
@@ -1,16 +1,35 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.service.incentivescheme.internal
 
 import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.IncentiveSchemeEligibilityScope
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.IncentiveSchemeEligibilityScopeEntityRepository
 
 @Service
-class IncentiveSchemeEligibilityService {
-  @Suppress(
-    // Suppress these warnings as this function is a deliberate stub until https://dsdmoj.atlassian.net/browse/PI-4220
-    // has been completed.
-    // TODO: Remove this `@Suppress` annotation when adding a proper implementation for this function.
-    "detekt.ForbiddenComment",
-    "detekt.FunctionOnlyReturningConstant",
-    "unused",
-  )
-  fun isEligible(crn: String, deliusEventNumber: Int): Boolean = true
+class IncentiveSchemeEligibilityService(
+  private val incentiveSchemeEligibilityScopeEntityRepository: IncentiveSchemeEligibilityScopeEntityRepository,
+  private val communityPaybackAndDeliusClient: CommunityPaybackAndDeliusClient,
+) {
+  fun isEligible(crn: String, deliusEventNumber: Int): Boolean {
+    val caseSummary = communityPaybackAndDeliusClient.getCaseSummary(crn) ?: return false
+
+    val upwDetails = caseSummary.unpaidWorkDetails.firstOrNull { it.eventNumber == deliusEventNumber } ?: return false
+
+    if (!incentiveSchemeEligibilityScopeEntityRepository.isEligible(IncentiveSchemeEligibilityScope.OUTCOME, upwDetails.eventOutcomeCode)) return false
+
+    return upwDetails.unpaidWorkRequirements.any {
+      it.subType != null &&
+        incentiveSchemeEligibilityScopeEntityRepository.isEligible(
+          IncentiveSchemeEligibilityScope.REQUIREMENT_SUBTYPE,
+          it.subType.code,
+        )
+    }
+  }
+
+  private fun CommunityPaybackAndDeliusClient.getCaseSummary(crn: String) = try {
+    this.getUpwDetailsSummary(crn, null)
+  } catch (_: WebClientResponseException.NotFound) {
+    null
+  }
 }

--- a/src/main/resources/db/migration/20260618155846__create_incentive_scheme_eligibility_scope_table.sql
+++ b/src/main/resources/db/migration/20260618155846__create_incentive_scheme_eligibility_scope_table.sql
@@ -1,0 +1,57 @@
+CREATE TABLE incentive_scheme_eligibility_scopes (
+  id UUID NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope TEXT NOT NULL,
+  code TEXT NOT NULL,
+  description TEXT NOT NULL,
+  is_eligible BOOLEAN NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT incentive_scheme_eligibility_scopes_unique UNIQUE (scope, code)
+);
+
+INSERT INTO incentive_scheme_eligibility_scopes (scope, code, description, is_eligible)
+VALUES
+    -- Orders in scope
+        -- Community orders
+    ('OUTCOME', '201', 'CJA - Community Order', TRUE),
+    ('OUTCOME', '340', 'SA2020 Community Order', TRUE),
+        -- Suspended sentence orders
+    ('OUTCOME', '203', 'CJA - Suspended Sentence Order', TRUE),
+    ('OUTCOME', '216', 'Suspended Sentence Supn Order', TRUE),
+    ('OUTCOME', '341', 'SA2020 Suspended Sentence Order', TRUE),
+    ('OUTCOME', '408', 'Suspended Sentence', TRUE),
+        -- Community payback orders made in Scotland and transferred to England/Wales
+    ('OUTCOME', '234', 'Scottish Community Order (CPA95)', TRUE),
+    ('OUTCOME', '235', 'Scottish Comm Payback (CJLA2010)', TRUE),
+    -- Orders out of scope
+        -- Supervision default orders
+    ('OUTCOME', '233', 'ORA Supervision Default Order', FALSE),
+        -- Service community orders
+        -- (none)
+        -- Enforcement orders
+    ('OUTCOME', '212', 'Enforcement Order (Pre-CJA)', FALSE),
+    ('OUTCOME', '226', 'CJA -Enforcement Order (C&AA 06)', FALSE),
+        -- Jersey orders
+    ('OUTCOME', '237', 'CS & Probation Order - Jersey', FALSE),
+        -- Deferred sentences
+    ('OUTCOME', '123', 'Deferred Sentence', FALSE),
+    ('OUTCOME', '202', 'CJA - Deferred Sentence', FALSE),
+    ('OUTCOME', '407', 'Deferred Sentence  (Pre CJA03)', FALSE),
+        -- Youth rehabilitation orders
+    ('OUTCOME', '204', 'CJA - Youth Rehabilitation Order', FALSE),
+    ('OUTCOME', '342', 'SA2020 Youth Rehab Order', FALSE),
+        -- Community service orders imposed in Northern Ireland
+        -- (none)
+
+    -- Requirement subtypes
+        -- In scope
+    ('REQUIREMENT_SUBTYPE', 'W01', 'Regular', TRUE),
+    ('REQUIREMENT_SUBTYPE', 'W06', 'Hours Concurrent to Another Order', TRUE),
+    ('REQUIREMENT_SUBTYPE', 'W07', 'Hours Consecutive to Another Order', TRUE),
+        -- TBC
+    ('REQUIREMENT_SUBTYPE', 'W05', 'Z - Hours Outstanding from a Previous Order', FALSE),
+    ('REQUIREMENT_SUBTYPE', 'UPCONC', 'UPW Hours to be worked Concurrently', FALSE),
+        -- Out of scope
+    ('REQUIREMENT_SUBTYPE', 'W03', 'Additional Hours', FALSE),
+    ('REQUIREMENT_SUBTYPE', 'W08', 'Hours Outstanding at Sentence Expiry', FALSE);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDCaseDetailFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDCaseDetailFactory.kt
@@ -1,11 +1,14 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client
 
+import org.springframework.context.ApplicationContext
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseDetailsSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCodeDescription
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDMainOffence
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDRequirementSubType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDUpwDetails
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.IncentiveSchemeEligibilityScope
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.IncentiveSchemeEligibilityScopeEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomLocalDate
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomPastLocalDate
@@ -33,6 +36,17 @@ fun NDUpwDetails.Companion.valid() = NDUpwDetails(
   unpaidWorkRequirements = listOf(NDRequirementSubType.valid()),
 )
 
+fun NDUpwDetails.Companion.valid(ctx: ApplicationContext): NDUpwDetails {
+  val repository = ctx.getBean(IncentiveSchemeEligibilityScopeEntityRepository::class.java)
+  val scopes = repository.findAll()
+  val eventOutcomeCode = scopes.first { it.scope == IncentiveSchemeEligibilityScope.OUTCOME && it.isEligible }.code
+
+  return NDUpwDetails.valid().copy(
+    eventOutcomeCode = eventOutcomeCode,
+    unpaidWorkRequirements = listOf(NDRequirementSubType.valid(ctx)),
+  )
+}
+
 fun NDMainOffence.Companion.valid() = NDMainOffence(
   code = String.random(10),
   description = String.random(100),
@@ -43,3 +57,13 @@ fun NDMainOffence.Companion.valid() = NDMainOffence(
 fun NDRequirementSubType.Companion.valid() = NDRequirementSubType(
   subType = NDCodeDescription.valid(),
 )
+
+fun NDRequirementSubType.Companion.valid(ctx: ApplicationContext): NDRequirementSubType {
+  val repository = ctx.getBean(IncentiveSchemeEligibilityScopeEntityRepository::class.java)
+  val scopes = repository.findAll()
+  val requirementSubtypeCode = scopes.first { it.scope == IncentiveSchemeEligibilityScope.REQUIREMENT_SUBTYPE && it.isEligible }.code
+
+  return NDRequirementSubType.valid().copy(
+    subType = NDCodeDescription.valid().copy(code = requirementSubtypeCode),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDCaseDetailFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDCaseDetailFactory.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseDetailsSumm
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCodeDescription
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDMainOffence
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDRequirementSubType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDUpwDetails
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomLocalDate
@@ -25,9 +26,11 @@ fun NDUpwDetails.Companion.valid() = NDUpwDetails(
   court = NDCodeDescription.Companion.valid(),
   mainOffence = NDMainOffence.Companion.valid(),
   eventOutcome = String.random(10),
+  eventOutcomeCode = String.random(4),
   upwStatus = String.random(10),
   referralDate = randomLocalDate(),
   convictionDate = randomLocalDate(),
+  unpaidWorkRequirements = listOf(NDRequirementSubType.valid()),
 )
 
 fun NDMainOffence.Companion.valid() = NDMainOffence(
@@ -35,4 +38,8 @@ fun NDMainOffence.Companion.valid() = NDMainOffence(
   description = String.random(100),
   date = randomLocalDate(),
   count = Random.nextInt(1, 100),
+)
+
+fun NDRequirementSubType.Companion.valid() = NDRequirementSubType(
+  subType = NDCodeDescription.valid(),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/IncentiveSchemeIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/IncentiveSchemeIT.kt
@@ -1,15 +1,18 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointmentSummary
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseSummary
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCodeDescription
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDContactOutcome
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDRequirementProgress
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDRequirementSubType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDUnpaidWorkRequirement
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDUpwDetails
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.util.bodyAsObject
@@ -24,6 +27,18 @@ import java.time.LocalTime
 class IncentiveSchemeIT : IntegrationTestBase() {
   @Autowired
   lateinit var contactOutcomeEntityRepository: ContactOutcomeEntityRepository
+
+  private val caseSummary = NDCaseSummary.valid()
+  private val unpaidWorkDetails by lazy { listOf(validUpwDetails()) }
+
+  private fun validUpwDetails(
+    eventNumber: Int? = null,
+    eventOutcomeCode: String? = null,
+    requirementCode: String? = null,
+  ): NDUpwDetails = NDUpwDetails.valid(ctx)
+    .copy(eventNumber = eventNumber ?: EVENT_NUMBER)
+    .let { if (eventOutcomeCode != null) it.copy(eventOutcomeCode = eventOutcomeCode) else it }
+    .let { if (requirementCode != null) it.copy(unpaidWorkRequirements = listOf(NDRequirementSubType(subType = NDCodeDescription.valid().copy(code = requirementCode)))) else it }
 
   companion object {
     private const val CRN = "X123456"
@@ -62,12 +77,14 @@ class IncentiveSchemeIT : IntegrationTestBase() {
         .isForbidden
     }
 
-    @Disabled("Eligibility is not yet implemented")
     @Test
     fun `should return OK with correct response when ineligible`() {
       val requirementProgress = NDRequirementProgress.valid().copy(requiredMinutes = 6000)
       val requirement = NDUnpaidWorkRequirement.valid().copy(requirementProgress = requirementProgress)
 
+      val unpaidWorkDetails = listOf(validUpwDetails(eventOutcomeCode = "SDO"))
+
+      CommunityPaybackAndDeliusMockServer.setupGetUpwDetailsSummaryResponse(CRN, caseSummary, unpaidWorkDetails)
       CommunityPaybackAndDeliusMockServer.setupGetUnpaidWorkRequirementResponse(CRN, EVENT_NUMBER, requirement)
       CommunityPaybackAndDeliusMockServer.setupGetAppointmentsResponse(
         crn = CRN,
@@ -106,6 +123,7 @@ class IncentiveSchemeIT : IntegrationTestBase() {
       val qualifyingContactOutcome = contactOutcomeEntityRepository.findAll().first { !it.enforceable }
       val disqualifyingContactOutcome = contactOutcomeEntityRepository.findAll().first { it.enforceable }
 
+      CommunityPaybackAndDeliusMockServer.setupGetUpwDetailsSummaryResponse(CRN, caseSummary, unpaidWorkDetails)
       CommunityPaybackAndDeliusMockServer.setupGetUnpaidWorkRequirementResponse(CRN, EVENT_NUMBER, requirement)
       CommunityPaybackAndDeliusMockServer.setupGetAppointmentsResponse(
         crn = CRN,
@@ -158,6 +176,7 @@ class IncentiveSchemeIT : IntegrationTestBase() {
 
       val contactOutcome = contactOutcomeEntityRepository.findAll().first { !it.enforceable }
 
+      CommunityPaybackAndDeliusMockServer.setupGetUpwDetailsSummaryResponse(CRN, caseSummary, unpaidWorkDetails)
       CommunityPaybackAndDeliusMockServer.setupGetUnpaidWorkRequirementResponse(CRN, EVENT_NUMBER, requirement)
       CommunityPaybackAndDeliusMockServer.setupGetAppointmentsResponse(
         crn = CRN,
@@ -217,6 +236,7 @@ class IncentiveSchemeIT : IntegrationTestBase() {
 
       val contactOutcome = contactOutcomeEntityRepository.findAll().first { !it.enforceable }
 
+      CommunityPaybackAndDeliusMockServer.setupGetUpwDetailsSummaryResponse(CRN, caseSummary, unpaidWorkDetails)
       CommunityPaybackAndDeliusMockServer.setupGetUnpaidWorkRequirementResponse(CRN, EVENT_NUMBER, requirement)
       CommunityPaybackAndDeliusMockServer.setupGetAppointmentsResponse(
         crn = CRN,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/incentivescheme/internal/IncentiveSchemeEligibilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/incentivescheme/internal/IncentiveSchemeEligibilityServiceTest.kt
@@ -1,0 +1,156 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.incentivescheme.internal
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.HttpHeaders
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseDetailsSummary
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCodeDescription
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDRequirementSubType
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDUpwDetails
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.IncentiveSchemeEligibilityScope
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.IncentiveSchemeEligibilityScopeEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.incentivescheme.internal.IncentiveSchemeEligibilityService
+import java.util.stream.Stream
+
+@ExtendWith(MockKExtension::class)
+class IncentiveSchemeEligibilityServiceTest {
+  @MockK
+  lateinit var incentiveSchemeEligibilityScopeEntityRepository: IncentiveSchemeEligibilityScopeEntityRepository
+
+  @MockK
+  lateinit var communityPaybackAndDeliusClient: CommunityPaybackAndDeliusClient
+
+  @InjectMockKs
+  lateinit var service: IncentiveSchemeEligibilityService
+
+  @Test
+  fun `isEligible returns false if no case summary could be found for CRN`() {
+    val crn = String.random(6)
+    val deliusEventNumber = Int.random(1, 10)
+
+    every { communityPaybackAndDeliusClient.getUpwDetailsSummary(any(), any()) } throws WebClientResponseException.create(
+      404,
+      "Not Found",
+      HttpHeaders(),
+      ByteArray(0),
+      null,
+    )
+
+    val result = service.isEligible(crn, deliusEventNumber)
+
+    assertThat(result).isFalse
+  }
+
+  @Test
+  fun `isEligible returns false if no UPW details could be found on the summary with the correct Delius event number`() {
+    val crn = String.random(6)
+    val deliusEventNumber = Int.random(1, 10)
+
+    every { communityPaybackAndDeliusClient.getUpwDetailsSummary(any(), any()) } returns NDCaseDetailsSummary.valid().copy(
+      unpaidWorkDetails = listOf(
+        NDUpwDetails.valid().copy(eventNumber = 999),
+      ),
+    )
+
+    val result = service.isEligible(crn, deliusEventNumber)
+
+    assertThat(result).isFalse
+  }
+
+  @Test
+  fun `isEligible returns false if the sentence order is not in scope`() {
+    val crn = String.random(6)
+    val deliusEventNumber = Int.random(1, 10)
+
+    every { incentiveSchemeEligibilityScopeEntityRepository.isEligible(IncentiveSchemeEligibilityScope.OUTCOME, any()) } returns false
+
+    every { communityPaybackAndDeliusClient.getUpwDetailsSummary(any(), any()) } returns NDCaseDetailsSummary.valid().copy(
+      unpaidWorkDetails = listOf(
+        NDUpwDetails.valid().copy(eventNumber = deliusEventNumber),
+      ),
+    )
+
+    val result = service.isEligible(crn, deliusEventNumber)
+
+    assertThat(result).isFalse
+  }
+
+  @Test
+  fun `isEligible returns false if the requirement subtype is not in scope`() {
+    val crn = String.random(6)
+    val deliusEventNumber = Int.random(1, 10)
+
+    every { incentiveSchemeEligibilityScopeEntityRepository.isEligible(IncentiveSchemeEligibilityScope.OUTCOME, any()) } returns true
+    every { incentiveSchemeEligibilityScopeEntityRepository.isEligible(IncentiveSchemeEligibilityScope.REQUIREMENT_SUBTYPE, any()) } returns false
+
+    every { communityPaybackAndDeliusClient.getUpwDetailsSummary(any(), any()) } returns NDCaseDetailsSummary.valid().copy(
+      unpaidWorkDetails = listOf(
+        NDUpwDetails.valid().copy(
+          eventNumber = deliusEventNumber,
+          unpaidWorkRequirements = listOf(
+            NDRequirementSubType.valid(),
+          ),
+        ),
+      ),
+    )
+
+    val result = service.isEligible(crn, deliusEventNumber)
+
+    assertThat(result).isFalse
+  }
+
+  @ParameterizedTest
+  @MethodSource("validOutcomeAndRequirementCodes")
+  fun `isEligible returns true if the sentence order is in scope and any requirement subtype is in scope`(
+    eventOutcomeCode: String,
+    upwRequirementCode: String,
+  ) {
+    val crn = String.random(6)
+    val deliusEventNumber = Int.random(1, 10)
+
+    every { incentiveSchemeEligibilityScopeEntityRepository.isEligible(any(), any()) } returns false
+    every { incentiveSchemeEligibilityScopeEntityRepository.isEligible(IncentiveSchemeEligibilityScope.OUTCOME, eventOutcomeCode) } returns true
+    every { incentiveSchemeEligibilityScopeEntityRepository.isEligible(IncentiveSchemeEligibilityScope.REQUIREMENT_SUBTYPE, upwRequirementCode) } returns true
+
+    every { communityPaybackAndDeliusClient.getUpwDetailsSummary(any(), any()) } returns NDCaseDetailsSummary.valid().copy(
+      unpaidWorkDetails = listOf(
+        NDUpwDetails.valid().copy(
+          eventNumber = deliusEventNumber,
+          eventOutcomeCode = eventOutcomeCode,
+          unpaidWorkRequirements = listOf(
+            NDRequirementSubType.valid(),
+            NDRequirementSubType.valid().copy(subType = NDCodeDescription.valid().copy(code = upwRequirementCode)),
+          ),
+        ),
+      ),
+    )
+
+    val result = service.isEligible(crn, deliusEventNumber)
+
+    assertThat(result).isTrue
+  }
+
+  companion object {
+    @JvmStatic
+    fun validOutcomeAndRequirementCodes(): Stream<Arguments> {
+      val eventOutcomeCodes = listOf("340", "341")
+      val requirementCodes = listOf("W01", "W06", "W07")
+
+      return eventOutcomeCodes.flatMap { eventOutcomeCode ->
+        requirementCodes.map { requirementCode -> Arguments.of(eventOutcomeCode, requirementCode) }
+      }.stream()
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/CaseDetailsSummaryMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/CaseDetailsSummaryMapperTest.kt
@@ -27,6 +27,7 @@ class CaseDetailsSummaryMapperTest {
         adjustments = 100,
         completedEteMinutes = 200,
         eventOutcome = "Event1",
+        eventOutcomeCode = "OUTC",
         upwStatus = "UPW1",
         referralDate = LocalDate.of(2022, 2, 12),
         convictionDate = LocalDate.of(2022, 2, 12),
@@ -40,6 +41,7 @@ class CaseDetailsSummaryMapperTest {
           code = "12345",
           description = "Court1",
         ),
+        unpaidWorkRequirements = emptyList(),
       ).toDto()
 
       assertThat(result.eventNumber).isEqualTo(1)

--- a/src/test/resources/application-integrationtest.yml
+++ b/src/test/resources/application-integrationtest.yml
@@ -52,7 +52,7 @@ hmpps.sar:
     expected-render-result:
       path: /sar/expected-report.html
     attachments-expected: false
-    expected-flyway-schema-version: 20260616120000
+    expected-flyway-schema-version: 20260618155846
     expected-jpa-entity-schema:
       path: /sar/expected-jpa-schema.json
 

--- a/src/test/resources/sar/expected-jpa-schema.json
+++ b/src/test/resources/sar/expected-jpa-schema.json
@@ -152,6 +152,15 @@
     "formType": "String",
     "updatedAt": "OffsetDateTime"
   },
+  "IncentiveSchemeEligibilityScopeEntity": {
+    "code": "String",
+    "createdAt": "OffsetDateTime",
+    "description": "String",
+    "id": "UUID",
+    "isEligible": "boolean",
+    "scope": "IncentiveSchemeEligibilityScope",
+    "updatedAt": "OffsetDateTime"
+  },
   "ProjectTypeEntity": {
     "code": "String",
     "createdAt": "OffsetDateTime",


### PR DESCRIPTION
In #706 a stub implementation of the `IncentiveSchemeEligibilityService` was introduced as a temporary scaffold.

This PR replaces the stub with an implementation of the eligibility rules as follows:
- Get the case details for the given CRN and Delius event number. If no details could be found, return `false`.
- If the event outcome is not in scope, return `false`.
- If any of the requirement subtypes are in scope, return `true`, otherwise return `false`.

To help achieve this, this PR updates the `NDUpwDetails` type to include new data introduced by [PI-4220](https://dsdmoj.atlassian.net/browse/PI-4220).

It also introduces a new concept of _eligibility scopes_. An eligibility scope represents an aspect about a person's case details that can be used to determine whether they are eligible for the Incentive Scheme.

Currently, there are two explicit criteria: an eligible event outcome (also referred to in various places as the _disposal_ or the _order type_), and an eligible requirement subtype. The requirement being for unpaid work is implied by the requirement subtypes and by the data returned to us through the PI API.

An eligibility scope represents these two types of criteria using the `scope` column.

The `IncentiveSchemeEligibilityScopeEntityRepository` provides the `isEligible` method, which allows for querying whether a given scope and code has `is_eligible` set. Unknown combinations return `false` by default, which allows for an inexhaustive list to be stored in the database and be handled gracefully.

[PI-4220]: https://dsdmoj.atlassian.net/browse/PI-4220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ