### PR TITLE
CPB-1113: Remove 'Failed to Comply with other Instruction' contact outcome from admin group

### DIFF
--- a/src/main/resources/db/migration/20260630101925__remove_failed_to_comply_with_other_instruction_from_admin_contact_outcomes_group.sql
+++ b/src/main/resources/db/migration/20260630101925__remove_failed_to_comply_with_other_instruction_from_admin_contact_outcomes_group.sql
@@ -1,0 +1,6 @@
+DELETE FROM contact_outcomes_groups
+WHERE contact_outcome_entity_id IN (
+    SELECT id
+    FROM contact_outcomes
+    WHERE name = 'Failed to Comply with other Instruction'
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/CommonReferencesIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/CommonReferencesIT.kt
@@ -186,7 +186,7 @@ class CommonReferencesIT : IntegrationTestBase() {
         .isOk
         .bodyAsObject<ContactOutcomesDto>()
 
-      assertThat(contactOutcomes.contactOutcomes).hasSize(10)
+      assertThat(contactOutcomes.contactOutcomes).hasSize(9)
     }
 
     @Test

--- a/src/test/resources/application-integrationtest.yml
+++ b/src/test/resources/application-integrationtest.yml
@@ -52,7 +52,7 @@ hmpps.sar:
     expected-render-result:
       path: /sar/expected-report.html
     attachments-expected: false
-    expected-flyway-schema-version: 20260629092029
+    expected-flyway-schema-version: 20260630101925
     expected-jpa-entity-schema:
       path: /sar/expected-jpa-schema.json
 


### PR DESCRIPTION
This contact outcome is no longer intended to be used within the Case Admin API, so should be removed.