### PR TITLE
CPB-1045: Refactor AppointmentBulkUpdateService for improved validation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/UpdateAppointmentsOutcomesResultDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/UpdateAppointmentsOutcomesResultDto.kt
@@ -7,6 +7,7 @@ data class UpdateAppointmentsOutcomesResultDto(
 data class UpdateAppointmentOutcomeResultDto(
   val deliusId: Long,
   val result: UpdateAppointmentOutcomeResultType,
+  val errorMessage: String? = null,
 )
 
 enum class UpdateAppointmentOutcomeResultType {
@@ -14,4 +15,5 @@ enum class UpdateAppointmentOutcomeResultType {
   NOT_FOUND,
   VERSION_CONFLICT,
   SERVER_ERROR,
+  VALIDATION_ERROR,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentBulkUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentBulkUpdateService.kt
@@ -1,13 +1,13 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeResultDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeResultType
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentsOutcomesResultDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.BadRequestException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.exceptions.ConflictException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SentryService
 
@@ -23,51 +23,41 @@ class AppointmentBulkUpdateService(
     projectCode: String,
     request: UpdateAppointmentOutcomesDto,
     trigger: AppointmentEventTrigger,
-  ): UpdateAppointmentsOutcomesResultDto {
-    val internalRequests = request.validate(projectCode)
-    val outcomes = internalRequests.apply(trigger)
-    return UpdateAppointmentsOutcomesResultDto(outcomes)
-  }
-
-  private fun UpdateAppointmentOutcomesDto.validate(projectCode: String) = updates.map {
-    val id = DeliusAppointmentIdDto(projectCode, it.deliusId)
-    val existingAppointment = appointmentRetrievalService.getAppointment(id)
-
-    if (existingAppointment != null) {
-      appointmentUpdateValidationService.validateUpdate(existingAppointment, it)
-    }
-
-    AppointmentWithUpdateRequest(id, existingAppointment, it)
-  }
+  ): UpdateAppointmentsOutcomesResultDto = UpdateAppointmentsOutcomesResultDto(
+    results = request.updates.map { update -> updateAppointment(projectCode, update, trigger) },
+  )
 
   @SuppressWarnings("TooGenericExceptionCaught")
-  private fun List<AppointmentWithUpdateRequest>.apply(
+  private fun updateAppointment(
+    projectCode: String,
+    update: UpdateAppointmentOutcomeDto,
     trigger: AppointmentEventTrigger,
-  ) = map { internalUpdateRequest ->
-    val outcome = if (internalUpdateRequest.existingAppointment == null) {
-      UpdateAppointmentOutcomeResultType.NOT_FOUND
-    } else {
-      try {
-        appointmentUpdateService.updateAppointment(
-          existingAppointment = internalUpdateRequest.existingAppointment,
-          update = internalUpdateRequest.update,
-          trigger = trigger,
-        )
-        UpdateAppointmentOutcomeResultType.SUCCESS
-      } catch (_: ConflictException) {
-        UpdateAppointmentOutcomeResultType.VERSION_CONFLICT
-      } catch (t: Throwable) {
-        sentryService.captureException(t)
-        UpdateAppointmentOutcomeResultType.SERVER_ERROR
-      }
-    }
+  ): UpdateAppointmentOutcomeResultDto {
+    val id = DeliusAppointmentIdDto(projectCode, update.deliusId)
+    val existingAppointment = appointmentRetrievalService.getAppointment(id)
+      ?: return result(id, UpdateAppointmentOutcomeResultType.NOT_FOUND)
 
-    UpdateAppointmentOutcomeResultDto(internalUpdateRequest.id.deliusAppointmentId, outcome)
+    return try {
+      appointmentUpdateValidationService.validateUpdate(existingAppointment, update)
+      appointmentUpdateService.updateAppointment(
+        existingAppointment = existingAppointment,
+        update = update,
+        trigger = trigger,
+      )
+      result(id, UpdateAppointmentOutcomeResultType.SUCCESS)
+    } catch (e: BadRequestException) {
+      result(id, UpdateAppointmentOutcomeResultType.VALIDATION_ERROR, e.message)
+    } catch (_: ConflictException) {
+      result(id, UpdateAppointmentOutcomeResultType.VERSION_CONFLICT)
+    } catch (t: Throwable) {
+      sentryService.captureException(t)
+      result(id, UpdateAppointmentOutcomeResultType.SERVER_ERROR)
+    }
   }
 
-  private data class AppointmentWithUpdateRequest(
-    val id: DeliusAppointmentIdDto,
-    val existingAppointment: AppointmentDto?,
-    val update: UpdateAppointmentOutcomeDto,
-  )
+  private fun result(
+    id: DeliusAppointmentIdDto,
+    type: UpdateAppointmentOutcomeResultType,
+    message: String? = null,
+  ) = UpdateAppointmentOutcomeResultDto(id.deliusAppointmentId, type, message)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
@@ -539,7 +539,7 @@ class AdminAppointmentIT : IntegrationTestBase() {
     }
 
     @Test
-    fun `fails one appointment due to validation failure and returns 400`() {
+    fun `fails one appointment due to validation failure and returns VALIDATION_ERROR for that appointment`() {
       val projectAndLocation = NDProjectAndLocation.valid().copy(code = "PC01")
       val project = NDProject.valid(ctx).copy(code = "PC01")
       val pickup = NDAppointmentPickUp.valid()
@@ -557,6 +557,7 @@ class AdminAppointmentIT : IntegrationTestBase() {
         project = project,
         username = "theusername",
       )
+      CommunityPaybackAndDeliusMockServer.setupPutAppointmentResponse("PC01", 1234L)
 
       // Appointment 2: Sensitive mismatch (Validation failure)
       CommunityPaybackAndDeliusMockServer.Aggregates.setupGetDataMocksForUpdateAppointment(
@@ -573,7 +574,7 @@ class AdminAppointmentIT : IntegrationTestBase() {
         username = "theusername",
       )
 
-      webTestClient.put()
+      val result = webTestClient.put()
         .uri("/admin/projects/PC01/appointments/bulk")
         .addAdminUiAuthHeader("theusername")
         .bodyValue(
@@ -586,10 +587,18 @@ class AdminAppointmentIT : IntegrationTestBase() {
         )
         .exchange()
         .expectStatus()
-        .isBadRequest
-        .bodyAsObject<ErrorResponse>()
+        .isOk
+        .bodyAsObject<UpdateAppointmentsOutcomesResultDto>()
 
-      domainEventAsserter.assertEventCount("community-payback.appointment.updated", 0)
+      assertThat(result.results).hasSize(2)
+      assertThat(result.results[0].deliusId).isEqualTo(1234L)
+      assertThat(result.results[0].result).isEqualTo(UpdateAppointmentOutcomeResultType.SUCCESS)
+      assertThat(result.results[1].deliusId).isEqualTo(5678L)
+      assertThat(result.results[1].result).isEqualTo(UpdateAppointmentOutcomeResultType.VALIDATION_ERROR)
+      assertThat(result.results[1].errorMessage).isEqualTo("This appointment has previously been marked as sensitive so this cannot be changed")
+
+      CommunityPaybackAndDeliusMockServer.verifyPutAppointmentRequest("PC01", 1234L)
+      domainEventAsserter.assertEventCount("community-payback.appointment.updated", 1)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentBulkUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentBulkUpdateServiceTest.kt
@@ -6,7 +6,6 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -55,27 +54,34 @@ class AppointmentBulkUpdateServiceTest {
   inner class UpdateAppointmentOutcomes {
 
     @Test
-    fun `don't proceed if validation fails`() {
+    fun `validation failure returned as VALIDATION_ERROR`() {
       val appointment1Dto = AppointmentDto.valid()
-      val update1 = UpdateAppointmentOutcomeDto.valid()
+      val update1 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 1L)
 
       val appointment2Dto = AppointmentDto.valid()
-      val update2 = UpdateAppointmentOutcomeDto.valid()
+      val update2 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 2L)
 
       every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update1.deliusId)) } returns appointment1Dto
       every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
       every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update2.deliusId)) } returns appointment2Dto
       every { appointmentUpdateValidationService.validateUpdate(appointment2Dto, update2) } throws BadRequestException("oh dear")
 
-      assertThatThrownBy {
-        service.updateAppointments(
-          projectCode = PROJECT_CODE,
-          request = UpdateAppointmentOutcomesDto(listOf(update1, update2)),
-          trigger = TRIGGER,
-        )
-      }.isInstanceOf(BadRequestException::class.java)
+      val result = service.updateAppointments(
+        projectCode = PROJECT_CODE,
+        request = UpdateAppointmentOutcomesDto(listOf(update1, update2)),
+        trigger = TRIGGER,
+      )
 
-      verify(exactly = 0) { appointmentUpdateService.updateAppointment(any(), any(), any()) }
+      assertThat(result.results).hasSize(2)
+      assertThat(result.results[0].deliusId).isEqualTo(1L)
+      assertThat(result.results[0].result).isEqualTo(UpdateAppointmentOutcomeResultType.SUCCESS)
+      assertThat(result.results[0].errorMessage).isNull()
+      assertThat(result.results[1].deliusId).isEqualTo(2L)
+      assertThat(result.results[1].result).isEqualTo(UpdateAppointmentOutcomeResultType.VALIDATION_ERROR)
+      assertThat(result.results[1].errorMessage).isEqualTo("oh dear")
+
+      verify(exactly = 1) { appointmentUpdateService.updateAppointment(appointment1Dto, update1, TRIGGER) }
+      verify(exactly = 0) { appointmentUpdateService.updateAppointment(appointment2Dto, update2, TRIGGER) }
     }
 
     @Test
@@ -167,39 +173,46 @@ class AppointmentBulkUpdateServiceTest {
       val existing2 = AppointmentDto.valid()
       val existing3 = AppointmentDto.valid()
       val existing4 = AppointmentDto.valid()
+      val existing5 = AppointmentDto.valid()
 
       val update1 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 1L)
       val update2 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 2L)
       val update3 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 3L)
       val update4 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 4L)
