### PR TITLE
CPB-1115: Reinstate work quality and behaviour compliance data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/AttendanceDataDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/AttendanceDataDto.kt
@@ -13,10 +13,8 @@ data class AttendanceDataDto(
   @param:Schema(description = "Deprecated, use penaltyMinutes instead", deprecated = true)
   val penaltyTime: HourMinuteDuration? = null,
   val penaltyMinutes: Long? = null,
-  @Deprecated("This property is no longer used as this is derived from the outcome.")
-  val workQuality: AppointmentWorkQualityDto?,
-  @Deprecated("This property is no longer used as this is derived from the outcome.")
-  val behaviour: AppointmentBehaviourDto?,
+  val workQuality: AppointmentWorkQualityDto,
+  val behaviour: AppointmentBehaviourDto,
 ) {
   companion object
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
@@ -339,7 +339,6 @@ fun NDAppointmentBehaviour.toDto() = when (this) {
 
 val AppointmentCommandDto.workQuality
   get() = when (this.contactOutcomeCode) {
-    null -> null
     "ATTC" -> NDAppointmentWorkQuality.GOOD
     "AFTC", "ATSH" -> NDAppointmentWorkQuality.POOR
     else -> NDAppointmentWorkQuality.NOT_APPLICABLE
@@ -347,7 +346,6 @@ val AppointmentCommandDto.workQuality
 
 val AppointmentCommandDto.behaviour
   get() = when (this.contactOutcomeCode) {
-    null -> null
     "ATTC" -> NDAppointmentBehaviour.GOOD
     "AFTC", "ATSH" -> NDAppointmentBehaviour.POOR
     else -> NDAppointmentBehaviour.NOT_APPLICABLE

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCreateAppointme
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDUpdateAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.formatForUser
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentBehaviourDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentCommandDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentWorkQualityDto
@@ -181,8 +180,8 @@ fun ValidatedAppointment<UpdateAppointmentOutcomeDto>.toNDUpdateAppointment(
     workedIntensively = null,
     penaltyMinutes = updateDto.attendanceData?.derivePenaltyMinutesDuration()?.toMinutes(),
     minutesCredited = minutesToCredit?.toMinutes(),
-    workQuality = updateDto.workQuality,
-    behaviour = updateDto.behaviour,
+    workQuality = updateDto.attendanceData?.workQuality?.let { WorkQuality.fromDto(it).upstreamType },
+    behaviour = updateDto.attendanceData?.behaviour?.let { Behaviour.fromDto(it).upstreamType },
     sensitive = updateDto.sensitive,
     alertActive = updateDto.alertActive,
     pickUp = existingAppointment.pickUpData?.let { pickUpData ->
@@ -244,8 +243,8 @@ fun ValidatedAppointment<CreateAppointmentDto>.toNDCreateAppointment(
     workedIntensively = null,
     penaltyMinutes = createDto.attendanceData?.derivePenaltyMinutesDuration()?.toMinutes(),
     minutesCredited = minutesToCredit?.toMinutes(),
-    workQuality = createDto.workQuality,
-    behaviour = createDto.behaviour,
+    workQuality = createDto.attendanceData?.workQuality?.let { WorkQuality.fromDto(it).upstreamType },
+    behaviour = createDto.attendanceData?.behaviour?.let { Behaviour.fromDto(it).upstreamType },
     sensitive = createDto.sensitive,
     alertActive = createDto.alertActive,
     allocationId = null,
@@ -336,17 +335,3 @@ fun NDAppointmentBehaviour.toDto() = when (this) {
   NDAppointmentBehaviour.SATISFACTORY -> AppointmentBehaviourDto.SATISFACTORY
   NDAppointmentBehaviour.UNSATISFACTORY -> AppointmentBehaviourDto.UNSATISFACTORY
 }
-
-val AppointmentCommandDto.workQuality
-  get() = when (this.contactOutcomeCode) {
-    "ATTC" -> NDAppointmentWorkQuality.GOOD
-    "AFTC", "ATSH" -> NDAppointmentWorkQuality.POOR
-    else -> NDAppointmentWorkQuality.NOT_APPLICABLE
-  }
-
-val AppointmentCommandDto.behaviour
-  get() = when (this.contactOutcomeCode) {
-    "ATTC" -> NDAppointmentBehaviour.GOOD
-    "AFTC", "ATSH" -> NDAppointmentBehaviour.POOR
-    else -> NDAppointmentBehaviour.NOT_APPLICABLE
-  }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
@@ -84,8 +84,8 @@ class AppointmentMappers(
           workedIntensively = appointment.workedIntensively,
           penaltyTime = appointment.penaltyHours,
           penaltyMinutes = appointment.penaltyHours?.duration?.toMinutes(),
-          workQuality = appointment.workQuality?.toDto(),
-          behaviour = appointment.behaviour?.toDto(),
+          workQuality = appointment.workQuality!!.toDto(),
+          behaviour = appointment.behaviour!!.toDto(),
         )
       } else {
         null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
@@ -39,7 +39,6 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PickUpDataDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEventEntity
@@ -60,12 +59,10 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService.ValidatedAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.AppointmentMappers
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.ToAppointmentEntity.toAppointmentEntity
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.behaviour
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.fromDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toAppointmentUpdatedDomainEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toNDCreateAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toNDUpdateAppointment
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.workQuality
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
@@ -101,6 +98,8 @@ class AppointmentMappersTest {
           pickUpTime = LocalTime.of(13, 14, 15),
           attendanceData = AttendanceDataDto.valid().copy(
             penaltyMinutes = 105,
+            workQuality = AppointmentWorkQualityDto.NOT_APPLICABLE,
+            behaviour = AppointmentBehaviourDto.UNSATISFACTORY,
           ),
           supervisorOfficerCode = "WO3736",
           notes = "The notes",
@@ -132,7 +131,7 @@ class AppointmentMappersTest {
       assertThat(result.penaltyMinutes).isEqualTo(105)
       assertThat(result.minutesCredited).isEqualTo(35)
       assertThat(result.workQuality).isEqualTo(NDAppointmentWorkQuality.NOT_APPLICABLE)
-      assertThat(result.behaviour).isEqualTo(NDAppointmentBehaviour.NOT_APPLICABLE)
+      assertThat(result.behaviour).isEqualTo(NDAppointmentBehaviour.UNSATISFACTORY)
       assertThat(result.alertActive).isFalse
       assertThat(result.sensitive).isTrue
       assertThat(result.pickUp?.location?.code).isEqualTo("PICKUP10")
@@ -178,8 +177,8 @@ class AppointmentMappersTest {
       assertThat(result.workedIntensively).isNull()
       assertThat(result.penaltyMinutes).isNull()
       assertThat(result.minutesCredited).isNull()
-      assertThat(result.workQuality).isEqualTo(NDAppointmentWorkQuality.NOT_APPLICABLE)
-      assertThat(result.behaviour).isEqualTo(NDAppointmentBehaviour.NOT_APPLICABLE)
+      assertThat(result.workQuality).isNull()
+      assertThat(result.behaviour).isNull()
       assertThat(result.alertActive).isNull()
       assertThat(result.sensitive).isNull()
       assertThat(result.pickUp?.location).isNull()
@@ -213,6 +212,8 @@ class AppointmentMappersTest {
           endTime = LocalTime.of(12, 11, 10),
           attendanceData = AttendanceDataDto.valid().copy(
             penaltyMinutes = 105,
+            workQuality = AppointmentWorkQualityDto.NOT_APPLICABLE,
+            behaviour = AppointmentBehaviourDto.UNSATISFACTORY,
           ),
           supervisorOfficerCode = "WO3736",
           notes = "The notes",
@@ -245,7 +246,7 @@ class AppointmentMappersTest {
       assertThat(result.penaltyMinutes).isEqualTo(105)
       assertThat(result.minutesCredited).isEqualTo(35)
       assertThat(result.workQuality).isEqualTo(NDAppointmentWorkQuality.NOT_APPLICABLE)
-      assertThat(result.behaviour).isEqualTo(NDAppointmentBehaviour.NOT_APPLICABLE)
+      assertThat(result.behaviour).isEqualTo(NDAppointmentBehaviour.UNSATISFACTORY)
       assertThat(result.alertActive).isFalse
       assertThat(result.sensitive).isTrue
       assertThat(result.pickUp?.time).isEqualTo(LocalTime.of(1, 0, 0))
@@ -293,8 +294,8 @@ class AppointmentMappersTest {
       assertThat(result.workedIntensively).isNull()
       assertThat(result.penaltyMinutes).isNull()
       assertThat(result.minutesCredited).isNull()
-      assertThat(result.workQuality).isEqualTo(NDAppointmentWorkQuality.NOT_APPLICABLE)
-      assertThat(result.behaviour).isEqualTo(NDAppointmentBehaviour.NOT_APPLICABLE)
+      assertThat(result.workQuality).isNull()
+      assertThat(result.behaviour).isNull()
       assertThat(result.alertActive).isNull()
       assertThat(result.sensitive).isNull()
       assertThat(result.pickUp).isNull()
@@ -847,52 +848,6 @@ class AppointmentMappersTest {
       expectedValue: Behaviour,
     ) {
       assertThat(Behaviour.fromDto(sourceValue)).isEqualTo(expectedValue)
-    }
-  }
-
-  @Nested
-  inner class AppointmentCommandDtoWorkQuality {
-    @ParameterizedTest
-    @CsvSource(
-      "ATTC,GOOD",
-      "AFTC,POOR",
-      "ATSH,POOR",
-      "AAAA,NOT_APPLICABLE",
-      "BBBB,NOT_APPLICABLE",
-      "CCCC,NOT_APPLICABLE",
-      "XXXX,NOT_APPLICABLE",
-      "YYYY,NOT_APPLICABLE",
-      "ZZZZ,NOT_APPLICABLE",
-    )
-    fun `work quality is automatically determined by outcome code`(outcomeCode: String, expected: NDAppointmentWorkQuality) {
-      val createAppointmentDto = CreateAppointmentDto.valid().copy(contactOutcomeCode = outcomeCode)
-      val updateAppointmentDto = UpdateAppointmentDto.valid().copy(contactOutcomeCode = outcomeCode)
-
-      assertThat(createAppointmentDto.workQuality).isEqualTo(expected)
-      assertThat(updateAppointmentDto.workQuality).isEqualTo(expected)
-    }
-  }
-
-  @Nested
-  inner class AppointmentCommandDtoBehaviour {
-    @ParameterizedTest
-    @CsvSource(
-      "ATTC,GOOD",
-      "AFTC,POOR",
-      "ATSH,POOR",
-      "AAAA,NOT_APPLICABLE",
-      "BBBB,NOT_APPLICABLE",
-      "CCCC,NOT_APPLICABLE",
-      "XXXX,NOT_APPLICABLE",
-      "YYYY,NOT_APPLICABLE",
-      "ZZZZ,NOT_APPLICABLE",
-    )
-    fun `behaviour is automatically determined by outcome code`(outcomeCode: String, expected: NDAppointmentBehaviour) {
-      val createAppointmentDto = CreateAppointmentDto.valid().copy(contactOutcomeCode = outcomeCode)
-      val updateAppointmentDto = UpdateAppointmentDto.valid().copy(contactOutcomeCode = outcomeCode)
-
-      assertThat(createAppointmentDto.behaviour).isEqualTo(expected)
-      assertThat(updateAppointmentDto.behaviour).isEqualTo(expected)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
@@ -854,7 +854,6 @@ class AppointmentMappersTest {
   inner class AppointmentCommandDtoWorkQuality {
     @ParameterizedTest
     @CsvSource(
-      ",",
       "ATTC,GOOD",
       "AFTC,POOR",
       "ATSH,POOR",
@@ -865,7 +864,7 @@ class AppointmentMappersTest {
       "YYYY,NOT_APPLICABLE",
       "ZZZZ,NOT_APPLICABLE",
     )
-    fun `work quality is automatically determined by outcome code`(outcomeCode: String?, expected: NDAppointmentWorkQuality?) {
+    fun `work quality is automatically determined by outcome code`(outcomeCode: String, expected: NDAppointmentWorkQuality) {
       val createAppointmentDto = CreateAppointmentDto.valid().copy(contactOutcomeCode = outcomeCode)
       val updateAppointmentDto = UpdateAppointmentDto.valid().copy(contactOutcomeCode = outcomeCode)
 
@@ -878,7 +877,6 @@ class AppointmentMappersTest {
   inner class AppointmentCommandDtoBehaviour {
     @ParameterizedTest
     @CsvSource(
-      ",",
       "ATTC,GOOD",
       "AFTC,POOR",
       "ATSH,POOR",
@@ -889,7 +887,7 @@ class AppointmentMappersTest {
       "YYYY,NOT_APPLICABLE",
       "ZZZZ,NOT_APPLICABLE",
     )
-    fun `behaviour is automatically determined by outcome code`(outcomeCode: String?, expected: NDAppointmentBehaviour?) {
+    fun `behaviour is automatically determined by outcome code`(outcomeCode: String, expected: NDAppointmentBehaviour) {
       val createAppointmentDto = CreateAppointmentDto.valid().copy(contactOutcomeCode = outcomeCode)
       val updateAppointmentDto = UpdateAppointmentDto.valid().copy(contactOutcomeCode = outcomeCode)
 


### PR DESCRIPTION
In #716 and #727 compliance data was automatically computed from the appointment outcome. However, the work quality and behaviour information may still be needed as evidence for enforcement and judicial decision making processes.

This PR reverts the changes in those previous PRs with respect to the work quality and behaviour information, restoring the original behaviour of the API to match that of NDelius.