### PR TITLE
CPB-1099: Introduce `GET /supervisor/sessions/future` endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
@@ -41,6 +41,7 @@ interface CommunityPaybackAndDeliusClient {
   @GetExchange("/providers/{providerCode}/teams")
   fun getProviderTeams(@PathVariable providerCode: String): NDProviderTeamSummaries
 
+  @Deprecated("This overload calls a deprecated endpoint.", replaceWith = ReplaceWith("getSessions(listOf(teamCode), startDate, endDate, typeCode, params)"))
   @GetExchange("/providers/{providerCode}/teams/{teamCode}/sessions")
   fun getSessions(
     @PathVariable providerCode: String,
@@ -50,6 +51,15 @@ interface CommunityPaybackAndDeliusClient {
     @RequestParam typeCode: List<String>?,
     @RequestParam params: Map<String, String>,
   ): NDSessionSummaries
+
+  @GetExchange("/sessions")
+  fun getSessions(
+    @RequestParam teamCodes: List<String>,
+    @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate,
+    @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate,
+    @RequestParam typeCode: List<String>?,
+    @RequestParam params: Map<String, String>,
+  ): PageResponse<NDSessionSummary>
 
   @Cacheable(CacheKey.Delius.GET_PROJECT)
   @GetExchange("/projects/{projectCode}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/PageUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/PageUtils.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.common
+
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
+
+fun <T : Any> PageResponse<T>.asPage(pageable: Pageable = Pageable.unpaged()) = PageImpl(this.content, pageable, this.page.totalElements)
+
+inline fun <T : Any, R : Any> PageResponse<T>.asPage(pageable: Pageable = Pageable.unpaged(), transform: (T) -> R) = PageImpl(this.content.map(transform), pageable, this.page.totalElements)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorSessionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorSessionsController.kt
@@ -14,6 +14,7 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.NotFoundException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.SessionService
@@ -54,6 +55,7 @@ class SupervisorSessionsController(
     @PathVariable supervisorCode: String,
   ) = sessionService.getNextAllocationForSupervisor(supervisorCode) ?: throw NotFoundException("There are no future sessions for supervisor $supervisorCode")
 
+  @Deprecated("The GET /supervisor/sessions/future endpoint should be used instead.")
   @PageableAsQueryParam
   @GetMapping(
     path = [ "/supervisor/providers/{providerCode}/teams/{teamCode}/sessions/future"],
@@ -80,6 +82,32 @@ class SupervisorSessionsController(
     LocalDate.now().plusDays(7),
     projectTypeGroup = ProjectTypeGroupDto.GROUP,
     pageable = pageable,
+  )
+
+  @PageableAsQueryParam
+  @GetMapping(
+    path = ["/supervisor/sessions/future"],
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+  )
+  @Operation(
+    description = "Get group sessions scheduled for the next 7 days (including today) that belong to the given teams.",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Successful response",
+      ),
+    ],
+  )
+  fun getFutureSessions(
+    @RequestParam teamCodes: List<String> = emptyList(),
+    @Parameter(hidden = true)
+    @PageableDefault(size = 50, sort = ["date"], direction = Sort.Direction.ASC) pageable: Pageable,
+  ) = sessionService.getSessions(
+    teamCodes,
+    LocalDate.now(),
+    LocalDate.now().plusDays(7),
+    projectTypeGroup = ProjectTypeGroupDto.GROUP,
+    pageable,
   )
 
   @GetMapping(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentRetrievalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentRetrievalService.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.asPage
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
@@ -65,7 +65,7 @@ class AppointmentRetrievalService(
       appointmentIds = deliusAppointmentIds,
       params = pageable.toHttpParams(),
     )
-    return PageImpl(pageResponse.content.map { appointmentMappers.toSummaryDto(it) }, pageable, pageResponse.page.totalElements)
+    return pageResponse.asPage(pageable) { appointmentMappers.toSummaryDto(it) }
   }
 
   fun getOrCreateAppointmentEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/ProjectService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/ProjectService.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.asPage
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectOutcomeSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
@@ -34,7 +34,7 @@ class ProjectService(
       typeCode = projectTypeGroup?.let { projectTypeGroup -> projectTypesForGroup(projectTypeGroup).map { it.code } },
       params = pageable.toHttpParams(),
     )
-    return PageImpl(pageResponse.content.map { it.toDto() }, pageable, pageResponse.page.totalElements)
+    return pageResponse.asPage(pageable) { it.toDto() }
   }
 
   fun projectTypesForGroup(projectTypeGroup: ProjectTypeGroupDto) = projectTypeEntityRepository.findByProjectTypeGroupOrderByCodeAsc(ProjectTypeGroup.fromDto(projectTypeGroup))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/SessionService.kt
@@ -1,12 +1,14 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.asPage
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.badRequest
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionDto
@@ -35,6 +37,7 @@ class SessionService(
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
+  @Deprecated("This overload calls a deprecated endpoint.", replaceWith = ReplaceWith("getSessions(listOf(teamCode), startDate, endDate, projectTypeGroup, pageable)"))
   fun getSessions(
     providerCode: String,
     teamCode: String,
@@ -57,6 +60,30 @@ class SessionService(
       },
       params = pageable.toHttpParams(),
     ).toDto()
+  }
+
+  fun getSessions(
+    teamCodes: List<String>,
+    startDate: LocalDate,
+    endDate: LocalDate,
+    projectTypeGroup: ProjectTypeGroupDto?,
+    pageable: Pageable,
+  ): Page<SessionSummaryDto> {
+    if (ChronoUnit.DAYS.between(startDate, endDate) > 7) {
+      badRequest("Date range cannot be greater than 7 days")
+    }
+
+    val response = communityPaybackAndDeliusClient.getSessions(
+      teamCodes = teamCodes,
+      startDate = startDate,
+      endDate = endDate,
+      typeCode = projectTypeGroup?.let { projectTypeGroup ->
+        projectService.projectTypesForGroup(projectTypeGroup).map { it.code }
+      },
+      params = pageable.toHttpParams(),
+    )
+
+    return response.asPage(pageable) { it.toDto() }
   }
 
   fun getSession(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/SupervisorSessionsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/SupervisorSessionsIT.kt
@@ -9,11 +9,9 @@ import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointmentSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProject
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProjectSummary
-import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionSummariesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.SessionSupervisorEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.SessionSupervisorEntityRepository
@@ -196,8 +194,8 @@ class SupervisorSessionsIT : IntegrationTestBase() {
   }
 
   @Nested
-  @DisplayName("GET /supervisor/supervisors/{supervisorCode}/sessions/future")
-  inner class GetFutureSessionEndpoint {
+  @DisplayName("GET /supervisor/sessions/future")
+  inner class GetFutureSessionsEndpoint {
 
     @BeforeEach
     fun setUp() {
@@ -207,7 +205,7 @@ class SupervisorSessionsIT : IntegrationTestBase() {
     @Test
     fun `should return unauthorized if no token`() {
       webTestClient.get()
-        .uri("/supervisor/providers/P123/teams/T456/sessions/future")
+        .uri("/supervisor/sessions/future?teamCodes=T456")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -216,7 +214,7 @@ class SupervisorSessionsIT : IntegrationTestBase() {
     @Test
     fun `should return forbidden if no role`() {
       webTestClient.get()
-        .uri("/supervisor/providers/P123/teams/T456/sessions/future")
+        .uri("/supervisor/sessions/future?teamCodes=T456")
         .headers(setAuthorisation())
         .exchange()
         .expectStatus()
@@ -226,7 +224,7 @@ class SupervisorSessionsIT : IntegrationTestBase() {
     @Test
     fun `should return forbidden if wrong role`() {
       webTestClient.get()
-        .uri("/supervisor/providers/P123/teams/T456/sessions/future")
+        .uri("/supervisor/sessions/future?teamCodes=T456")
         .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
         .exchange()
         .expectStatus()
@@ -244,32 +242,25 @@ class SupervisorSessionsIT : IntegrationTestBase() {
       )
 
       CommunityPaybackAndDeliusMockServer.setupGetSessionsResponse(
-        providerCode = "P123",
-        teamCode = "T456",
+        teamCodes = listOf("T456"),
         startDate = LocalDate.now(),
         endDate = LocalDate.now().plusDays(7),
         typeCode = listOf("NP1", "NP2", "PL"),
-        projectSessions = NDSessionSummaries(
-          sessions,
-          pageResponse = PageResponse(
-            content = sessions,
-            page = PageResponse.PageMeta(50, 0, 2, 1),
-          ),
+        sessions = PageResponse(
+          content = sessions,
+          page = PageResponse.PageMeta(50, 0, 2, 1),
         ),
-        sortString = "date,desc",
+        sortString = "date,asc",
       )
 
       val result = webTestClient.get()
-        .uri("/supervisor/providers/P123/teams/T456/sessions/future")
+        .uri("/supervisor/sessions/future?teamCodes=T456")
         .addSupervisorUiAuthHeader(username = "USER1")
         .exchange()
         .expectStatus()
         .isOk
-        .bodyAsObject<SessionSummariesDto>()
+        .bodyAsObject<PageResponse<SessionSummaryDto>>()
 
-      assertThat(result.allocations).hasSize(2)
-      assertThat(result.allocations[0].projectName).isEqualTo(projectName1)
-      assertThat(result.allocations[1].projectName).isEqualTo(projectName2)
       assertThat(result.content).hasSize(2)
       assertThat(result.content[0].projectName).isEqualTo(projectName1)
       assertThat(result.content[1].projectName).isEqualTo(projectName2)
@@ -291,32 +282,25 @@ class SupervisorSessionsIT : IntegrationTestBase() {
     )
 
     CommunityPaybackAndDeliusMockServer.setupGetSessionsResponse(
-      providerCode = "P123",
-      teamCode = "T456",
+      teamCodes = listOf("T456"),
       startDate = LocalDate.now(),
       endDate = LocalDate.now().plusDays(7),
       typeCode = listOf("NP1", "NP2", "PL"),
-      projectSessions = NDSessionSummaries(
-        sessions,
-        pageResponse = PageResponse(
-          content = sessions,
-          page = PageResponse.PageMeta(25, 0, 2, 1),
-        ),
+      sessions = PageResponse(
+        content = sessions,
+        page = PageResponse.PageMeta(25, 0, 2, 1),
       ),
       sortString = "projectName,asc",
     )
 
     val result = webTestClient.get()
-      .uri("/supervisor/providers/P123/teams/T456/sessions/future?page=0&size=25&sort=projectName,asc")
+      .uri("/supervisor/sessions/future?teamCodes=T456&page=0&size=25&sort=projectName,asc")
       .addSupervisorUiAuthHeader(username = "USER1")
       .exchange()
       .expectStatus()
       .isOk
-      .bodyAsObject<SessionSummariesDto>()
+      .bodyAsObject<PageResponse<SessionSummaryDto>>()
 
-    assertThat(result.allocations).hasSize(2)
-    assertThat(result.allocations[0].projectName).isEqualTo(projectName1)
-    assertThat(result.allocations[1].projectName).isEqualTo(projectName2)
     assertThat(result.content).hasSize(2)
     assertThat(result.content[0].projectName).isEqualTo(projectName1)
     assertThat(result.content[1].projectName).isEqualTo(projectName2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProjectOutcomeS
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProviderSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProviderTeamSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummaries
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSupervisor
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSupervisorSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSupervisorSummary
@@ -252,6 +253,7 @@ object CommunityPaybackAndDeliusMockServer {
     )
   }
 
+  @Deprecated("This mocks a deprecated endpoint.", replaceWith = ReplaceWith("setupGetSessionsResponse(listOf(teamCode), startDate, endDate, sessions, typeCode, sortString)"))
   fun setupGetSessionsResponse(
     providerCode: String,
     teamCode: String,
@@ -277,6 +279,38 @@ object CommunityPaybackAndDeliusMockServer {
           aResponse()
             .withHeader("Content-Type", "application/json")
             .withBody(jsonMapper.writeValueAsString(projectSessions)),
+        ),
+    )
+  }
+
+  fun setupGetSessionsResponse(
+    teamCodes: List<String>,
+    startDate: LocalDate,
+    endDate: LocalDate,
+    sessions: PageResponse<NDSessionSummary>,
+    typeCode: List<String> = emptyList(),
+    sortString: String,
+  ) {
+    val url = buildString {
+      append("/community-payback-and-delius/sessions?")
+      teamCodes.forEach {
+        append("teamCodes=$it&")
+      }
+      append("startDate=${startDate.toIsoDateString()}&endDate=${endDate.toIsoDateString()}")
+      typeCode.forEach {
+        append("&typeCode=$it")
+      }
+      append("&page=${sessions.page.number}")
+      append("&size=${sessions.page.size}")
+      append("&sort=${URLEncoder.encode(sortString, "UTF-8")}")
+    }
+
+    WireMock.stubFor(
+      get(url)
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(jsonMapper.writeValueAsString(sessions)),
         ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/SessionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/SessionServiceTest.kt
@@ -13,7 +13,6 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
-import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummaries
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeDto
@@ -29,6 +28,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.SessionService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.SessionMappers
 import java.time.LocalDate
 
+@Suppress("unused") // Mocked objects that need to exist but aren't directly referenced
 @ExtendWith(MockKExtension::class)
 class SessionServiceTest {
 
@@ -60,8 +60,7 @@ class SessionServiceTest {
     fun `if date range greater than 7 days throw exception`() {
       assertThatThrownBy {
         service.getSessions(
-          providerCode = "provider code 1",
-          teamCode = "team code 1",
+          teamCodes = listOf("team code 1"),
           startDate = LocalDate.of(2025, 1, 1),
           endDate = LocalDate.of(2025, 1, 9),
           projectTypeGroup = null,
@@ -86,36 +85,30 @@ class SessionServiceTest {
 
       every {
         communityPaybackAndDeliusClient.getSessions(
-          providerCode = "provider code 1",
-          teamCode = "team code 1",
+          teamCodes = listOf("team code 1"),
           startDate = LocalDate.of(2025, 1, 1),
           endDate = LocalDate.of(2025, 1, 5),
           typeCode = listOf("PT1"),
           params = mapOf("page" to pageNumber.toString(), "size" to pageSize.toString(), "sort" to "projectName,asc"),
         )
-      } returns NDSessionSummaries.valid().copy(
-        sessions = sessions,
-        pageResponse = PageResponse(
-          content = sessions,
-          PageResponse.PageMeta(pageSize, pageNumber, 3, 1),
-        ),
+      } returns PageResponse(
+        content = sessions,
+        PageResponse.PageMeta(pageSize, pageNumber, 3, 1),
       )
 
       val result = service.getSessions(
-        providerCode = "provider code 1",
-        teamCode = "team code 1",
+        teamCodes = listOf("team code 1"),
         startDate = LocalDate.of(2025, 1, 1),
         endDate = LocalDate.of(2025, 1, 5),
         projectTypeGroup = ProjectTypeGroupDto.GROUP,
         pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.ASC, "projectName")),
       )
 
-      assertThat(result.allocations).hasSize(3)
       assertThat(result.content).hasSize(3)
-      assertThat(result.page.totalElements).isEqualTo(3)
-      assertThat(result.page.totalPages).isEqualTo(1)
-      assertThat(result.page.number).isEqualTo(pageNumber)
-      assertThat(result.page.size).isEqualTo(pageSize)
+      assertThat(result.totalElements).isEqualTo(3)
+      assertThat(result.totalPages).isEqualTo(1)
+      assertThat(result.number).isEqualTo(pageNumber)
+      assertThat(result.size).isEqualTo(pageSize)
     }
   }
 }


### PR DESCRIPTION
The existing `GET /supervisor/providers/{providerCode}/teams/{teamCode}/sessions/future` endpoint does not support situations where supervisors belong to multiple teams.

This PR introduces a new endpoint (`GET /supervisor/sessions/future`) that accepts multiple team codes as a query parameter, and deprecates the existing endpoint.