### PR TITLE
CPB-1111: Set compliance data to null on appointments when no contact outcome is provided

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
@@ -339,6 +339,7 @@ fun NDAppointmentBehaviour.toDto() = when (this) {
 
 val AppointmentCommandDto.workQuality
   get() = when (this.contactOutcomeCode) {
+    null -> null
     "ATTC" -> NDAppointmentWorkQuality.GOOD
     "AFTC", "ATSH" -> NDAppointmentWorkQuality.POOR
     else -> NDAppointmentWorkQuality.NOT_APPLICABLE
@@ -346,6 +347,7 @@ val AppointmentCommandDto.workQuality
 
 val AppointmentCommandDto.behaviour
   get() = when (this.contactOutcomeCode) {
+    null -> null
     "ATTC" -> NDAppointmentBehaviour.GOOD
     "AFTC", "ATSH" -> NDAppointmentBehaviour.POOR
     else -> NDAppointmentBehaviour.NOT_APPLICABLE

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
@@ -854,6 +854,7 @@ class AppointmentMappersTest {
   inner class AppointmentCommandDtoWorkQuality {
     @ParameterizedTest
     @CsvSource(
+      ",",
       "ATTC,GOOD",
       "AFTC,POOR",
       "ATSH,POOR",
@@ -864,7 +865,7 @@ class AppointmentMappersTest {
       "YYYY,NOT_APPLICABLE",
       "ZZZZ,NOT_APPLICABLE",
     )
-    fun `work quality is automatically determined by outcome code`(outcomeCode: String, expected: NDAppointmentWorkQuality) {
+    fun `work quality is automatically determined by outcome code`(outcomeCode: String?, expected: NDAppointmentWorkQuality?) {
       val createAppointmentDto = CreateAppointmentDto.valid().copy(contactOutcomeCode = outcomeCode)
       val updateAppointmentDto = UpdateAppointmentDto.valid().copy(contactOutcomeCode = outcomeCode)
 
@@ -877,6 +878,7 @@ class AppointmentMappersTest {
   inner class AppointmentCommandDtoBehaviour {
     @ParameterizedTest
     @CsvSource(
+      ",",
       "ATTC,GOOD",
       "AFTC,POOR",
       "ATSH,POOR",
@@ -887,7 +889,7 @@ class AppointmentMappersTest {
       "YYYY,NOT_APPLICABLE",
       "ZZZZ,NOT_APPLICABLE",
     )
-    fun `behaviour is automatically determined by outcome code`(outcomeCode: String, expected: NDAppointmentBehaviour) {
+    fun `behaviour is automatically determined by outcome code`(outcomeCode: String?, expected: NDAppointmentBehaviour?) {
       val createAppointmentDto = CreateAppointmentDto.valid().copy(contactOutcomeCode = outcomeCode)
       val updateAppointmentDto = UpdateAppointmentDto.valid().copy(contactOutcomeCode = outcomeCode)
 


### PR DESCRIPTION
Currently, when the contact outcome is `null`, the work quality and behaviour data is set to `NOT_APPLICABLE`. In this situation, the appointment has not been resolved yet, so it is incorrect to have any data for these values.

This changes the logic in the `AppointmentMappers.kt` file to explicitly handle `null` as a contact outcome, returning `null` for both of these in this case.

This means that when an appointment is created or updated, these will remain unset in Delius.