+      val update5 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 5L)
 
       every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update1.deliusId)) } returns null
       every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update2.deliusId)) } returns existing2
       every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update3.deliusId)) } returns existing3
       every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update4.deliusId)) } returns existing4
+      every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update5.deliusId)) } returns existing5
 
       every { appointmentUpdateValidationService.validateUpdate(existing2, update2) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update2)
-      every { appointmentUpdateValidationService.validateUpdate(existing3, update3) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update3)
+      every { appointmentUpdateValidationService.validateUpdate(existing3, update3) } throws BadRequestException("validation failed")
       every { appointmentUpdateValidationService.validateUpdate(existing4, update4) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update4)
+      every { appointmentUpdateValidationService.validateUpdate(existing5, update5) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update5)
 
       every { appointmentUpdateService.updateAppointment(existing2, update2, TRIGGER) } throws ConflictException("oh no")
-      every { appointmentUpdateService.updateAppointment(existing3, update3, TRIGGER) } throws IllegalStateException("oh no")
+      every { appointmentUpdateService.updateAppointment(existing4, update4, TRIGGER) } throws IllegalStateException("oh no")
 
       val result = service.updateAppointments(
         projectCode = PROJECT_CODE,
-        request = UpdateAppointmentOutcomesDto(listOf(update1, update2, update3, update4)),
+        request = UpdateAppointmentOutcomesDto(listOf(update1, update2, update3, update4, update5)),
         trigger = TRIGGER,
       )
 
