### PR TITLE
CPB-1100: Add `GET /course-completions/{id}/draft-resolution` endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminCourseCompletionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminCourseCompletionController.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.common.atFirstSecondOfDa
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.atLastSecondOfDay
 import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.SupportsIdempotencyKey
 import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.notFound
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionDraftResolutionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionRecommendationDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionEventDto
@@ -183,6 +184,21 @@ class AdminCourseCompletionController(val eteService: EteService) {
   ): List<EteCourseCompletionEventDto> {
     ensureCourseCompletionExists(id)
     return eteService.getCourseCompletionBlock(id, blockSize)
+  }
+
+  @GetMapping("/course-completions/{id}/draft-resolution", produces = [MediaType.APPLICATION_JSON_VALUE])
+  @Operation(
+    description = "Gets the draft resolution for this course completion.",
+    responses = [
+      ApiResponse(responseCode = "200", description = "Draft resolution for this course completion"),
+      ApiResponse(responseCode = "404", description = "Draft resolution not found", content = [Content(schema = Schema(implementation = ErrorResponse::class))]),
+    ],
+  )
+  fun getCourseCompletionDraftResolution(
+    @PathVariable id: UUID,
+  ): CourseCompletionDraftResolutionDto {
+    ensureCourseCompletionExists(id)
+    return eteService.getCourseCompletionDraftResolution(id) ?: notFound("Draft resolution", id.toString())
   }
 
   private fun ensureCourseCompletionExists(id: UUID) = eteService.getCourseCompletionEvent(id) ?: notFound("Course completion event", id.toString())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CourseCompletionDraftResolutionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CourseCompletionDraftResolutionDto.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
