### PR TITLE
CPB-1105: Update Incentive Scheme to account for course completions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionEventResolutionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionEventResolutionRepository.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.entity
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
@@ -12,4 +13,13 @@ interface EteCourseCompletionEventResolutionRepository : JpaRepository<EteCourse
     office: String,
     courseName: String,
   ): EteCourseCompletionEventResolutionEntity?
+
+  @Query(
+    value = """
+      SELECT r.deliusAppointmentId
+      FROM EteCourseCompletionEventResolutionEntity r
+      WHERE r.deliusAppointmentId IN (:appointmentIds)
+    """,
+  )
+  fun existsByDeliusAppointmentId(appointmentIds: List<Long>): List<Long>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/incentivescheme/internal/IncentiveSchemeEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/incentivescheme/internal/IncentiveSchemeEvent.kt
@@ -29,15 +29,5 @@ sealed interface IncentiveSchemeEvent {
     override val duration: Duration = inner.amount.negated()
   }
 
-  companion object {
-    fun fromAppointmentsAndAdjustments(
-      appointments: List<AppointmentSummaryDto>,
-      adjustments: List<AdjustmentDto>,
-    ): List<IncentiveSchemeEvent> {
-      val appointmentEvents = appointments.map { IncentiveSchemeAppointmentEvent(it) }
-      val adjustmentEvents = adjustments.map { IncentiveSchemeAdjustmentEvent(it) }
-
-      return (adjustmentEvents + appointmentEvents).sortedBy { it.timestamp }
-    }
-  }
+  companion object
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/incentivescheme/internal/IncentiveSchemeEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/incentivescheme/internal/IncentiveSchemeEvent.kt
@@ -21,6 +21,14 @@ sealed interface IncentiveSchemeEvent {
     override val duration: Duration = Duration.ofMinutes(inner.minutesCredited ?: 0)
   }
 
