### PR TITLE
CPB-394 - Remove system note for compliance data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
@@ -216,10 +216,6 @@ private fun ValidatedAppointment<UpdateAppointmentOutcomeDto>.buildUpdateNote(
     appendLine("Appointment End Time changed from ${existingEndTime.formatForUser()} to ${updatedEndTime.formatForUser()}")
   }
 
-  if (existingAppointment.contactOutcomeCode != updateDto.contactOutcomeCode) {
-    appendLine("Compliance information has been automatically set by the Community Payback service.")
-  }
-
   if (updateDto.notes?.isNotBlank() == true) {
     appendLine(updateDto.notes)
   }
@@ -238,7 +234,7 @@ fun ValidatedAppointment<CreateAppointmentDto>.toNDCreateAppointment(
     endTime = createDto.endTime,
     outcome = contactOutcome?.let { NDCode(it.code) },
     supervisor = createDto.supervisorOfficerCode?.let { NDCode(it) },
-    notes = buildCreateNote(),
+    notes = createDto.notes,
     hiVisWorn = null,
     workedIntensively = null,
     penaltyMinutes = createDto.attendanceData?.derivePenaltyMinutesDuration()?.toMinutes(),
@@ -254,16 +250,6 @@ fun ValidatedAppointment<CreateAppointmentDto>.toNDCreateAppointment(
     ),
   )
 }
-
-private fun ValidatedAppointment<CreateAppointmentDto>.buildCreateNote() = buildString {
-  val createDto = dto
-
-  appendLine("Compliance information has been automatically set by the Community Payback service.")
-
-  if (createDto.notes?.isNotBlank() == true) {
-    appendLine(createDto.notes)
-  }
-}.trimEnd().ifBlank { null }
 
 object ToAppointmentEntity {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
@@ -120,12 +120,7 @@ class AppointmentMappersTest {
       assertThat(result.endTime).isEqualTo(LocalTime.of(12, 11, 10))
       assertThat(result.outcome?.code).isEqualTo("COE1")
       assertThat(result.supervisor?.code).isEqualTo("WO3736")
-      assertThat(result.notes).isEqualTo(
-        """
-          |Compliance information has been automatically set by the Community Payback service.
-          |The notes
-        """.trimMargin(),
-      )
+      assertThat(result.notes).isEqualTo("The notes")
       assertThat(result.hiVisWorn).isNull()
       assertThat(result.workedIntensively).isNull()
       assertThat(result.penaltyMinutes).isEqualTo(105)
@@ -172,7 +167,7 @@ class AppointmentMappersTest {
       assertThat(result.endTime).isEqualTo(LocalTime.of(12, 11, 10))
       assertThat(result.outcome).isNull()
       assertThat(result.supervisor).isNull()
-      assertThat(result.notes).isEqualTo("Compliance information has been automatically set by the Community Payback service.")
+      assertThat(result.notes).isNull()
       assertThat(result.hiVisWorn).isNull()
       assertThat(result.workedIntensively).isNull()
       assertThat(result.penaltyMinutes).isNull()
@@ -237,7 +232,6 @@ class AppointmentMappersTest {
           |Appointment Date changed from 02/01/2020 to 09/12/2018
           |Appointment Start Time changed from 02:02 to 03:02
           |Appointment End Time changed from 11:11 to 12:11
-          |Compliance information has been automatically set by the Community Payback service.
           |The notes
         """.trimMargin(),
       )


### PR DESCRIPTION
[Ticket](https://dsdmoj.atlassian.net/browse/CPB-394?atlOrigin=eyJpIjoiODVmODQwMWRjN2YzNDQwYTk4ZGEyMTA1MWE2MzUyZjciLCJwIjoiaiJ9)

We have removed hi-vis and worked intensively questions from the case admin
UI and [automatically assign null to each in the API](https://github.com/ministryofjustice/hmpps-community-payback-api/pull/716/changes/45afdb482fbf3ed86013e8aee8d7533ace5c98c8).

And as we are no longer setting the values for workQuality and behaviour, we no
longer need the system note.

Rolls back the work done in this [commit](https://github.com/ministryofjustice/hmpps-community-payback-api/pull/716/changes/b05c8eff400bcf9d4cf3133139afe97844050fd6).

<img width="726" height="777" alt="Screenshot 2026-07-01 at 14 46 17" src="https://github.com/user-attachments/assets/adb7b8dc-f3ba-4e66-9a09-a295b7db462e" />