-      assertThat(result.results).hasSize(4)
+      assertThat(result.results).hasSize(5)
       assertThat(result.results[0].deliusId).isEqualTo(1L)
       assertThat(result.results[0].result).isEqualTo(UpdateAppointmentOutcomeResultType.NOT_FOUND)
       assertThat(result.results[1].deliusId).isEqualTo(2L)
       assertThat(result.results[1].result).isEqualTo(UpdateAppointmentOutcomeResultType.VERSION_CONFLICT)
       assertThat(result.results[2].deliusId).isEqualTo(3L)
-      assertThat(result.results[2].result).isEqualTo(UpdateAppointmentOutcomeResultType.SERVER_ERROR)
+      assertThat(result.results[2].result).isEqualTo(UpdateAppointmentOutcomeResultType.VALIDATION_ERROR)
+      assertThat(result.results[2].errorMessage).isEqualTo("validation failed")
       assertThat(result.results[3].deliusId).isEqualTo(4L)
-      assertThat(result.results[3].result).isEqualTo(UpdateAppointmentOutcomeResultType.SUCCESS)
+      assertThat(result.results[3].result).isEqualTo(UpdateAppointmentOutcomeResultType.SERVER_ERROR)
+      assertThat(result.results[4].deliusId).isEqualTo(5L)
+      assertThat(result.results[4].result).isEqualTo(UpdateAppointmentOutcomeResultType.SUCCESS)
     }
   }
 }


### PR DESCRIPTION
 - For validation exceptions, we no longer fail on the first appointment
 - All appointments are validated, and successful ones are updated in delius
 - Both validation and server errors will now use UpdateAppointmentsOutcomesResultDto for multiple appointments to indicate successes and failures