+  data class IncentiveSchemeCourseCompletionAppointmentEvent(private val inner: AppointmentSummaryDto) : IncentiveSchemeEvent {
+    override val name: String = "Course completion appointment ${inner.id}"
+    override val timestamp: OffsetDateTime = inner.date.atTime(inner.startTime).atZone(ZoneId.of("Europe/London")).toOffsetDateTime()
+    override val isDisqualifying: Boolean = false
+    override val isQualifying: Boolean = inner.hasOutcome()
+    override val duration: Duration = Duration.ofMinutes(inner.minutesCredited ?: 0)
+  }
+
   data class IncentiveSchemeAdjustmentEvent(private val inner: AdjustmentDto) : IncentiveSchemeEvent {
     override val name: String = "Adjustment ${inner.deliusId}"
     override val timestamp: OffsetDateTime = inner.date.atTime(23, 59, 59).atZone(ZoneId.of("Europe/London")).toOffsetDateTime()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/incentivescheme/internal/IncentiveSchemeEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/incentivescheme/internal/IncentiveSchemeEventService.kt
@@ -5,16 +5,22 @@ import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AdjustmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventResolutionRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeGroup
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.incentivescheme.internal.IncentiveSchemeEvent.IncentiveSchemeAdjustmentEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.incentivescheme.internal.IncentiveSchemeEvent.IncentiveSchemeAppointmentEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.incentivescheme.internal.IncentiveSchemeEvent.IncentiveSchemeCourseCompletionAppointmentEvent
 import java.time.LocalDate
 
 @Service
 class IncentiveSchemeEventService(
   private val appointmentService: AppointmentService,
   private val adjustmentService: AdjustmentService,
+  private val eteCourseCompletionEventResolutionRepository: EteCourseCompletionEventResolutionRepository,
+  private val projectTypeEntityRepository: ProjectTypeEntityRepository,
 ) {
   private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -26,8 +32,10 @@ class IncentiveSchemeEventService(
       pageable = Pageable.unpaged(),
     ).toList()
     val adjustments = adjustmentService.getAdjustments(crn = crn, eventNumber = deliusEventNumber)
+    val eteAppointmentIds = eteCourseCompletionEventResolutionRepository.existsByDeliusAppointmentId(appointments.map { it.id })
+    val eteProjectTypeCodes = projectTypeEntityRepository.findByProjectTypeGroupOrderByCodeAsc(ProjectTypeGroup.ETE).map { it.code }
 
-    val events = getEventsFromAppointmentsAndAdjustments(appointments, adjustments)
+    val events = getEvents(appointments, adjustments, eteAppointmentIds, eteProjectTypeCodes)
 
     logger.debug(
       "Found {} events for CRN {} and Delius event number {}:\n{}",
@@ -40,11 +48,19 @@ class IncentiveSchemeEventService(
     return events
   }
 
-  private fun getEventsFromAppointmentsAndAdjustments(
+  private fun getEvents(
     appointments: List<AppointmentSummaryDto>,
     adjustments: List<AdjustmentDto>,
+    eteAppointmentIds: List<Long>,
+    eteProjectTypeCodes: List<String>,
   ): List<IncentiveSchemeEvent> {
-    val appointmentEvents = appointments.map { IncentiveSchemeAppointmentEvent(it) }
+    val appointmentEvents = appointments.map {
+      if (eteAppointmentIds.contains(it.id) || eteProjectTypeCodes.contains(it.projectTypeCode)) {
+        IncentiveSchemeCourseCompletionAppointmentEvent(it)
+      } else {
+        IncentiveSchemeAppointmentEvent(it)
+      }
+    }
     val adjustmentEvents = adjustments.map { IncentiveSchemeAdjustmentEvent(it) }
 
     return (adjustmentEvents + appointmentEvents).sortedBy { it.timestamp }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/incentivescheme/internal/IncentiveSchemeEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/incentivescheme/internal/IncentiveSchemeEventService.kt
@@ -3,8 +3,12 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.service.incentivescheme
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AdjustmentDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentService
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.incentivescheme.internal.IncentiveSchemeEvent.IncentiveSchemeAdjustmentEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.incentivescheme.internal.IncentiveSchemeEvent.IncentiveSchemeAppointmentEvent
 import java.time.LocalDate
 
 @Service
@@ -23,7 +27,7 @@ class IncentiveSchemeEventService(
     ).toList()
     val adjustments = adjustmentService.getAdjustments(crn = crn, eventNumber = deliusEventNumber)
 
-    val events = IncentiveSchemeEvent.fromAppointmentsAndAdjustments(appointments, adjustments)
+    val events = getEventsFromAppointmentsAndAdjustments(appointments, adjustments)
 
     logger.debug(
       "Found {} events for CRN {} and Delius event number {}:\n{}",
@@ -34,5 +38,15 @@ class IncentiveSchemeEventService(
     )
 
     return events
+  }
+
+  private fun getEventsFromAppointmentsAndAdjustments(
+    appointments: List<AppointmentSummaryDto>,
+    adjustments: List<AdjustmentDto>,
+  ): List<IncentiveSchemeEvent> {
+    val appointmentEvents = appointments.map { IncentiveSchemeAppointmentEvent(it) }
+    val adjustmentEvents = adjustments.map { IncentiveSchemeAdjustmentEvent(it) }
+
+    return (adjustmentEvents + appointmentEvents).sortedBy { it.timestamp }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/incentivescheme/internal/IncentiveSchemeEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/incentivescheme/internal/IncentiveSchemeEventServiceTest.kt
@@ -11,11 +11,17 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AdjustmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventResolutionRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeGroup
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.valid
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AdjustmentService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.incentivescheme.internal.IncentiveSchemeEvent.IncentiveSchemeAdjustmentEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.incentivescheme.internal.IncentiveSchemeEvent.IncentiveSchemeAppointmentEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.incentivescheme.internal.IncentiveSchemeEvent.IncentiveSchemeCourseCompletionAppointmentEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.incentivescheme.internal.IncentiveSchemeEventService
 import java.time.LocalDate
 import java.time.LocalTime
@@ -27,6 +33,12 @@ class IncentiveSchemeEventServiceTest {
 
   @MockK
   private lateinit var adjustmentService: AdjustmentService
+
+  @MockK
+  private lateinit var eteCourseCompletionEventResolutionRepository: EteCourseCompletionEventResolutionRepository
+
+  @MockK
+  private lateinit var projectTypeEntityRepository: ProjectTypeEntityRepository
 
   @InjectMockKs
   private lateinit var incentiveSchemeEventService: IncentiveSchemeEventService
@@ -71,16 +83,20 @@ class IncentiveSchemeEventServiceTest {
 
     every { appointmentService.getAppointments(crn = "X123456", toDate = LocalDate.now(), eventNumber = "1", pageable = Pageable.unpaged()) } returns PageImpl(appointments)
     every { adjustmentService.getAdjustments(crn = "X123456", eventNumber = 1) } returns adjustments
+    every { eteCourseCompletionEventResolutionRepository.existsByDeliusAppointmentId(any()) } returns listOf(appointments[2].id)
+    every { projectTypeEntityRepository.findByProjectTypeGroupOrderByCodeAsc(ProjectTypeGroup.ETE) } returns listOf(
+      ProjectTypeEntity.valid().copy(projectTypeGroup = ProjectTypeGroup.ETE, code = appointments[3].projectTypeCode),
+    )
 
     val result = incentiveSchemeEventService.getEvents("X123456", 1)
 
     assertThat(result).hasSize(8)
-    assertThat(result[0]).isInstanceOf(IncentiveSchemeAppointmentEvent::class.java).extracting { it.name }.isEqualTo("Appointment ${appointments[3].id}")
+    assertThat(result[0]).isInstanceOf(IncentiveSchemeCourseCompletionAppointmentEvent::class.java).extracting { it.name }.isEqualTo("Course completion appointment ${appointments[3].id}")
     assertThat(result[1]).isInstanceOf(IncentiveSchemeAppointmentEvent::class.java).extracting { it.name }.isEqualTo("Appointment ${appointments[5].id}")
     assertThat(result[2]).isInstanceOf(IncentiveSchemeAppointmentEvent::class.java).extracting { it.name }.isEqualTo("Appointment ${appointments[4].id}")
     assertThat(result[3]).isInstanceOf(IncentiveSchemeAdjustmentEvent::class.java).extracting { it.name }.isEqualTo("Adjustment ${adjustments[1].deliusId}")
     assertThat(result[4]).isInstanceOf(IncentiveSchemeAdjustmentEvent::class.java).extracting { it.name }.isEqualTo("Adjustment ${adjustments[0].deliusId}")
-    assertThat(result[5]).isInstanceOf(IncentiveSchemeAppointmentEvent::class.java).extracting { it.name }.isEqualTo("Appointment ${appointments[2].id}")
+    assertThat(result[5]).isInstanceOf(IncentiveSchemeCourseCompletionAppointmentEvent::class.java).extracting { it.name }.isEqualTo("Course completion appointment ${appointments[2].id}")
     assertThat(result[6]).isInstanceOf(IncentiveSchemeAppointmentEvent::class.java).extracting { it.name }.isEqualTo("Appointment ${appointments[1].id}")
     assertThat(result[7]).isInstanceOf(IncentiveSchemeAppointmentEvent::class.java).extracting { it.name }.isEqualTo("Appointment ${appointments[0].id}")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/incentivescheme/internal/IncentiveSchemeEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/incentivescheme/internal/IncentiveSchemeEventTest.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.incentivescheme.internal
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AdjustmentDto
@@ -24,7 +24,7 @@ class IncentiveSchemeEventTest {
           AppointmentSummaryDto.valid().copy(date = LocalDate.of(2026, 6, 6), startTime = LocalTime.of(10, 0)),
         )
 
-        Assertions.assertThat(result.timestamp).isEqualTo(
+        assertThat(result.timestamp).isEqualTo(
           ZonedDateTime.of(2026, 6, 6, 10, 0, 0, 0, ZoneId.of("Europe/London")).toOffsetDateTime(),
         )
       }
@@ -38,7 +38,7 @@ class IncentiveSchemeEventTest {
           AppointmentSummaryDto.valid().copy(contactOutcome = ContactOutcomeDto.valid().copy(enforceable = true)),
         )
 
-        Assertions.assertThat(result.isDisqualifying).isTrue
+        assertThat(result.isDisqualifying).isTrue
       }
 
       @Test
@@ -47,7 +47,7 @@ class IncentiveSchemeEventTest {
           AppointmentSummaryDto.valid().copy(contactOutcome = ContactOutcomeDto.valid().copy(enforceable = false)),
         )
 
-        Assertions.assertThat(result.isDisqualifying).isFalse
+        assertThat(result.isDisqualifying).isFalse
       }
 
       @Test
@@ -56,7 +56,7 @@ class IncentiveSchemeEventTest {
           AppointmentSummaryDto.valid().copy(contactOutcome = null),
         )
 
-        Assertions.assertThat(result.isDisqualifying).isFalse
+        assertThat(result.isDisqualifying).isFalse
       }
     }
 
@@ -68,7 +68,7 @@ class IncentiveSchemeEventTest {
           AppointmentSummaryDto.valid().copy(contactOutcome = ContactOutcomeDto.valid()),
         )
 
-        Assertions.assertThat(result.isQualifying).isTrue
+        assertThat(result.isQualifying).isTrue
       }
 
       @Test
@@ -77,7 +77,7 @@ class IncentiveSchemeEventTest {
           AppointmentSummaryDto.valid().copy(contactOutcome = null),
         )
 
-        Assertions.assertThat(result.isQualifying).isFalse
+        assertThat(result.isQualifying).isFalse
       }
     }
 
@@ -89,7 +89,7 @@ class IncentiveSchemeEventTest {
           AppointmentSummaryDto.valid().copy(minutesCredited = 120),
         )
 
-        Assertions.assertThat(result.duration).isEqualTo(java.time.Duration.ofMinutes(120))
+        assertThat(result.duration).isEqualTo(java.time.Duration.ofMinutes(120))
       }
 
       @Test
