### PR TITLE
CPB-1062: Adds automatic project resolution for Community Campus course completion draft resolutions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/CourseCompletionAutoResolutionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/CourseCompletionAutoResolutionService.kt
@@ -16,6 +16,7 @@ import java.util.UUID
 class CourseCompletionAutoResolutionService(
   private val personSearchClient: ProbationOffenderSearchClient,
   private val officeUpwTeamMappingRepository: OfficeUpwTeamMappingRepository,
+  private val courseCompletionProjectResolutionService: CourseCompletionProjectResolutionService,
   private val draftResolutionRepository: EteCourseCompletionDraftResolutionRepository,
 ) {
   private companion object {
@@ -27,6 +28,7 @@ class CourseCompletionAutoResolutionService(
   fun resolveAndPersistDraft(event: EteCourseCompletionEventEntity) {
     val crn = searchForCrn(event)
     val teamCode = resolveTeamCode(event)
+    val projectCode = teamCode?.let { resolveProjectCode(event, it) }
 
     draftResolutionRepository.save(
       EteCourseCompletionDraftResolutionEntity(
@@ -34,6 +36,7 @@ class CourseCompletionAutoResolutionService(
         eteCourseCompletionEvent = event,
         crn = crn,
         teamCode = teamCode,
+        projectCode = projectCode,
       ),
     )
   }
@@ -73,5 +76,13 @@ class CourseCompletionAutoResolutionService(
         else -> log.debug("No UPW team mapping for event {}", event.id)
       }
     }
+  }
+
+  @Suppress("TooGenericExceptionCaught")
+  private fun resolveProjectCode(event: EteCourseCompletionEventEntity, teamCode: String): String? = try {
+    courseCompletionProjectResolutionService.resolveProjectCode(event, teamCode)
+  } catch (e: Exception) {
+    log.warn("Project auto-resolution failed for event {}; project will be left blank", event.id, e)
+    null
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/CourseCompletionProjectResolutionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/CourseCompletionProjectResolutionService.kt
@@ -17,56 +17,62 @@ class CourseCompletionProjectResolutionService(
     val projects = getEteProjects(event.pdu.providerCode, teamCode)
     if (projects.isEmpty()) return null
 
-    return when (event.region) {
-      "East Midlands" -> projects.matchCourse(event) ?: when {
-        event.isMoodle() -> projects.matchProjectName("ET5 ETE HMPPS portal")
-        event.isAlison() -> projects.matchProjectName("Alison.com")
-        else -> null
-      }
+    return projects.resolveRegionalProject(event, teamCode)?.code
+  }
 
-      "East of England" -> projects.matchCourse(event) ?: when {
-        event.isAlison() -> projects.matchProjectName("ETE Alison.com")
-        else -> null
-      }
+  private fun List<NDProject>.resolveRegionalProject(event: EteCourseCompletionEventEntity, teamCode: String) = when (event.region) {
+    "East Midlands" -> resolveEastMidlandsProject(event)
+    "East of England" -> resolveEastOfEnglandProject(event)
+    "Greater Manchester" -> resolveGreaterManchesterProject(event)
+    "Kent, Surrey and Sussex" -> matchProjectName(event.courseName)
+    "London" -> matchProjectName("20% ETE Standalone HMPPS Portal")
+    "North East" -> resolveNorthEastProject(event)
+    "North West" -> resolveNorthWestProject(teamCode, event.office)
+    "South Central" -> resolveSouthCentralProject(event)
+    "South West" -> resolveSouthWestProject(event)
+    "Wales" -> resolveWalesProject(event)
+    "West Midlands" -> matchProjectName("ET5 ETE HMPPS Portal")
+    "Yorks & Humber" -> resolveYorksAndHumberProject(event)
+    else -> null
+  }
 
-      "Greater Manchester" -> projects.matchCourse(event) ?: when {
-        event.isAlison() -> projects.matchProjectName("Alison Community Campus")
-        else -> null
-      }
+  private fun List<NDProject>.resolveEastMidlandsProject(event: EteCourseCompletionEventEntity) = matchProjectName(event.courseName) ?: when {
+    event.isMoodle() -> matchProjectName("ET5 ETE HMPPS portal")
+    event.isAlison() -> matchProjectName("Alison.com")
+    else -> null
+  }
 
-      "Kent, Surrey and Sussex" -> projects.matchCourse(event)
-      "London" -> projects.matchProjectName("20% ETE Standalone HMPPS Portal")
-      "North East" -> projects.matchCourse(event) ?: when {
-        event.isAlison() -> projects.matchProjectName("ETE HMPPS Portal Alison.com")
-        else -> null
-      }
+  private fun List<NDProject>.resolveEastOfEnglandProject(event: EteCourseCompletionEventEntity) = matchProjectName(event.courseName) ?: when {
+    event.isAlison() -> matchProjectName("ETE Alison.com")
+    else -> null
+  }
 
-      "North West" -> projects.resolveNorthWestProject(teamCode, event.office)
-      "South Central" -> projects.matchCourse(event)
-        ?: projects.matchProjectName("ET5 ETE HMPSS Portal")
-        ?: projects.matchProjectName("ET5 ETE HMPPS Portal")
+  private fun List<NDProject>.resolveGreaterManchesterProject(event: EteCourseCompletionEventEntity) = matchProjectName(event.courseName) ?: when {
+    event.isAlison() -> matchProjectName("Alison Community Campus")
+    else -> null
+  }
 
-      "South West" -> projects.matchCourse(event) ?: when {
-        event.isAlison() -> projects.matchProjectName("Alison")
-        else -> null
-      }
+  private fun List<NDProject>.resolveNorthEastProject(event: EteCourseCompletionEventEntity) = matchProjectName(event.courseName) ?: when {
+    event.isAlison() -> matchProjectName("ETE HMPPS Portal Alison.com")
+    else -> null
+  }
 
-      "Wales" -> when {
-        event.isMandatory() -> projects.matchProjectName("Mandatory ETE")
-        else -> projects.matchProjectName("ETE E-Learning")
-      }
+  private fun List<NDProject>.resolveSouthCentralProject(event: EteCourseCompletionEventEntity) = matchProjectName(event.courseName) ?: matchProjectName("ET5 ETE HMPPS Portal")
 
-      "West Midlands" -> projects.matchProjectName("ET5 ETE HMPPS Portal")
-      "Yorks & Humber" -> when {
-        event.isYorksAndHumberMandatory() -> projects.matchCourse(event)
-          ?: projects.matchProjectName("mandatory")
+  private fun List<NDProject>.resolveSouthWestProject(event: EteCourseCompletionEventEntity) = matchProjectName(event.courseName) ?: when {
+    event.isAlison() -> matchProjectName("Alison")
+    else -> null
+  }
 
-        event.isAlison() -> projects.matchProjectName("ETE Alison.com Course")
-        else -> projects.matchProjectName("ET5 ETE HMPPS Portal Other")
-      }
+  private fun List<NDProject>.resolveWalesProject(event: EteCourseCompletionEventEntity) = when {
+    event.isMandatory() -> matchProjectName("Mandatory ETE")
+    else -> matchProjectName("ETE E-Learning")
+  }
 
-      else -> null
-    }?.code
+  private fun List<NDProject>.resolveYorksAndHumberProject(event: EteCourseCompletionEventEntity) = when {
+    event.isYorksAndHumberMandatory() -> matchProjectName(event.courseName) ?: matchProjectName("mandatory")
+    event.isAlison() -> matchProjectName("ETE Alison.com Course")
+    else -> matchProjectName("ET5 ETE HMPPS Portal Other")
   }
 
   private fun getEteProjects(providerCode: String, teamCode: String): List<NDProject> {
@@ -82,59 +88,29 @@ class CourseCompletionProjectResolutionService(
     ).content.map { it.project }
   }
 
-  private fun List<NDProject>.matchCourse(event: EteCourseCompletionEventEntity): NDProject? = matchProjectName(event.courseName)
-
   private fun List<NDProject>.matchProjectName(name: String): NDProject? {
     val target = name.normalizedWords()
     return closestMatch(filter { it.name.normalizedWords().contains(target) })
-      ?: closestMatch(filter { it.name.normalizedWordSet().containsAll(target.significantWords()) })
+      ?: closestMatch(filter { it.name.significantWords().containsAll(target.significantWords()) })
   }
 
   private fun closestMatch(projects: List<NDProject>) = projects.minWithOrNull(compareBy<NDProject> { it.name.normalizedWords().length }.thenBy { it.name })
 
   private fun List<NDProject>.resolveNorthWestProject(teamCode: String, office: String): NDProject? {
     val projectName = when (teamCode) {
-      "N51CBH" -> "Preston ETE"
-      "N51CAH" -> "Barrow ETE"
-      "N51CAJ" -> "Blackburn ETE"
-      "N51CAO" -> "Burnley ETE"
-      "N51CAP" -> "Carlisle ETE"
-      "N51LNP" -> "ETE Community Portal"
-      "N51CWP" -> if (office.equals(
-          "Winsford Office",
-          ignoreCase = true,
-        )
-      ) {
+      "N51CWP" -> if (office.lowercase() == "winsford office") {
         "ETE Community Portal Winsford"
       } else {
         "ETE Community Portal Ellesmere Port/Chester"
       }
-
-      "N51CAV" -> "Chorley ETE"
-      "N51CAK" -> "Blackpool ETE"
-      "N51CEP" -> if (office.equals(
-          "Crewe Office",
-          ignoreCase = true,
-        )
-      ) {
+      "N51CEP" -> if (office.lowercase() == "crewe office") {
         "ETE Community Portal Crewe"
       } else {
         "ETE Community Portal Macclesfield"
       }
-
-      "N51CAB" -> "Accrington ETE"
-      "N51CBB" -> "Kendal ETE"
-      "N51CBD" -> "Lancaster ETE"
-      "N51KCP" -> "ETE Community Portal"
-      "N51HWP" -> "ETE Community Portal"
-      "N51CBM" -> "Skelmersdale ETE"
-      "N51SCP" -> "ETE Community Portal"
-      "N51WCP" -> "ETE Community Portal"
-      "N51CBP" -> "Workington ETE"
-      else -> null
+      else -> "ETE"
     }
-
-    return projectName?.let { matchProjectName(it) }
+    return matchProjectName(projectName)
   }
 
   private fun String.normalizedWords() = lowercase()
@@ -153,13 +129,12 @@ class CourseCompletionProjectResolutionService(
     .filter { it.isNotBlank() && it !in setOf("a", "and", "in", "of", "the", "to") }
     .toSet()
 
-  private fun String.normalizedWordSet() = significantWords()
-
   private fun EteCourseCompletionEventEntity.isMoodle() = this.provider.lowercase() == "moodle"
 
   private fun EteCourseCompletionEventEntity.isAlison() = this.provider.lowercase() == "alison"
 
-  private fun EteCourseCompletionEventEntity.isMandatory() = this.courseType.lowercase() == "mandatory" || this.courseName.normalizedWords() in mandatoryCourseNames
+  private fun EteCourseCompletionEventEntity.isMandatory() = this.courseType.lowercase() == "mandatory" ||
+    this.courseName.normalizedWords() in mandatoryCourseNames
 
   private fun EteCourseCompletionEventEntity.isYorksAndHumberMandatory() = this.courseType.lowercase() == "mandatory" ||
     this.courseName.normalizedWords() in mandatoryCourseNames ||

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/CourseCompletionProjectResolutionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/CourseCompletionProjectResolutionService.kt
@@ -82,8 +82,7 @@ class CourseCompletionProjectResolutionService(
     ).content.map { it.project }
   }
 
-  private fun List<NDProject>.matchCourse(event: EteCourseCompletionEventEntity): NDProject? =
-    matchProjectName(event.courseName)
+  private fun List<NDProject>.matchCourse(event: EteCourseCompletionEventEntity): NDProject? = matchProjectName(event.courseName)
 
   private fun List<NDProject>.matchProjectName(name: String): NDProject? {
     val target = name.normalizedWords()
@@ -91,8 +90,7 @@ class CourseCompletionProjectResolutionService(
       ?: closestMatch(filter { it.name.normalizedWordSet().containsAll(target.significantWords()) })
   }
 
-  private fun closestMatch(projects: List<NDProject>) =
-    projects.minWithOrNull(compareBy<NDProject> { it.name.normalizedWords().length }.thenBy { it.name })
+  private fun closestMatch(projects: List<NDProject>) = projects.minWithOrNull(compareBy<NDProject> { it.name.normalizedWords().length }.thenBy { it.name })
 
   private fun List<NDProject>.resolveNorthWestProject(teamCode: String, office: String): NDProject? {
     val projectName = when (teamCode) {
@@ -106,7 +104,11 @@ class CourseCompletionProjectResolutionService(
           "Winsford Office",
           ignoreCase = true,
         )
-      ) "ETE Community Portal Winsford" else "ETE Community Portal Ellesmere Port/Chester"
+      ) {
+        "ETE Community Portal Winsford"
+      } else {
+        "ETE Community Portal Ellesmere Port/Chester"
+      }
 
       "N51CAV" -> "Chorley ETE"
       "N51CAK" -> "Blackpool ETE"
@@ -114,7 +116,11 @@ class CourseCompletionProjectResolutionService(
           "Crewe Office",
           ignoreCase = true,
         )
-      ) "ETE Community Portal Crewe" else "ETE Community Portal Macclesfield"
+      ) {
+        "ETE Community Portal Crewe"
+      } else {
+        "ETE Community Portal Macclesfield"
+      }
 
       "N51CAB" -> "Accrington ETE"
       "N51CBB" -> "Kendal ETE"
@@ -153,13 +159,11 @@ class CourseCompletionProjectResolutionService(
 
   private fun EteCourseCompletionEventEntity.isAlison() = this.provider.lowercase() == "alison"
 
-  private fun EteCourseCompletionEventEntity.isMandatory() =
-    this.courseType.lowercase() == "mandatory" || this.courseName.normalizedWords() in mandatoryCourseNames
+  private fun EteCourseCompletionEventEntity.isMandatory() = this.courseType.lowercase() == "mandatory" || this.courseName.normalizedWords() in mandatoryCourseNames
 
-  private fun EteCourseCompletionEventEntity.isYorksAndHumberMandatory() =
-    this.courseType.lowercase() == "mandatory" ||
-      this.courseName.normalizedWords() in mandatoryCourseNames ||
-      (this.courseName.normalizedWords() == "employability" && this.courseType.normalizedWords().contains("unemployed"))
+  private fun EteCourseCompletionEventEntity.isYorksAndHumberMandatory() = this.courseType.lowercase() == "mandatory" ||
+    this.courseName.normalizedWords() in mandatoryCourseNames ||
+    (this.courseName.normalizedWords() == "employability" && this.courseType.normalizedWords().contains("unemployed"))
 
   companion object {
     private val mandatoryCourseNames = setOf(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/CourseCompletionProjectResolutionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/CourseCompletionProjectResolutionService.kt
@@ -1,0 +1,171 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProject
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeGroup
+
+@Service
+class CourseCompletionProjectResolutionService(
+  private val communityPaybackAndDeliusClient: CommunityPaybackAndDeliusClient,
+  private val projectTypeEntityRepository: ProjectTypeEntityRepository,
+) {
+  fun resolveProjectCode(event: EteCourseCompletionEventEntity, teamCode: String): String? {
+    val projects = getEteProjects(event.pdu.providerCode, teamCode)
+    if (projects.isEmpty()) return null
+
+    return when (event.region) {
+      "East Midlands" -> projects.matchCourse(event) ?: when {
+        event.isMoodle() -> projects.matchProjectName("ET5 ETE HMPPS portal")
+        event.isAlison() -> projects.matchProjectName("Alison.com")
+        else -> null
+      }
+
+      "East of England" -> projects.matchCourse(event) ?: when {
+        event.isAlison() -> projects.matchProjectName("ETE Alison.com")
+        else -> null
+      }
+
+      "Greater Manchester" -> projects.matchCourse(event) ?: when {
+        event.isAlison() -> projects.matchProjectName("Alison Community Campus")
+        else -> null
+      }
+
+      "Kent, Surrey and Sussex" -> projects.matchCourse(event)
+      "London" -> projects.matchProjectName("20% ETE Standalone HMPPS Portal")
+      "North East" -> projects.matchCourse(event) ?: when {
+        event.isAlison() -> projects.matchProjectName("ETE HMPPS Portal Alison.com")
+        else -> null
+      }
+
+      "North West" -> projects.resolveNorthWestProject(teamCode, event.office)
+      "South Central" -> projects.matchCourse(event)
+        ?: projects.matchProjectName("ET5 ETE HMPSS Portal")
+        ?: projects.matchProjectName("ET5 ETE HMPPS Portal")
+
+      "South West" -> projects.matchCourse(event) ?: when {
+        event.isAlison() -> projects.matchProjectName("Alison")
+        else -> null
+      }
+
+      "Wales" -> when {
+        event.isMandatory() -> projects.matchProjectName("Mandatory ETE")
+        else -> projects.matchProjectName("ETE E-Learning")
+      }
+
+      "West Midlands" -> projects.matchProjectName("ET5 ETE HMPPS Portal")
+      "Yorks & Humber" -> when {
+        event.isYorksAndHumberMandatory() -> projects.matchCourse(event)
+          ?: projects.matchProjectName("mandatory")
+
+        event.isAlison() -> projects.matchProjectName("ETE Alison.com Course")
+        else -> projects.matchProjectName("ET5 ETE HMPPS Portal Other")
+      }
+
+      else -> null
+    }?.code
+  }
+
+  private fun getEteProjects(providerCode: String, teamCode: String): List<NDProject> {
+    val eteProjectTypeCodes =
+      projectTypeEntityRepository.findByProjectTypeGroupOrderByCodeAsc(ProjectTypeGroup.fromDto(ProjectTypeGroupDto.ETE))
+        .map { it.code }
+
+    return communityPaybackAndDeliusClient.getProjects(
+      providerCode = providerCode,
+      teamCode = teamCode,
+      typeCode = eteProjectTypeCodes,
+      params = mapOf("page" to "0", "size" to "500", "sort" to "name,asc"),
+    ).content.map { it.project }
+  }
+
+  private fun List<NDProject>.matchCourse(event: EteCourseCompletionEventEntity): NDProject? =
+    matchProjectName(event.courseName)
+
+  private fun List<NDProject>.matchProjectName(name: String): NDProject? {
+    val target = name.normalizedWords()
+    return closestMatch(filter { it.name.normalizedWords().contains(target) })
+      ?: closestMatch(filter { it.name.normalizedWordSet().containsAll(target.significantWords()) })
+  }
+
+  private fun closestMatch(projects: List<NDProject>) =
+    projects.minWithOrNull(compareBy<NDProject> { it.name.normalizedWords().length }.thenBy { it.name })
+
+  private fun List<NDProject>.resolveNorthWestProject(teamCode: String, office: String): NDProject? {
+    val projectName = when (teamCode) {
+      "N51CBH" -> "Preston ETE"
+      "N51CAH" -> "Barrow ETE"
+      "N51CAJ" -> "Blackburn ETE"
+      "N51CAO" -> "Burnley ETE"
+      "N51CAP" -> "Carlisle ETE"
+      "N51LNP" -> "ETE Community Portal"
+      "N51CWP" -> if (office.equals(
+          "Winsford Office",
+          ignoreCase = true,
+        )
+      ) "ETE Community Portal Winsford" else "ETE Community Portal Ellesmere Port/Chester"
+
+      "N51CAV" -> "Chorley ETE"
+      "N51CAK" -> "Blackpool ETE"
+      "N51CEP" -> if (office.equals(
+          "Crewe Office",
+          ignoreCase = true,
+        )
+      ) "ETE Community Portal Crewe" else "ETE Community Portal Macclesfield"
+
+      "N51CAB" -> "Accrington ETE"
+      "N51CBB" -> "Kendal ETE"
+      "N51CBD" -> "Lancaster ETE"
+      "N51KCP" -> "ETE Community Portal"
+      "N51HWP" -> "ETE Community Portal"
+      "N51CBM" -> "Skelmersdale ETE"
+      "N51SCP" -> "ETE Community Portal"
+      "N51WCP" -> "ETE Community Portal"
+      "N51CBP" -> "Workington ETE"
+      else -> null
+    }
+
+    return projectName?.let { matchProjectName(it) }
+  }
+
+  private fun String.normalizedWords() = lowercase()
+    .replace("&", " and ")
+    .replace(Regex("[^a-z0-9]+"), " ")
+    .replace(Regex("\\b(introduction|intro)\\b"), "")
+    .replace(Regex("\\bcustomer services\\b"), "customer service")
+    .replace(Regex("\\bindustrial and commercial cleaning\\b"), "industrial cleaning")
+    .replace(Regex("\\bgardening\\b"), "garden")
+    .replace(Regex("\\bit\\b"), "")
+    .trim()
+    .replace(Regex("\\s+"), " ")
+
+  private fun String.significantWords() = normalizedWords()
+    .split(" ")
+    .filter { it.isNotBlank() && it !in setOf("a", "and", "in", "of", "the", "to") }
+    .toSet()
+
+  private fun String.normalizedWordSet() = significantWords()
+
+  private fun EteCourseCompletionEventEntity.isMoodle() = this.provider.lowercase() == "moodle"
+
+  private fun EteCourseCompletionEventEntity.isAlison() = this.provider.lowercase() == "alison"
+
+  private fun EteCourseCompletionEventEntity.isMandatory() =
+    this.courseType.lowercase() == "mandatory" || this.courseName.normalizedWords() in mandatoryCourseNames
+
+  private fun EteCourseCompletionEventEntity.isYorksAndHumberMandatory() =
+    this.courseType.lowercase() == "mandatory" ||
+      this.courseName.normalizedWords() in mandatoryCourseNames ||
+      (this.courseName.normalizedWords() == "employability" && this.courseType.normalizedWords().contains("unemployed"))
+
+  companion object {
+    private val mandatoryCourseNames = setOf(
+      "health and safety",
+      "manual handling",
+      "first aid",
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/EducationCourseCompletionListenerIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/EducationCourseCompletionListenerIT.kt
@@ -8,13 +8,17 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 import tools.jackson.databind.json.JsonMapper
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProject
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProjectOutcomeStats
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.CommunityCampusPduEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionDraftResolutionRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.OfficeUpwTeamMappingEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.OfficeUpwTeamMappingRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.listener.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.util.DatabasePurgeUtils
+import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.wiremock.CommunityPaybackAndDeliusMockServer
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.wiremock.ProbationOffenderSearchMockServer
 import uk.gov.justice.digital.hmpps.communitypaybackapi.listener.EducationCourseCompletionMessage
 import uk.gov.justice.digital.hmpps.communitypaybackapi.listener.EducationCourseMessageAttributes
@@ -110,7 +114,7 @@ class EducationCourseCompletionListenerIT : IntegrationTestBase() {
     fun `team code is populated in draft resolution when office maps to a UPW team`() {
       ProbationOffenderSearchMockServer.stubNoMatches()
 
-      val pdu = communityCampusPduEntityRepository.findAll().minByOrNull { it.name }!!
+      val pdu = communityCampusPduEntityRepository.findByName("Hertfordshire")!!
       val office = "St Albans ${UUID.randomUUID()}"
       officeUpwTeamMappingRepository.save(
         OfficeUpwTeamMappingEntity(
@@ -120,12 +124,28 @@ class EducationCourseCompletionListenerIT : IntegrationTestBase() {
           teamCode = "N56ST",
         ),
       )
+      CommunityPaybackAndDeliusMockServer.setupGetProjectsResponse(
+        providerCode = pdu.providerCode,
+        teamCode = "N56ST",
+        projectTypeCodes = listOf("ET1", "ET3", "ET5", "UP06"),
+        response = listOf(
+          NDProjectOutcomeStats.valid().copy(
+            project = NDProject.valid(ctx).copy(
+              name = "ETE Portal - Health & Safety in Construction",
+              code = "PROJECT1",
+            ),
+          ),
+        ),
+        pageSize = 500,
+      )
 
       sendMessage(
         EducationCourseCompletionMessage.valid(ctx).copy(
           messageAttributes = EducationCourseMessageAttributes.valid(ctx).copy(
+            region = "East of England",
             pdu = pdu.name,
             office = office,
+            courseName = "Health and Safety in Construction",
           ),
         ),
       )
@@ -137,7 +157,7 @@ class EducationCourseCompletionListenerIT : IntegrationTestBase() {
       val draft = eteCourseCompletionDraftResolutionRepository.findAll().first()
       assertThat(draft.crn).isNull()
       assertThat(draft.teamCode).isEqualTo("N56ST")
-      assertThat(draft.projectCode).isNull()
+      assertThat(draft.projectCode).isEqualTo("PROJECT1")
       assertThat(draft.appointmentIdToUpdate).isNull()
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/CourseCompletionAutoResolutionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/CourseCompletionAutoResolutionServiceTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.OfficeUpwTeamMapp
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.OfficeUpwTeamMappingRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.CourseCompletionAutoResolutionService
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.CourseCompletionProjectResolutionService
 import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
@@ -33,6 +34,9 @@ class CourseCompletionAutoResolutionServiceTest {
   lateinit var officeUpwTeamMappingRepository: OfficeUpwTeamMappingRepository
 
   @RelaxedMockK
+  lateinit var courseCompletionProjectResolutionService: CourseCompletionProjectResolutionService
+
+  @RelaxedMockK
   lateinit var draftResolutionRepository: EteCourseCompletionDraftResolutionRepository
 
   private lateinit var service: CourseCompletionAutoResolutionService
@@ -42,6 +46,7 @@ class CourseCompletionAutoResolutionServiceTest {
     service = CourseCompletionAutoResolutionService(
       personSearchClient,
       officeUpwTeamMappingRepository,
+      courseCompletionProjectResolutionService,
       draftResolutionRepository,
     )
   }
@@ -139,6 +144,52 @@ class CourseCompletionAutoResolutionServiceTest {
     }
 
     @Test
+    fun `persists draft with project code when team and project are resolved`() {
+      val event = EteCourseCompletionEventEntity.valid().copy(office = "St Albans")
+      every { personSearchClient.searchPerson(any()) } returns emptyList()
+      every {
+        officeUpwTeamMappingRepository.findByPduAndOffice(event.pdu, "St Albans")
+      } returns OfficeUpwTeamMappingEntity(
+        id = UUID.randomUUID(),
+        pdu = event.pdu,
+        office = "St Albans",
+        teamCode = "N56ST",
+      )
+      every { courseCompletionProjectResolutionService.resolveProjectCode(event, "N56ST") } returns "PROJECT1"
+
+      val saved = slot<EteCourseCompletionDraftResolutionEntity>()
+      every { draftResolutionRepository.save(capture(saved)) } answers { firstArg() }
+
+      service.resolveAndPersistDraft(event)
+
+      assertThat(saved.captured.teamCode).isEqualTo("N56ST")
+      assertThat(saved.captured.projectCode).isEqualTo("PROJECT1")
+    }
+
+    @Test
+    fun `persists draft with team code and null project code when project resolution fails`() {
+      val event = EteCourseCompletionEventEntity.valid().copy(office = "St Albans")
+      every { personSearchClient.searchPerson(any()) } returns emptyList()
+      every {
+        officeUpwTeamMappingRepository.findByPduAndOffice(event.pdu, "St Albans")
+      } returns OfficeUpwTeamMappingEntity(
+        id = UUID.randomUUID(),
+        pdu = event.pdu,
+        office = "St Albans",
+        teamCode = "N56ST",
+      )
+      every { courseCompletionProjectResolutionService.resolveProjectCode(event, "N56ST") } throws RuntimeException("Project lookup failed")
+
+      val saved = slot<EteCourseCompletionDraftResolutionEntity>()
+      every { draftResolutionRepository.save(capture(saved)) } answers { firstArg() }
+
+      service.resolveAndPersistDraft(event)
+
+      assertThat(saved.captured.teamCode).isEqualTo("N56ST")
+      assertThat(saved.captured.projectCode).isNull()
+    }
+
+    @Test
     fun `persists draft with null team code when office has no mapping`() {
       val event = EteCourseCompletionEventEntity.valid().copy(office = "Watford")
       every { personSearchClient.searchPerson(any()) } returns emptyList()
@@ -152,6 +203,7 @@ class CourseCompletionAutoResolutionServiceTest {
       service.resolveAndPersistDraft(event)
 
       assertThat(saved.captured.teamCode).isNull()
+      verify(exactly = 0) { courseCompletionProjectResolutionService.resolveProjectCode(any(), any()) }
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/CourseCompletionProjectResolutionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/CourseCompletionProjectResolutionServiceTest.kt
@@ -204,16 +204,6 @@ class CourseCompletionProjectResolutionServiceTest {
       assertThat(result).isEqualTo(projectCodeFor(expectedProjectName))
     }
 
-    @Test
-    fun `uses South Central portal fallback when course project is not found`() {
-      val event = event(region = "South Central", provider = "Moodle", courseName = "Introduction to Supervision")
-      stubProjects(*projectsFor(southCentral))
-
-      val result = service.resolveProjectCode(event, "TEAM1")
-
-      assertThat(result).isEqualTo(projectCodeFor("ET5 ETE – HMPPS portal"))
-    }
-
     @ParameterizedTest(name = "South West course {0} resolves to {1}")
     @MethodSource("uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.CourseCompletionProjectResolutionServiceTest#southWestCourseMappings")
     fun `resolves South West course projects`(
@@ -259,11 +249,19 @@ class CourseCompletionProjectResolutionServiceTest {
       expectedProjectName: String,
     ) {
       val event = event(region = "North West", office = office)
-      stubProjects(*northWestProjects())
+      stubProjects(project(expectedProjectName, projectCodeFor(expectedProjectName)))
 
       val result = service.resolveProjectCode(event, teamCode)
 
       assertThat(result).isEqualTo(projectCodeFor(expectedProjectName))
+      verify {
+        communityPaybackAndDeliusClient.getProjects(
+          providerCode = event.pdu.providerCode,
+          teamCode = teamCode,
+          typeCode = listOf("ET5", "UP06"),
+          params = mapOf("page" to "0", "size" to "500", "sort" to "name,asc"),
+        )
+      }
     }
 
     @ParameterizedTest(name = "Wales course {0} with type {1} resolves to {2}")
@@ -328,12 +326,6 @@ class CourseCompletionProjectResolutionServiceTest {
   private fun project(name: String, code: String) = NDProject.valid().copy(name = name, code = code)
 
   private fun eastMidlandsProjects() = projectsFor(eastMidlands)
-
-  private fun northWestProjects() = northWest
-    .map { it.projectName }
-    .distinct()
-    .map { project(it, projectCodeFor(it)) }
-    .toTypedArray()
 
   private fun projectsFor(courseToProjects: List<CourseToProject>) = courseToProjects
     .map { it.projectName }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/CourseCompletionProjectResolutionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/CourseCompletionProjectResolutionServiceTest.kt
@@ -1,0 +1,613 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service
+
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProject
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProjectOutcomeStats
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeGroup
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.CourseCompletionProjectResolutionService
+import java.util.stream.Stream
+
+@ExtendWith(MockKExtension::class)
+class CourseCompletionProjectResolutionServiceTest {
+
+  @RelaxedMockK
+  lateinit var communityPaybackAndDeliusClient: CommunityPaybackAndDeliusClient
+
+  @RelaxedMockK
+  lateinit var projectTypeEntityRepository: ProjectTypeEntityRepository
+
+  private lateinit var service: CourseCompletionProjectResolutionService
+
+  @BeforeEach
+  fun setUp() {
+    service = CourseCompletionProjectResolutionService(
+      communityPaybackAndDeliusClient,
+      projectTypeEntityRepository,
+    )
+
+    every { projectTypeEntityRepository.findByProjectTypeGroupOrderByCodeAsc(ProjectTypeGroup.ETE) } returns listOf(
+      ProjectTypeEntity.valid().copy(code = "ET5"),
+      ProjectTypeEntity.valid().copy(code = "UP06"),
+    )
+  }
+
+  @Nested
+  inner class ResolveProjectCode {
+
+    @Test
+    fun `gets ETE projects for the resolved UPW team`() {
+      val event = event(region = "East Midlands", courseName = "Painting and Decorating")
+      stubProjects(project("ETE - Painting & Decorating", "PROJ1"))
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo("PROJ1")
+      verify {
+        communityPaybackAndDeliusClient.getProjects(
+          providerCode = event.pdu.providerCode,
+          teamCode = "TEAM1",
+          typeCode = listOf("ET5", "UP06"),
+          params = mapOf("page" to "0", "size" to "500", "sort" to "name,asc"),
+        )
+      }
+    }
+
+    @Test
+    fun `matches project name to course name flexibly`() {
+      val event = event(region = "East of England", courseName = "Health and Safety in Construction")
+      stubProjects(project("ETE Portal - Health & Safety in Construction", "MATCH"))
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo("MATCH")
+    }
+
+    @ParameterizedTest(name = "East Midlands course {0} resolves to {1}")
+    @MethodSource("uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.CourseCompletionProjectResolutionServiceTest#eastMidlandsCourseMappings")
+    fun `resolves East Midlands course projects and Moodle fallback`(
+      courseName: String,
+      expectedProjectName: String,
+    ) {
+      val event = event(region = "East Midlands", provider = "Moodle", courseName = courseName)
+      stubProjects(*eastMidlandsProjects())
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo(projectCodeFor(expectedProjectName))
+    }
+
+    @Test
+    fun `uses East Midlands Alison fallback when course project is not found`() {
+      val event = event(region = "East Midlands", provider = "Alison", courseName = "Introduction to Supervision")
+      stubProjects(*eastMidlandsProjects())
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo(projectCodeFor("Alison.com"))
+    }
+
+    @ParameterizedTest(name = "East of England course {0} resolves to {1}")
+    @MethodSource("uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.CourseCompletionProjectResolutionServiceTest#eastOfEnglandCourseMappings")
+    fun `resolves East of England course projects`(
+      courseName: String,
+      expectedProjectName: String,
+    ) {
+      val event = event(region = "East of England", provider = "Moodle", courseName = courseName)
+      stubProjects(*projectsFor(eastOfEngland))
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo(projectCodeFor(expectedProjectName))
+    }
+
+    @Test
+    fun `uses East of England Alison fallback when course project is not found`() {
+      val event = event(region = "East of England", provider = "Alison", courseName = "Introduction to Supervision")
+      stubProjects(*projectsFor(eastOfEngland))
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo(projectCodeFor("ETE - Alison.com"))
+    }
+
+    @ParameterizedTest(name = "Greater Manchester course {0} resolves to {1}")
+    @MethodSource("uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.CourseCompletionProjectResolutionServiceTest#greaterManchesterCourseMappings")
+    fun `resolves Greater Manchester course projects`(
+      courseName: String,
+      expectedProjectName: String,
+    ) {
+      val event = event(region = "Greater Manchester", provider = "Moodle", courseName = courseName)
+      stubProjects(*projectsFor(greaterManchester))
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo(projectCodeFor(expectedProjectName))
+    }
+
+    @Test
+    fun `uses Greater Manchester Alison fallback when course project is not found`() {
+      val event = event(region = "Greater Manchester", provider = "Alison", courseName = "Introduction to Supervision")
+      stubProjects(*projectsFor(greaterManchester))
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo(projectCodeFor("Alison - Community Campus"))
+    }
+
+    @ParameterizedTest(name = "Kent, Surrey and Sussex course {0} resolves to {1}")
+    @MethodSource("uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.CourseCompletionProjectResolutionServiceTest#kentSurreyAndSussexCourseMappings")
+    fun `resolves Kent Surrey and Sussex course projects`(
+      courseName: String,
+      expectedProjectName: String,
+    ) {
+      val event = event(region = "Kent, Surrey and Sussex", provider = "Moodle", courseName = courseName)
+      stubProjects(*projectsFor(kentSurreyAndSussex))
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo(projectCodeFor(expectedProjectName))
+    }
+
+    @ParameterizedTest(name = "North East course {0} resolves to {1}")
+    @MethodSource("uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.CourseCompletionProjectResolutionServiceTest#northEastCourseMappings")
+    fun `resolves North East course projects`(
+      courseName: String,
+      expectedProjectName: String,
+    ) {
+      val event = event(region = "North East", provider = "Moodle", courseName = courseName)
+      stubProjects(*projectsFor(northEast))
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo(projectCodeFor(expectedProjectName))
+    }
+
+    @Test
+    fun `uses North East Alison fallback when course project is not found`() {
+      val event = event(region = "North East", provider = "Alison", courseName = "Introduction to Supervision")
+      stubProjects(*projectsFor(northEast))
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo(projectCodeFor("ETE - HMPPS Portal - Alison.com"))
+    }
+
+    @ParameterizedTest(name = "South Central course {0} resolves to {1}")
+    @MethodSource("uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.CourseCompletionProjectResolutionServiceTest#southCentralCourseMappings")
+    fun `resolves South Central course projects`(
+      courseName: String,
+      expectedProjectName: String,
+    ) {
+      val event = event(region = "South Central", provider = "Moodle", courseName = courseName)
+      stubProjects(*projectsFor(southCentral))
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo(projectCodeFor(expectedProjectName))
+    }
+
+    @Test
+    fun `uses South Central portal fallback when course project is not found`() {
+      val event = event(region = "South Central", provider = "Moodle", courseName = "Introduction to Supervision")
+      stubProjects(*projectsFor(southCentral))
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo(projectCodeFor("ET5 ETE – HMPPS portal"))
+    }
+
+    @ParameterizedTest(name = "South West course {0} resolves to {1}")
+    @MethodSource("uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.CourseCompletionProjectResolutionServiceTest#southWestCourseMappings")
+    fun `resolves South West course projects`(
+      courseName: String,
+      expectedProjectName: String,
+    ) {
+      val event = event(region = "South West", provider = "Moodle", courseName = courseName)
+      stubProjects(*projectsFor(southWest))
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo(projectCodeFor(expectedProjectName))
+    }
+
+    @Test
+    fun `uses South West Alison fallback when course project is not found`() {
+      val event = event(region = "South West", provider = "Alison", courseName = "Introduction to Supervision")
+      stubProjects(*projectsFor(southWest))
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo(projectCodeFor("ETE CC Alison Bath"))
+    }
+
+    @Test
+    fun `always uses London standalone portal project`() {
+      val event = event(region = "London", courseName = "Food Hygiene")
+      stubProjects(
+        project("Food Hygiene", "COURSE"),
+        project("20% ETE Standalone HMPPS Portal", "LONDON"),
+      )
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo("LONDON")
+    }
+
+    @ParameterizedTest(name = "North West team {0} and office {1} resolves to {2}")
+    @MethodSource("uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.CourseCompletionProjectResolutionServiceTest#northWestMappings")
+    fun `resolves North West team and office projects`(
+      teamCode: String,
+      office: String,
+      expectedProjectName: String,
+    ) {
+      val event = event(region = "North West", office = office)
+      stubProjects(*northWestProjects())
+
+      val result = service.resolveProjectCode(event, teamCode)
+
+      assertThat(result).isEqualTo(projectCodeFor(expectedProjectName))
+    }
+
+    @ParameterizedTest(name = "Wales course {0} with type {1} resolves to {2}")
+    @MethodSource("uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.CourseCompletionProjectResolutionServiceTest#walesMappings")
+    fun `resolves Wales projects`(
+      courseName: String,
+      courseType: String,
+      expectedProjectName: String,
+    ) {
+      val event = event(region = "Wales", courseName = courseName, courseType = courseType)
+      stubProjects(
+        project("Mandatory ETE", projectCodeFor("Mandatory ETE")),
+        project("ETE - E-Learning", projectCodeFor("ETE - E-Learning")),
+      )
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo(projectCodeFor(expectedProjectName))
+    }
+
+    @ParameterizedTest(name = "Yorks & Humber course {0}, type {1}, provider {2} resolves to {3}")
+    @MethodSource("uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.CourseCompletionProjectResolutionServiceTest#yorksAndHumberMappings")
+    fun `resolves Yorks and Humber projects`(
+      courseName: String,
+      courseType: String,
+      provider: String,
+      expectedProjectName: String,
+    ) {
+      val event = event(region = "Yorks & Humber", provider = provider, courseName = courseName, courseType = courseType)
+      stubProjects(*projectsFor(yorksAndHumber))
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isEqualTo(projectCodeFor(expectedProjectName))
+    }
+
+    @Test
+    fun `returns null when no region rule resolves a project`() {
+      val event = event(region = "Kent, Surrey and Sussex", courseName = "Food Hygiene")
+      stubProjects(project("CC Introduction to Retail", "RETAIL"))
+
+      val result = service.resolveProjectCode(event, "TEAM1")
+
+      assertThat(result).isNull()
+    }
+  }
+
+  private fun event(
+    region: String,
+    provider: String = "Moodle",
+    courseName: String = "Food Hygiene",
+    courseType: String = "Certified",
+    office: String = "Office 1",
+  ) = EteCourseCompletionEventEntity.valid().copy(
+    region = region,
+    provider = provider,
+    courseName = courseName,
+    courseType = courseType,
+    office = office,
+  )
+
+  private fun project(name: String, code: String) = NDProject.valid().copy(name = name, code = code)
+
+  private fun eastMidlandsProjects() = projectsFor(eastMidlands)
+
+  private fun northWestProjects() = northWest
+    .map { it.projectName }
+    .distinct()
+    .map { project(it, projectCodeFor(it)) }
+    .toTypedArray()
+
+  private fun projectsFor(courseToProjects: List<CourseToProject>) = courseToProjects
+    .map { it.projectName }
+    .distinct()
+    .map { project(it, projectCodeFor(it)) }
+    .toTypedArray()
+
+  private fun projectCodeFor(projectName: String) = projectName
+    .uppercase()
+    .replace(Regex("[^A-Z0-9]+"), "_")
+    .trim('_')
+
+  private fun stubProjects(vararg projects: NDProject) {
+    every {
+      communityPaybackAndDeliusClient.getProjects(any(), any(), any(), any())
+    } returns PageResponse(
+      content = projects.map { NDProjectOutcomeStats.valid().copy(project = it) },
+      page = PageResponse.PageMeta(size = projects.size, number = 0, totalElements = projects.size.toLong(), totalPages = 1),
+    )
+  }
+
+
+  companion object {
+    @JvmStatic
+    fun eastMidlandsCourseMappings(): Stream<Arguments> = courseMappingsFor(eastMidlands)
+
+    @JvmStatic
+    fun eastOfEnglandCourseMappings(): Stream<Arguments> = courseMappingsFor(eastOfEngland)
+
+    @JvmStatic
+    fun greaterManchesterCourseMappings(): Stream<Arguments> = courseMappingsFor(greaterManchester)
+
+    @JvmStatic
+    fun kentSurreyAndSussexCourseMappings(): Stream<Arguments> = courseMappingsFor(kentSurreyAndSussex)
+
+    @JvmStatic
+    fun northEastCourseMappings(): Stream<Arguments> = courseMappingsFor(northEast)
+
+    @JvmStatic
+    fun northWestMappings(): Stream<Arguments> = northWest.map {
+      Arguments.of(it.teamCode, it.office, it.projectName)
+    }.stream()
+
+    @JvmStatic
+    fun southCentralCourseMappings(): Stream<Arguments> = courseMappingsFor(southCentral)
+
+    @JvmStatic
+    fun southWestCourseMappings(): Stream<Arguments> = courseMappingsFor(southWest)
+
+    @JvmStatic
+    fun walesMappings(): Stream<Arguments> = Stream.of(
+      Arguments.of("Health & Safety", "Certified", "Mandatory ETE"),
+      Arguments.of("Manual Handling", "Certified", "Mandatory ETE"),
+      Arguments.of("First Aid", "Certified", "Mandatory ETE"),
+      Arguments.of("Introduction to Digital", "Mandatory", "Mandatory ETE"),
+      Arguments.of("Introduction to Digital", "Certified", "ETE - E-Learning"),
+    )
+
+    @JvmStatic
+    fun yorksAndHumberMappings(): Stream<Arguments> = Stream.of(
+      Arguments.of("Employability", "Unemployed", "Moodle", "ETE HMPPS Portal - Employability - mandatory if unemployed"),
+      Arguments.of("Employability", "Certified", "Moodle", "ET5 ETE – HMPPS Portal - Other"),
+      Arguments.of("First Aid", "Certified", "Moodle", "ETE HMPPS Portal - First Aid - mandatory"),
+      Arguments.of("Health and Safety", "Certified", "Moodle", "ETE HMPPS Portal - Health and Safety - mandatory"),
+      Arguments.of("Manual Handling", "Certified", "Moodle", "ETE HMPPS Portal - Manual Handling - mandatory"),
+      Arguments.of("Introduction to Digital", "Certified", "Moodle", "ET5 ETE – HMPPS Portal - Other"),
+      Arguments.of("Introduction to Supervision", "Certified", "Alison", "ETE Alison.com Course"),
+    )
+
+    private fun courseMappingsFor(courseToProjects: List<CourseToProject>) = courseToProjects
+      .filter { it.courseName != null }
+      .map { Arguments.of(it.courseName, it.projectName) }
+      .stream()
+
+    private data class CourseToProject(
+      val courseName: String?,
+      val projectName: String,
+    )
+
+    private data class NorthWestCase(
+      val teamCode: String,
+      val office: String = "Office 1",
+      val projectName: String,
+    )
+
+    private val eastMidlands = listOf(
+      CourseToProject(null, "Alison.com"),
+      CourseToProject("Introduction to Digital", "ETE - Introduction to Digital"),
+      CourseToProject("Introduction to Retail", "ETE - Introduction to Retail"),
+      CourseToProject("Introduction to Industrial and Commercial Cleaning", "ETE – Introduction to Industrial and Commercial Cleaning"),
+      CourseToProject("Health and Safety in Construction", "ETE - Health & Safety in Construction"),
+      CourseToProject("Introduction to Self-Employment", "ETE – Introduction to self-employment"),
+      CourseToProject("Introduction to Plumbing", "ETE – Introduction to Plumbing"),
+      CourseToProject("Effective Communication", "ETE - Effective Communication"),
+      CourseToProject("Introduction to Electrical", "ETE – Introduction to Electrical"),
+      CourseToProject("Building your path: A Career in Construction", "ETE - Building your Path: A Career in Construction"),
+      CourseToProject("Employability", "ETE - Employability"),
+      CourseToProject("Food Hygiene", "ETE - Food Hygiene"),
+      CourseToProject("Money Management", "ETE - Money Management"),
+      CourseToProject("Adult Social Care", "ETE - Adult Social Care"),
+      CourseToProject("First Aid", "ETE - First Aid"),
+      CourseToProject("Manual Handling", "ETE - Manual Handling"),
+      CourseToProject("Health and Safety", "ETE - Health & Safety"),
+      CourseToProject("Customer Service", "ETE - Introduction to Customer Service"),
+      CourseToProject("Gardening and Horticulture", "ETE - Introduction to Gardening & Horticulture"),
+      CourseToProject("Painting and Decorating", "ETE - Painting & Decorating"),
+      CourseToProject("Mental Health Awareness", "ETE - Mental Health Awareness"),
+      CourseToProject("Introduction to Supervision", "ET5 ETE – HMPPS portal"),
+      CourseToProject("Diploma in Basic English Grammar", "ET5 ETE – HMPPS portal"),
+      CourseToProject("Comprehensive Car Mechanic", "ET5 ETE – HMPPS portal"),
+    )
+
+    private val eastOfEngland = listOf(
+      CourseToProject(null, "ETE - Alison.com"),
+      CourseToProject("Adult Social Care", "ETE Portal - Adult Social Care"),
+      CourseToProject("Building your path: A Career in Construction", "ETE Portal - Building Your Path: A Career in Construction"),
+      CourseToProject("Effective Communication", "ETE Portal - Effective Communication"),
+      CourseToProject("Employability", "ETE Portal - Employability"),
+      CourseToProject("Food Hygiene", "ETE Portal - Food Hygiene"),
+      CourseToProject("Health and Safety in Construction", "ETE Portal - Health & Safety in Construction"),
+      CourseToProject("Customer Service", "ETE Portal - Introduction to Customer Service"),
+      CourseToProject("Introduction to Digital", "ETE Portal - Introduction to Digital"),
+      CourseToProject("Introduction to Electrical", "ETE Portal - Introduction to Electrical"),
+      CourseToProject("Gardening and Horticulture", "ETE Portal - Introduction to Gardening & Horticulture"),
+      CourseToProject("Introduction to Industrial and Commercial Cleaning", "ETE Portal - Introduction to Industrial & Commercial Cleaning"),
+      CourseToProject("Introduction to Plumbing", "ETE Portal - Introduction to Plumbing"),
+      CourseToProject("Introduction to Retail", "ETE Portal - Introduction to Retail"),
+      CourseToProject("Introduction to Self-Employment", "ETE Portal - Introduction to Self-Employment"),
+      CourseToProject("Mental Health Awareness", "ETE Portal - Mental Health Awareness"),
+      CourseToProject("Money Management", "ETE Portal - Money Management"),
+      CourseToProject("Painting and Decorating", "ETE Portal - Painting & Decorating"),
+      CourseToProject("First Aid", "ETE Portal – First Aid"),
+      CourseToProject("Health and Safety", "ETE Portal – Health & Safety"),
+      CourseToProject("Manual Handling", "ETE Portal – Manual Handling"),
+    )
+
+    private val greaterManchester = listOf(
+      CourseToProject(null, "Alison - Community Campus"),
+      CourseToProject("Adult Social Care", "Adult Social Care - Community Campus"),
+      CourseToProject("Building your Path", "Building your Path - Community Campus"),
+      CourseToProject("Health and Safety in Construction", "Construction Health & Safety - Community Campus"),
+      CourseToProject("Effective Communication", "Effective Communication - Community Campus"),
+      CourseToProject("Employability", "Employability - Community Campus"),
+      CourseToProject("First Aid", "FIRST AID - Community Campus"),
+      CourseToProject("Food Hygiene", "Food Hygiene - Community Campus"),
+      CourseToProject("Health and Safety", "HEALTH & SAFETY - Community Campus"),
+      CourseToProject("Customer Service", "Intro to Customer Service - Community Campus"),
+      CourseToProject("Introduction to Digital", "Intro to Digital - Community Campus"),
+      CourseToProject("Introduction to Electrical", "Intro to Electrical - Community Campus"),
+      CourseToProject("Gardening and Horticulture", "Intro to Gardening & Horticulture - Community Campus"),
+      CourseToProject("Introduction to Industrial and Commercial Cleaning", "Intro to Industrial & Commercial Cleaning - Community Campus"),
+      CourseToProject("Painting and Decorating", "Intro to Painting & Decorating - Community Campus"),
+      CourseToProject("Introduction to Plumbing", "Intro to Plumbing - Community Campus"),
+      CourseToProject("Introduction to Retail", "Intro to Retail - Community Campus"),
+      CourseToProject("Introduction to Self-Employment", "Intro to Self-Employment - Community Campus"),
+      CourseToProject("Manual Handling", "MANUAL HANDLING - Community Campus"),
+      CourseToProject("Mental Health Awareness", "Mental Health Awareness - Community Campus"),
+      CourseToProject("Money Management", "Money Management - Community Campus"),
+    )
+
+    private val kentSurreyAndSussex = listOf(
+      CourseToProject("Adult Social Care", "CC Adult Social Care"),
+      CourseToProject("Building your path: A Career in Construction", "CC Building your path: A Career in Construction"),
+      CourseToProject("Effective Communication", "CC Effective Communication"),
+      CourseToProject("Employability", "CC Employability"),
+      CourseToProject(null, "CC Employability V2"),
+      CourseToProject("First Aid", "CC First Aid"),
+      CourseToProject("Food Hygiene", "CC Food Hygiene"),
+      CourseToProject("Health and Safety", "CC Health & Safety"),
+      CourseToProject("Health and Safety in Construction", "CC Health & Safety in Construction"),
+      CourseToProject("Customer Service", "CC Introduction to Customer Service"),
+      CourseToProject("Introduction to Digital", "CC Introduction to Digital"),
+      CourseToProject("Introduction to Electrical", "CC Introduction to Electrical"),
+      CourseToProject("Gardening and Horticulture", "CC Introduction to Garden & Horticulture"),
+      CourseToProject("Introduction to Plumbing", "CC Introduction to Plumbing"),
+      CourseToProject("Introduction to Retail", "CC Introduction To Retail"),
+      CourseToProject("Introduction to Self-Employment", "CC Introduction to Self-Employment"),
+      CourseToProject("Manual Handling", "CC Manual Handling"),
+      CourseToProject("Mental Health Awareness", "CC Mental Health awareness"),
+      CourseToProject("Money Management", "CC Money Management"),
+      CourseToProject("Painting and Decorating", "CC Painting & Decorating"),
+      CourseToProject("Introduction to Industrial and Commercial Cleaning", "CC Introduction to Industrial & Commercial Cleaning"),
+    )
+
+    private val northEast = listOf(
+      CourseToProject(null, "ETE - HMPPS Portal - Alison.com"),
+      CourseToProject(null, "ETE - HMPPS Portal - Instruction"),
+      CourseToProject(null, "ETE - HMPPS Portal Course, Health & Safety in Construction"),
+      CourseToProject("Building your path: A Career in Construction", "ETE - HMPPS Portal, Building your path: A Career in Construction"),
+      CourseToProject("Effective Communication", "ETE - HMPPS Portal, Effective Communication"),
+      CourseToProject("Employability", "ETE - HMPPS Portal, Employability"),
+      CourseToProject("First Aid", "ETE - HMPPS Portal, First Aid"),
+      CourseToProject("Food Hygiene", "ETE - HMPPS Portal, Food Hygiene"),
+      CourseToProject("Health and Safety", "ETE - HMPPS Portal, Health & Safety Course"),
+      CourseToProject("Health and Safety in Construction", "ETE - HMPPS Portal, Health & Safety in Construction"),
+      CourseToProject("Adult Social Care", "ETE - HMPPS Portal, Intro to Adult Social Care"),
+      CourseToProject(null, "ETE - HMPPS Portal, Intro to Construction"),
+      CourseToProject("Customer Service", "ETE - HMPPS Portal, Intro to Customer Service"),
+      CourseToProject("Introduction to Digital", "ETE - HMPPS Portal, Intro to Digital"),
+      CourseToProject("Introduction to Electrical", "ETE - HMPPS Portal, Intro to Electrical"),
+      CourseToProject("Gardening and Horticulture", "ETE - HMPPS Portal, Intro to Gardening & Horticulture"),
+      CourseToProject("Introduction to Industrial and Commercial Cleaning", "ETE - HMPPS Portal, Intro to Industrial Cleaning"),
+      CourseToProject("Introduction to Plumbing", "ETE - HMPPS Portal, Intro to Plumbing"),
+      CourseToProject("Introduction to Retail", "ETE - HMPPS Portal, Intro to Retail"),
+      CourseToProject("Introduction to Self-Employment", "ETE - HMPPS Portal, Intro to Self-Employment"),
+      CourseToProject("Manual Handling", "ETE - HMPPS Portal, Manual Handling"),
+      CourseToProject("Mental Health Awareness", "ETE - HMPPS Portal, Mental Health Awareness"),
+      CourseToProject("Money Management", "ETE - HMPPS Portal, Money Management"),
+      CourseToProject("Painting and Decorating", "ETE - HMPPS Portal, Painting & Decorating"),
+    )
+
+    private val northWest = listOf(
+      NorthWestCase("N51CBH", projectName = "Preston ETE"),
+      NorthWestCase("N51CAH", projectName = "Barrow ETE"),
+      NorthWestCase("N51CAJ", projectName = "Blackburn ETE"),
+      NorthWestCase("N51CAO", projectName = "Burnley ETE"),
+      NorthWestCase("N51CAP", projectName = "Carlisle ETE"),
+      NorthWestCase("N51LNP", projectName = "ETE Community Portal"),
+      NorthWestCase("N51CWP", office = "Winsford Office", projectName = "ETE Community Portal Winsford"),
+      NorthWestCase("N51CWP", office = "Chester Office", projectName = "ETE Community Portal Ellesmere Port/Chester"),
+      NorthWestCase("N51CAV", projectName = "Chorley ETE"),
+      NorthWestCase("N51CAK", projectName = "Blackpool ETE"),
+      NorthWestCase("N51CEP", office = "Crewe Office", projectName = "ETE Community Portal Crewe"),
+      NorthWestCase("N51CEP", office = "Macclesfield Office", projectName = "ETE Community Portal Macclesfield"),
+      NorthWestCase("N51CAB", projectName = "Accrington ETE"),
+      NorthWestCase("N51CBB", projectName = "Kendal ETE"),
+      NorthWestCase("N51CBD", projectName = "Lancaster ETE"),
+      NorthWestCase("N51KCP", projectName = "ETE Community Portal"),
+      NorthWestCase("N51HWP", projectName = "ETE Community Portal"),
+      NorthWestCase("N51CBM", projectName = "Skelmersdale ETE"),
+      NorthWestCase("N51SCP", projectName = "ETE Community Portal"),
+      NorthWestCase("N51WCP", projectName = "ETE Community Portal"),
+      NorthWestCase("N51CBP", projectName = "Workington ETE"),
+    )
+
+    private val southCentral = listOf(
+      CourseToProject(null, "ET5 ETE – HMPPS portal"),
+      CourseToProject("First Aid", "ET5-ETE CC First Aid"),
+      CourseToProject("Health and Safety", "ET5-ETE CC Health & Safety"),
+      CourseToProject("Manual Handling", "ET5-ETE CC Manual Handling"),
+    )
+
+    private val southWest = listOf(
+      CourseToProject(null, "ETE CC Alison Bath"),
+      CourseToProject("Building your path: A Career in Construction", "ETE CC Building your path: A Career in Construction Bath"),
+      CourseToProject("Effective Communication", "ETE CC Effective Communication Bath"),
+      CourseToProject("Employability", "ETE CC Employability Bath"),
+      CourseToProject("First Aid", "ETE CC First Aid Bath"),
+      CourseToProject("Food Hygiene", "ETE CC Food Hygiene Bath"),
+      CourseToProject("Health and Safety", "ETE CC Health and Safety Bath"),
+      CourseToProject("Health and Safety in Construction", "ETE CC Health and Safety in Construction Bath"),
+      CourseToProject("Adult Social Care", "ETE CC Intro to Adult Social Care Bath"),
+      CourseToProject("Customer Service", "ETE CC Intro to Customer Services Bath"),
+      CourseToProject("Introduction to Digital", "ETE CC Intro to Digital (IT) Bath"),
+      CourseToProject("Introduction to Electrical", "ETE CC Intro to Electrical Bath"),
+      CourseToProject("Gardening and Horticulture", "ETE CC Intro to Gardening & Horticulture Bath"),
+      CourseToProject("Introduction to Industrial and Commercial Cleaning", "ETE CC Intro to Industrial & Commercial Cleaning Bath"),
+      CourseToProject("Introduction to Plumbing", "ETE CC Intro to Plumbing Bath"),
+      CourseToProject("Introduction to Retail", "ETE CC Intro to Retail Bath"),
+      CourseToProject("Introduction to Self-Employment", "ETE CC Intro to Self Employment Bath"),
+      CourseToProject(null, "ETE CC Mandated Courses Bath"),
+      CourseToProject("Manual Handling", "ETE CC Manual Handling Bath"),
+      CourseToProject("Mental Health Awareness", "ETE CC Mental Health Awareness Bath"),
+      CourseToProject("Money Management", "ETE CC Money Management Bath"),
+      CourseToProject("Painting and Decorating", "ETE CC Painting & Decorating Bath"),
+    )
+
+    private val yorksAndHumber = listOf(
+      CourseToProject("Employability", "ETE HMPPS Portal - Employability - mandatory if unemployed"),
+      CourseToProject("First Aid", "ETE HMPPS Portal - First Aid - mandatory"),
+      CourseToProject("Health and Safety", "ETE HMPPS Portal - Health and Safety - mandatory"),
+      CourseToProject("Manual Handling", "ETE HMPPS Portal - Manual Handling - mandatory"),
+      CourseToProject(null, "ET5 ETE – HMPPS Portal - Other"),
+      CourseToProject(null, "ETE Alison.com Course"),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/CourseCompletionProjectResolutionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/CourseCompletionProjectResolutionServiceTest.kt
@@ -355,7 +355,6 @@ class CourseCompletionProjectResolutionServiceTest {
     )
   }
 
-
   companion object {
     @JvmStatic
     fun eastMidlandsCourseMappings(): Stream<Arguments> = courseMappingsFor(eastMidlands)


### PR DESCRIPTION
Adds automatic project resolution for Community Campus course completion draft resolutions.

This introduces `CourseCompletionProjectResolutionService`, which fetches ETE projects for the resolved UPW team and applies region-specific rules to select the correct Delius project code. `CourseCompletionAutoResolutionService` now persists the resolved `projectCode` alongside the existing CRN and team code draft resolution data.

- Added project auto-resolution after office-to-UPW-team resolution.
- Fetches ETE projects from Delius using the resolved provider/team and ETE project type codes.
- Persists `projectCode` on `EteCourseCompletionDraftResolutionEntity`.
- Leaves `projectCode` blank if project lookup or matching fails, without blocking draft creation.
- Added flexible course/project matching:
  - case-insensitive
  - `&` / `and` tolerant
  - punctuation tolerant
  - supports `intro` / `introduction`
  - supports selected wording differences such as `gardening` / `garden`, `customer services` / `customer service`, and `industrial and commercial cleaning` / `industrial cleaning`
- Added region-specific resolution rules for:
  - East Midlands
  - East of England
  - Greater Manchester
  - Kent, Surrey and Sussex
  - London
  - North East
  - North West
  - South Central
  - South West
  - Wales
  - West Midlands
  - Yorks & Humber