### PR TITLE
CPB-1061: Add new contact outcome group for Supervisor UI

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/ContactOutcomeDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/ContactOutcomeDto.kt
@@ -22,4 +22,5 @@ data class ContactOutcomeDto(
 enum class ContactOutcomeGroupDto {
   AVAILABLE_TO_ADMIN,
   AVAILABLE_FOR_ETE,
+  AVAILABLE_TO_SUPERVISOR,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/ContactOutcomeEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/ContactOutcomeEntity.kt
@@ -77,12 +77,14 @@ data class ContactOutcomeEntity(
 enum class ContactOutcomeGroup {
   AVAILABLE_TO_ADMIN,
   AVAILABLE_FOR_ETE,
+  AVAILABLE_TO_SUPERVISOR,
   ;
 
   companion object {
     fun fromDto(dto: ContactOutcomeGroupDto) = when (dto) {
       ContactOutcomeGroupDto.AVAILABLE_TO_ADMIN -> AVAILABLE_TO_ADMIN
       ContactOutcomeGroupDto.AVAILABLE_FOR_ETE -> AVAILABLE_FOR_ETE
+      ContactOutcomeGroupDto.AVAILABLE_TO_SUPERVISOR -> AVAILABLE_TO_SUPERVISOR
     }
   }
 }

--- a/src/main/resources/db/migration/20260622145958__add_supervisor_contact_outcome_group.sql
+++ b/src/main/resources/db/migration/20260622145958__add_supervisor_contact_outcome_group.sql
@@ -1,0 +1,10 @@
+INSERT INTO contact_outcomes_groups (contact_outcome_entity_id, contact_outcome_group)
+SELECT id, 'AVAILABLE_TO_SUPERVISOR'
+FROM contact_outcomes
+WHERE name IN (
+    'Attended - Complied',
+    'Attended - Failed to Comply',
+    'Attended - Sent Home (behaviour)',
+    'Attended - Sent Home (service issues)',
+    'Unacceptable Absence'
+);

--- a/src/test/resources/application-integrationtest.yml
+++ b/src/test/resources/application-integrationtest.yml
@@ -52,7 +52,7 @@ hmpps.sar:
     expected-render-result:
       path: /sar/expected-report.html
     attachments-expected: false
-    expected-flyway-schema-version: 20260618155846
+    expected-flyway-schema-version: 20260622145958
     expected-jpa-entity-schema:
       path: /sar/expected-jpa-schema.json
 


### PR DESCRIPTION
In order to determine which contact outcomes a supervisor can record within the Supervisor UI, a new contact outcome group needs to be added. This adds the `AVAILABLE_TO_SUPERVISOR` contact outcome group, with the following outcomes:
- Attended - Complied
- Attended - Failed to Comply
- Attended - Sent Home (behaviour)
- Attended - Sent Home (service issues)
- Unacceptable Absence