@@ -98,7 +98,76 @@ class IncentiveSchemeEventTest {
           AppointmentSummaryDto.valid().copy(minutesCredited = null),
         )
 
-        Assertions.assertThat(result.duration).isEqualTo(java.time.Duration.ZERO)
+        assertThat(result.duration).isEqualTo(java.time.Duration.ZERO)
+      }
+    }
+  }
+
+  @Nested
+  inner class IncentiveSchemeCourseCompletionAppointmentEvent {
+    @Nested
+    inner class Timestamp {
+      @Test
+      fun `derived from appointment date and start time`() {
+        val result = IncentiveSchemeEvent.IncentiveSchemeCourseCompletionAppointmentEvent(
+          AppointmentSummaryDto.valid().copy(date = LocalDate.of(2026, 6, 6), startTime = LocalTime.of(10, 0)),
+        )
+
+        assertThat(result.timestamp).isEqualTo(
+          ZonedDateTime.of(2026, 6, 6, 10, 0, 0, 0, ZoneId.of("Europe/London")).toOffsetDateTime(),
+        )
+      }
+    }
+
+    @Nested
+    inner class IsDisqualifying {
+      @Test
+      fun `is always false`() {
+        val result = IncentiveSchemeEvent.IncentiveSchemeCourseCompletionAppointmentEvent(AppointmentSummaryDto.valid())
+
+        assertThat(result.isDisqualifying).isFalse
+      }
+    }
+
+    @Nested
+    inner class IsQualifying {
+      @Test
+      fun `is true when there is a contact outcome`() {
+        val result = IncentiveSchemeEvent.IncentiveSchemeCourseCompletionAppointmentEvent(
+          AppointmentSummaryDto.valid().copy(contactOutcome = ContactOutcomeDto.valid()),
+        )
+
+        assertThat(result.isQualifying).isTrue
+      }
+
+      @Test
+      fun `is false when there is no contact outcome`() {
+        val result = IncentiveSchemeEvent.IncentiveSchemeCourseCompletionAppointmentEvent(
+          AppointmentSummaryDto.valid().copy(contactOutcome = null),
+        )
+
+        assertThat(result.isQualifying).isFalse
+      }
+    }
+
+    @Nested
+    inner class Duration {
+      @Test
+      fun `is equal to the number of minutes credited when present`() {
+        val result = IncentiveSchemeEvent.IncentiveSchemeCourseCompletionAppointmentEvent(
+          AppointmentSummaryDto.valid().copy(minutesCredited = 120),
+        )
+
+        assertThat(result.duration).isEqualTo(java.time.Duration.ofMinutes(120))
+      }
+
+      @Test
+      fun `is zero when the number of minutes credit is not present`() {
+        val result = IncentiveSchemeEvent.IncentiveSchemeCourseCompletionAppointmentEvent(
+          AppointmentSummaryDto.valid().copy(minutesCredited = null),
+        )
+
+        assertThat(result.duration).isEqualTo(java.time.Duration.ZERO)
       }
     }
   }
