### PR TITLE
CPB-1125: Added start and end time fields to project availability

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
@@ -551,6 +551,8 @@ data class NDProjectAvailability(
   val dayOfWeek: NDSchedulingDayOfWeek,
   val startDateInclusive: LocalDate?,
   val endDateExclusive: LocalDate?,
+  val startTime: LocalTime?,
+  val endTime: LocalTime?,
 ) {
   companion object
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/ProjectDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/ProjectDto.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
 
 import java.time.LocalDate
+import java.time.LocalTime
 
 data class ProjectDto(
   val projectName: String,
@@ -25,6 +26,8 @@ data class ProjectAvailabilityDto(
   val dayOfWeek: SchedulingDayOfWeekDto,
   val startDateInclusive: LocalDate?,
   val endDateExclusive: LocalDate?,
+  val startTime: LocalTime?,
+  val endTime: LocalTime?,
 ) {
   companion object
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/ProjectMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/ProjectMappers.kt
@@ -55,6 +55,8 @@ fun NDProjectAvailability.toDto() = ProjectAvailabilityDto(
   dayOfWeek = dayOfWeek.toDto(),
   startDateInclusive = startDateInclusive,
   endDateExclusive = endDateExclusive,
+  startTime = startTime,
+  endTime = endTime,
 )
 
 fun NDSchedulingFrequency.toDto() = when (this) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDProjectAvailabilityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDProjectAvailabilityFactory.kt
@@ -4,10 +4,13 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProjectAvailabi
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSchedulingDayOfWeek
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSchedulingFrequency
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomLocalDate
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomLocalTime
 
 fun NDProjectAvailability.Companion.valid() = NDProjectAvailability(
   frequency = NDSchedulingFrequency.entries.random(),
   dayOfWeek = NDSchedulingDayOfWeek.entries.random(),
   startDateInclusive = randomLocalDate(),
   endDateExclusive = randomLocalDate(),
+  startTime = randomLocalTime(),
+  endTime = randomLocalTime(),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/ProjectDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/ProjectDtoFactory.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SchedulingDayOfWeekD
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SchedulingFrequencyDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomLocalDate
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.randomLocalTime
 import kotlin.String
 
 fun ProjectDto.Companion.valid() = ProjectDto(
@@ -52,4 +53,6 @@ fun ProjectAvailabilityDto.Companion.valid() = ProjectAvailabilityDto(
   dayOfWeek = SchedulingDayOfWeekDto.entries.random(),
   startDateInclusive = randomLocalDate(),
   endDateExclusive = randomLocalDate(),
+  startTime = randomLocalTime(),
+  endTime = randomLocalTime(),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminProjectsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminProjectsIT.kt
@@ -5,10 +5,12 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProject
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProjectAvailability
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.util.bodyAsObject
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.wiremock.CommunityPaybackAndDeliusMockServer
+import java.time.LocalTime
 
 class AdminProjectsIT : IntegrationTestBase() {
 
@@ -61,10 +63,16 @@ class AdminProjectsIT : IntegrationTestBase() {
 
     @Test
     fun `Should return existing project`() {
+      val availability = NDProjectAvailability.valid().copy(
+        startTime = LocalTime.of(9, 30),
+        endTime = LocalTime.of(16, 45),
+      )
+
       CommunityPaybackAndDeliusMockServer.setupGetProjectResponse(
         project = NDProject.valid(ctx).copy(
           code = "PC01",
           name = "the project name",
+          availability = listOf(availability),
         ),
       )
 
@@ -77,6 +85,9 @@ class AdminProjectsIT : IntegrationTestBase() {
         .bodyAsObject<ProjectDto>()
 
       assertThat(response.projectName).isEqualTo("the project name")
+      assertThat(response.availability).hasSize(1)
+      assertThat(response.availability[0].startTime).isEqualTo(LocalTime.of(9, 30))
+      assertThat(response.availability[0].endTime).isEqualTo(LocalTime.of(16, 45))
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/ProjectMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/ProjectMappersTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
 import java.time.LocalDate
+import java.time.LocalTime
 
 class ProjectMappersTest {
 
@@ -55,6 +56,8 @@ class ProjectMappersTest {
             dayOfWeek = NDSchedulingDayOfWeek.Saturday,
             startDateInclusive = LocalDate.of(2020, 10, 11),
             endDateExclusive = LocalDate.of(2035, 12, 30),
+            startTime = LocalTime.of(9, 30),
+            endTime = LocalTime.of(16, 45),
           ),
         ),
       ).toDto(projectTypeEntity)
@@ -83,6 +86,8 @@ class ProjectMappersTest {
       assertThat(result.availability[0].dayOfWeek).isEqualTo(SchedulingDayOfWeekDto.SATURDAY)
       assertThat(result.availability[0].startDateInclusive).isEqualTo(LocalDate.of(2020, 10, 11))
       assertThat(result.availability[0].endDateExclusive).isEqualTo(LocalDate.of(2035, 12, 30))
+      assertThat(result.availability[0].startTime).isEqualTo(LocalTime.of(9, 30))
+      assertThat(result.availability[0].endTime).isEqualTo(LocalTime.of(16, 45))
     }
   }
 


### PR DESCRIPTION
Added start and end time fields to project availability, updated DTOs, mappers, factories, and tests.