+
+data class CourseCompletionDraftResolutionDto(
+  val crn: String?,
+) {
+  companion object
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionDraftResolutionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionDraftResolutionRepository.kt
@@ -3,4 +3,6 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.entity
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
-interface EteCourseCompletionDraftResolutionRepository : JpaRepository<EteCourseCompletionDraftResolutionEntity, UUID>
+interface EteCourseCompletionDraftResolutionRepository : JpaRepository<EteCourseCompletionDraftResolutionEntity, UUID> {
+  fun findByEteCourseCompletionEventId(id: UUID): EteCourseCompletionDraftResolutionEntity?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/CourseCompletionAutoResolutionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/CourseCompletionAutoResolutionService.kt
@@ -20,6 +20,8 @@ class CourseCompletionAutoResolutionService(
     val log: Logger = LoggerFactory.getLogger(CourseCompletionAutoResolutionService::class.java)
   }
 
+  fun getDraftResolutionForCourseCompletion(courseCompletionEventId: UUID): EteCourseCompletionDraftResolutionEntity? = draftResolutionRepository.findByEteCourseCompletionEventId(courseCompletionEventId)
+
   fun resolveAndPersistDraft(event: EteCourseCompletionEventEntity) {
     val crn = searchForCrn(event)
     draftResolutionRepository.save(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
@@ -8,6 +8,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.badRequest
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionDraftResolutionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionRecommendationDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionTypeDto
@@ -155,6 +156,8 @@ class EteService(
 
     return CourseCompletionRecommendationDto(crn)
   }
+
+  fun getCourseCompletionDraftResolution(courseCompletionEventId: UUID): CourseCompletionDraftResolutionDto? = courseCompletionAutoResolutionService.getDraftResolutionForCourseCompletion(courseCompletionEventId)?.toDto()
 
   @Transactional
   fun recordCourseCompletionResolution(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/EteMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/EteMappers.kt
@@ -10,12 +10,14 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentBehaviour
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentWorkQualityDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AttendanceDataDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionDraftResolutionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionEventDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.CommunityCampusPduEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionDraftResolutionEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository.CourseFailureFilter
@@ -254,3 +256,7 @@ fun EteCourseCompletionEventStatus.formatForUser(): String = when (this) {
   EteCourseCompletionEventStatus.PASSED -> "pass"
   EteCourseCompletionEventStatus.FAILED -> "fail"
 }
+
+fun EteCourseCompletionDraftResolutionEntity.toDto() = CourseCompletionDraftResolutionDto(
+  crn = crn,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/CourseCompletionDraftResolutionDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/CourseCompletionDraftResolutionDtoFactory.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto
+
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionDraftResolutionDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
+
+fun CourseCompletionDraftResolutionDto.Companion.valid() = CourseCompletionDraftResolutionDto(
+  crn = String.random(7),
+)
+
+fun CourseCompletionDraftResolutionDto.Companion.validEmpty() = CourseCompletionDraftResolutionDto(
+  crn = null,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/entity/EteCourseCompletionDraftResolutionEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/entity/EteCourseCompletionDraftResolutionEntityFactory.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity
+
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionDraftResolutionEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
+import java.util.UUID
+
+fun EteCourseCompletionDraftResolutionEntity.Companion.valid() = EteCourseCompletionDraftResolutionEntity(
+  id = UUID.randomUUID(),
+  eteCourseCompletionEvent = EteCourseCompletionEventEntity.valid(),
+  crn = String.random(7),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminCourseCompletionIT.kt
@@ -23,11 +23,14 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.common.atLastSecondOfDay
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.toLocalTimeEuropeLondon
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionCreditTimeDetailsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionDontCreditTimeDetailsDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionDraftResolutionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionRecommendationDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CourseCompletionResolutionTypeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionEventDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.CommunityCampusPduEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionDraftResolutionEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionDraftResolutionRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventResolutionEntity
@@ -61,6 +64,9 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
 
   @Autowired
   lateinit var eteCourseCompletionEventResolutionRepository: EteCourseCompletionEventResolutionRepository
+
+  @Autowired
+  lateinit var eteCourseCompletionDraftResolutionRepository: EteCourseCompletionDraftResolutionRepository
 
   @Autowired
   lateinit var domainEventAsserter: DomainEventAsserter
@@ -1358,6 +1364,85 @@ class AdminCourseCompletionIT : IntegrationTestBase() {
         .exchange()
         .expectStatus()
         .isBadRequest
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /course-completions/{id}/draft-resolution")
+  inner class GetCourseCompletionDraftResolutionEndpoint {
+
+    @BeforeEach
+    fun setUp() {
+      databasePurgeUtils.deleteAllEteData()
+    }
+
+    @Test
+    fun `should return unauthorized if no token`() {
+      val id = UUID.randomUUID()
+      webTestClient.get()
+        .uri("/admin/course-completions/$id/draft-resolution")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden if no role`() {
+      val id = UUID.randomUUID()
+      webTestClient.get()
+        .uri("/admin/course-completions/$id/draft-resolution")
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `should return 404 when course completion not found`() {
+      val id = UUID.randomUUID()
+      webTestClient.get()
+        .uri("/admin/course-completions/$id/draft-resolution")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+
+    @Test
+    fun `should return draft resolution with all fields when available`() {
+      val crn = "X123456"
+
+      val targetEvent = eteCourseCompletionEventEntityRepository.save(
+        EteCourseCompletionEventEntity.valid(ctx),
+      )
+
+      eteCourseCompletionDraftResolutionRepository.save(
+        EteCourseCompletionDraftResolutionEntity.valid().copy(eteCourseCompletionEvent = targetEvent, crn = crn),
+      )
+
+      val result = webTestClient.get()
+        .uri("/admin/course-completions/${targetEvent.id}/draft-resolution")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<CourseCompletionDraftResolutionDto>()
+
+      assertThat(result.crn).isEqualTo(crn)
+    }
+
+    @Test
+    fun `should return 404 Not Found when no draft resolution is found`() {
+      val targetEvent = eteCourseCompletionEventEntityRepository.save(
+        EteCourseCompletionEventEntity.valid(ctx),
+      )
+
+      webTestClient.get()
+        .uri("/admin/course-completions/${targetEvent.id}/draft-resolution")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isNotFound
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/CourseCompletionAutoResolutionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/CourseCompletionAutoResolutionServiceTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompleti
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.CourseCompletionAutoResolutionService
+import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
 class CourseCompletionAutoResolutionServiceTest {
@@ -117,6 +118,20 @@ class CourseCompletionAutoResolutionServiceTest {
       }
 
       verify(exactly = 0) { draftResolutionRepository.save(any()) }
+    }
+  }
+
+  @Nested
+  inner class GetDraftResolutionForCourseCompletion {
+    @Test
+    fun `delegates to repository method`() {
+      val courseCompletionEventId = UUID.randomUUID()
+      val expected = EteCourseCompletionDraftResolutionEntity.valid()
+      every { draftResolutionRepository.findByEteCourseCompletionEventId(courseCompletionEventId) } returns expected
+
+      val result = service.getDraftResolutionForCourseCompletion(courseCompletionEventId)
+
+      assertThat(result).isEqualTo(expected)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/EteServiceTest.kt
@@ -15,6 +15,7 @@ import org.springframework.data.repository.findByIdOrNull
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.atFirstSecondOfDay
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.atLastSecondOfDay
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EteCourseCompletionShowCourseFailuresDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionDraftResolutionEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository.CourseFailureFilter
@@ -568,6 +569,22 @@ class EteServiceTest {
         eteService.getCourseCompletionBlock(id, 0)
       }
       assertThat(exception.message).isEqualTo("blockSize must be greater than 0")
+    }
+  }
+
+  @Nested
+  inner class GetCourseCompletionDraftRecommendation {
+    @Test
+    fun `returns expected result for course completion`() {
+      val courseCompletionEvent = EteCourseCompletionEventEntity.valid()
+      val draftResolutionEntity = EteCourseCompletionDraftResolutionEntity.valid().copy(eteCourseCompletionEvent = courseCompletionEvent)
+
+      every { courseCompletionAutoResolutionService.getDraftResolutionForCourseCompletion(courseCompletionEvent.id) } returns draftResolutionEntity
+
+      val result = eteService.getCourseCompletionDraftResolution(courseCompletionEvent.id)
+
+      assertThat(result).isNotNull
+      assertThat(result!!.crn).isEqualTo(draftResolutionEntity.crn)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/EteMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/EteMappersTest.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.CommunityCampusPd
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.CommunityCampusPduEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionDraftResolutionEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository.CourseFailureFilter
@@ -730,6 +731,18 @@ class EteMappersTest {
       assertThat(result.completionDateTime).isEqualTo("2026-01-01T10:00:00Z")
       assertThat(result.externalReference).isEqualTo("EXT123")
       assertThat(result.receivedAt).isCloseTo(OffsetDateTime.now(), within(1, ChronoUnit.SECONDS))
+    }
+  }
+
+  @Nested
+  inner class EteCourseCompletionDraftResolutionEntityToCourseCompletionDraftResolutionDto {
+    @Test
+    fun `maps required fields`() {
+      val draftResolutionEntity = EteCourseCompletionDraftResolutionEntity.valid()
+
+      val result = draftResolutionEntity.toDto()
+
+      assertThat(result.crn).isEqualTo(draftResolutionEntity.crn)
     }
   }
 }


### PR DESCRIPTION
The API will attempt to automatically match course completion events to CRNs, where possible, as they arrive. This is intended to simplify the process for users who are recording course completions against appointments. To allow this, the outcome of the automatically matched data must be made available to the UI.

This PR introduces the `GET /course-completions/{id}/draft-resolution` endpoint to do this. It accepts the ID of the course completion event, and returns any automatically matched information stored in the draft resolution for that event.

Currently, this is just the CRN:
```json
{
  "crn": "X123456"
}
```