@@ -113,7 +182,7 @@ class IncentiveSchemeEventTest {
           AdjustmentDto.valid().copy(date = LocalDate.of(2026, 6, 6)),
         )
 
-        Assertions.assertThat(result.timestamp)
+        assertThat(result.timestamp)
           .isEqualTo(ZonedDateTime.of(2026, 6, 6, 23, 59, 59, 0, ZoneId.of("Europe/London")).toOffsetDateTime())
       }
     }
@@ -124,7 +193,7 @@ class IncentiveSchemeEventTest {
       fun `is always false`() {
         val result = IncentiveSchemeEvent.IncentiveSchemeAdjustmentEvent(AdjustmentDto.valid())
 
-        Assertions.assertThat(result.isDisqualifying).isFalse
+        assertThat(result.isDisqualifying).isFalse
       }
     }
 
@@ -134,7 +203,7 @@ class IncentiveSchemeEventTest {
       fun `is always true`() {
         val result = IncentiveSchemeEvent.IncentiveSchemeAdjustmentEvent(AdjustmentDto.valid())
 
-        Assertions.assertThat(result.isQualifying).isTrue
+        assertThat(result.isQualifying).isTrue
       }
     }
 
@@ -148,7 +217,7 @@ class IncentiveSchemeEventTest {
         )
 
         // A positive credit of 20 minutes
-        Assertions.assertThat(result.duration).isEqualTo(java.time.Duration.ofMinutes(20))
+        assertThat(result.duration).isEqualTo(java.time.Duration.ofMinutes(20))
       }
     }
   }


### PR DESCRIPTION
Currently, all appointment events with an enforceable outcome are disqualifying in the Incentive Scheme. However, appointments representing course completions should always be included, regardless of outcome.

This PR implements this behaviour by introducing a new type of event - `IncentiveSchemeCourseCompletionAppointmentEvent` - which is never disqualifying, but otherwise acts like an appointment event.

When building an event for an appointment, there are two ways to check if an appointment represents a course completion:
- the `course_completion_resolutions` table has a row that has that appointment's ID as its `deliusAppointmentId`.
- the `project_types` table has a row that has a `group` of `"ETE"` and that appointment's project type as its `projectTypeCode`.

If either check succeeds, then the appointment is for a course completion, and so the new event type is used. Otherwise, the existing behaviour is used.