### PR TITLE
CPB-1129: Search for suitable appointments for CC auto-resolution

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/CourseCompletionAutoResolutionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/CourseCompletionAutoResolutionService.kt
@@ -2,7 +2,10 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointmentSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.OffenderSearchRequest
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.OffenderSearchResult
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.ProbationOffenderSearchClient
@@ -10,6 +13,10 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompleti
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionDraftResolutionRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.OfficeUpwTeamMappingRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeGroup
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.toHttpParams
+import java.time.LocalDate
 import java.util.UUID
 
 @Service
@@ -18,10 +25,14 @@ class CourseCompletionAutoResolutionService(
   private val officeUpwTeamMappingRepository: OfficeUpwTeamMappingRepository,
   private val courseCompletionProjectResolutionService: CourseCompletionProjectResolutionService,
   private val draftResolutionRepository: EteCourseCompletionDraftResolutionRepository,
+  private val communityPaybackAndDeliusClient: CommunityPaybackAndDeliusClient,
+  private val projectTypeEntityRepository: ProjectTypeEntityRepository,
 ) {
   private companion object {
     val log: Logger = LoggerFactory.getLogger(CourseCompletionAutoResolutionService::class.java)
   }
+
+  private val eteProjectTypeCodes by lazy { projectTypeEntityRepository.findByProjectTypeGroupOrderByCodeAsc(ProjectTypeGroup.ETE).map { it.code } }
 
   fun getDraftResolutionForCourseCompletion(courseCompletionEventId: UUID): EteCourseCompletionDraftResolutionEntity? = draftResolutionRepository.findByEteCourseCompletionEventId(courseCompletionEventId)
 
@@ -30,6 +41,14 @@ class CourseCompletionAutoResolutionService(
     val teamCode = resolveTeamCode(event)
     val projectCode = teamCode?.let { resolveProjectCode(event, it) }
 
+    val appointmentId = if (crn != null && projectCode != null) {
+      log.info("CRN and project code auto-resolved, searching for matching appointments")
+      searchForAppointment(crn, projectCode)
+    } else {
+      log.info("Could not match appointment")
+      null
+    }
+
     draftResolutionRepository.save(
       EteCourseCompletionDraftResolutionEntity(
         id = UUID.randomUUID(),
@@ -37,6 +56,7 @@ class CourseCompletionAutoResolutionService(
         crn = crn,
         teamCode = teamCode,
         projectCode = projectCode,
+        appointmentIdToUpdate = appointmentId,
       ),
     )
   }
@@ -84,5 +104,52 @@ class CourseCompletionAutoResolutionService(
   } catch (e: Exception) {
     log.warn("Project auto-resolution failed for event {}; project will be left blank", event.id, e)
     null
+  }
+
+  private fun searchForAppointment(crn: String, projectCode: String): Long? {
+    val eventNumber = getEventNumberForCrn(crn) ?: return null
+
+    val candidateAppointments = communityPaybackAndDeliusClient.getAppointments(
+      username = "",
+      crn = crn,
+      fromDate = LocalDate.now(),
+      toDate = null,
+      outcomeCodes = listOf("NO_OUTCOME"),
+      projectCodes = listOf(projectCode),
+      projectTypeCodes = eteProjectTypeCodes,
+      eventNumber = eventNumber,
+      appointmentIds = null,
+      params = Pageable.unpaged().toHttpParams(), // Unsorted because the PI API does not support sorting by both date and start time
+    ).content
+      // Perform the sorting that was unable to be done through the client.
+      .sortedWith(compareBy<NDAppointmentSummary> { it.date }.thenBy { it.startTime })
+
+    log.info("Found candidate appointments: {}", candidateAppointments.map { it.id })
+
+    val appointmentId = candidateAppointments.firstOrNull()?.id
+
+    log.info("Soonest appointment without contact outcome: {}", appointmentId)
+
+    return appointmentId
+  }
+
+  private fun getEventNumberForCrn(crn: String): String? {
+    val upwDetails = communityPaybackAndDeliusClient.getUpwDetailsSummary(crn, null).unpaidWorkDetails
+    return when (upwDetails.size) {
+      1 -> {
+        val result = upwDetails.first().eventNumber.toString()
+        log.debug("Event number auto-resolved for CRN {}: {}", crn, result)
+
+        result
+      }
+      0 -> {
+        log.debug("No events for CRN {}", crn)
+        null
+      }
+      else -> {
+        log.debug("Ambiguous event number (multiple matches) for CRN {}", crn)
+        null
+      }
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/CourseCompletionAutoResolutionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/CourseCompletionAutoResolutionServiceTest.kt
@@ -11,17 +11,29 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.IDs
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointmentSummary
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseDetailsSummary
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDUpwDetails
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.OffenderDetail
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse.PageMeta
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.ProbationOffenderSearchClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionDraftResolutionEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionDraftResolutionRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.OfficeUpwTeamMappingEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.OfficeUpwTeamMappingRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeGroup
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.CourseCompletionAutoResolutionService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.CourseCompletionProjectResolutionService
+import java.time.LocalDate
+import java.time.LocalTime
 import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
@@ -39,6 +51,12 @@ class CourseCompletionAutoResolutionServiceTest {
   @RelaxedMockK
   lateinit var draftResolutionRepository: EteCourseCompletionDraftResolutionRepository
 
+  @RelaxedMockK
+  lateinit var communityPaybackAndDeliusClient: CommunityPaybackAndDeliusClient
+
+  @RelaxedMockK
+  lateinit var projectTypeEntityRepository: ProjectTypeEntityRepository
+
   private lateinit var service: CourseCompletionAutoResolutionService
 
   @BeforeEach
@@ -48,6 +66,8 @@ class CourseCompletionAutoResolutionServiceTest {
       officeUpwTeamMappingRepository,
       courseCompletionProjectResolutionService,
       draftResolutionRepository,
+      communityPaybackAndDeliusClient,
+      projectTypeEntityRepository,
     )
   }
 
@@ -240,6 +260,221 @@ class CourseCompletionAutoResolutionServiceTest {
       }
 
       verify(exactly = 0) { draftResolutionRepository.save(any()) }
+    }
+
+    @Test
+    fun `persists draft with appointment ID when a future unresolved appointment exists for the CRN and project code`() {
+      val event = EteCourseCompletionEventEntity.valid().copy(office = "St Albans")
+      every { personSearchClient.searchPerson(any()) } returns listOf(
+        OffenderDetail(otherIds = IDs(crn = "X12345")),
+      )
+      every {
+        officeUpwTeamMappingRepository.findByPduAndOffice(event.pdu, "St Albans")
+      } returns OfficeUpwTeamMappingEntity(
+        id = UUID.randomUUID(),
+        pdu = event.pdu,
+        office = "St Albans",
+        teamCode = "N56ST",
+      )
+      every { courseCompletionProjectResolutionService.resolveProjectCode(event, "N56ST") } returns "PROJECT1"
+
+      every { communityPaybackAndDeliusClient.getUpwDetailsSummary("X12345", null) } returns NDCaseDetailsSummary.valid()
+      every { projectTypeEntityRepository.findByProjectTypeGroupOrderByCodeAsc(ProjectTypeGroup.ETE) } returns listOf(
+        ProjectTypeEntity.valid().copy(code = "ETE_TYPE"),
+      )
+
+      every {
+        communityPaybackAndDeliusClient.getAppointments(
+          username = "",
+          crn = "X12345",
+          fromDate = LocalDate.now(),
+          toDate = null,
+          outcomeCodes = listOf("NO_OUTCOME"),
+          projectCodes = listOf("PROJECT1"),
+          projectTypeCodes = listOf("ETE_TYPE"),
+          eventNumber = any(),
+          appointmentIds = null,
+          params = any(),
+        )
+      } returns PageResponse(listOf(NDAppointmentSummary.valid().copy(id = 1234L, outcome = null)), PageMeta(1, 0, 1, 1))
+
+      val saved = slot<EteCourseCompletionDraftResolutionEntity>()
+      every { draftResolutionRepository.save(capture(saved)) } answers { firstArg() }
+
+      service.resolveAndPersistDraft(event)
+
+      assertThat(saved.captured.teamCode).isEqualTo("N56ST")
+      assertThat(saved.captured.projectCode).isEqualTo("PROJECT1")
+      assertThat(saved.captured.appointmentIdToUpdate).isEqualTo(1234L)
+    }
+
+    @Test
+    fun `persists draft with the ID of the soonest appointment when multiple suitable appointments exist`() {
+      val event = EteCourseCompletionEventEntity.valid().copy(office = "St Albans")
+      every { personSearchClient.searchPerson(any()) } returns listOf(
+        OffenderDetail(otherIds = IDs(crn = "X12345")),
+      )
+      every {
+        officeUpwTeamMappingRepository.findByPduAndOffice(event.pdu, "St Albans")
+      } returns OfficeUpwTeamMappingEntity(
+        id = UUID.randomUUID(),
+        pdu = event.pdu,
+        office = "St Albans",
+        teamCode = "N56ST",
+      )
+      every { courseCompletionProjectResolutionService.resolveProjectCode(event, "N56ST") } returns "PROJECT1"
+
+      every { communityPaybackAndDeliusClient.getUpwDetailsSummary("X12345", null) } returns NDCaseDetailsSummary.valid()
+      every { projectTypeEntityRepository.findByProjectTypeGroupOrderByCodeAsc(ProjectTypeGroup.ETE) } returns listOf(
+        ProjectTypeEntity.valid().copy(code = "ETE_TYPE"),
+      )
+
+      every {
+        communityPaybackAndDeliusClient.getAppointments(
+          username = "",
+          crn = "X12345",
+          fromDate = LocalDate.now(),
+          toDate = null,
+          outcomeCodes = listOf("NO_OUTCOME"),
+          projectCodes = listOf("PROJECT1"),
+          projectTypeCodes = listOf("ETE_TYPE"),
+          eventNumber = any(),
+          appointmentIds = null,
+          params = any(),
+        )
+      } returns PageResponse(
+        listOf(
+          NDAppointmentSummary.valid().copy(id = 1234L, outcome = null, date = LocalDate.now().plusDays(2)),
+          NDAppointmentSummary.valid().copy(id = 2345L, outcome = null, date = LocalDate.now().plusDays(1), startTime = LocalTime.now().plusHours(1)),
+          NDAppointmentSummary.valid().copy(id = 3456L, outcome = null, date = LocalDate.now().plusDays(1), startTime = LocalTime.now()),
+        ),
+        PageMeta(3, 0, 3, 1),
+      )
+
+      val saved = slot<EteCourseCompletionDraftResolutionEntity>()
+      every { draftResolutionRepository.save(capture(saved)) } answers { firstArg() }
+
+      service.resolveAndPersistDraft(event)
+
+      assertThat(saved.captured.teamCode).isEqualTo("N56ST")
+      assertThat(saved.captured.projectCode).isEqualTo("PROJECT1")
+      assertThat(saved.captured.appointmentIdToUpdate).isEqualTo(3456L)
+    }
+
+    @Test
+    fun `persists draft without appointment ID when no suitable appointments are found`() {
+      val event = EteCourseCompletionEventEntity.valid().copy(office = "St Albans")
+      every { personSearchClient.searchPerson(any()) } returns listOf(
+        OffenderDetail(otherIds = IDs(crn = "X12345")),
+      )
+      every {
+        officeUpwTeamMappingRepository.findByPduAndOffice(event.pdu, "St Albans")
+      } returns OfficeUpwTeamMappingEntity(
+        id = UUID.randomUUID(),
+        pdu = event.pdu,
+        office = "St Albans",
+        teamCode = "N56ST",
+      )
+      every { courseCompletionProjectResolutionService.resolveProjectCode(event, "N56ST") } returns "PROJECT1"
+
+      every { communityPaybackAndDeliusClient.getUpwDetailsSummary("X12345", null) } returns NDCaseDetailsSummary.valid()
+      every { projectTypeEntityRepository.findByProjectTypeGroupOrderByCodeAsc(ProjectTypeGroup.ETE) } returns listOf(
+        ProjectTypeEntity.valid().copy(code = "ETE_TYPE"),
+      )
+
+      every {
+        communityPaybackAndDeliusClient.getAppointments(
+          username = "",
+          crn = "X12345",
+          fromDate = LocalDate.now(),
+          toDate = null,
+          outcomeCodes = listOf("NO_OUTCOME"),
+          projectCodes = listOf("PROJECT1"),
+          projectTypeCodes = listOf("ETE_TYPE"),
+          eventNumber = any(),
+          appointmentIds = null,
+          params = any(),
+        )
+      } returns PageResponse(
+        emptyList(),
+        PageMeta(0, 0, 0, 0),
+      )
+
+      val saved = slot<EteCourseCompletionDraftResolutionEntity>()
+      every { draftResolutionRepository.save(capture(saved)) } answers { firstArg() }
+
+      service.resolveAndPersistDraft(event)
+
+      assertThat(saved.captured.teamCode).isEqualTo("N56ST")
+      assertThat(saved.captured.projectCode).isEqualTo("PROJECT1")
+      assertThat(saved.captured.appointmentIdToUpdate).isNull()
+    }
+
+    @Test
+    fun `persists draft without appointment ID when no events are found for the CRN`() {
+      val event = EteCourseCompletionEventEntity.valid().copy(office = "St Albans")
+      every { personSearchClient.searchPerson(any()) } returns listOf(
+        OffenderDetail(otherIds = IDs(crn = "X12345")),
+      )
+      every {
+        officeUpwTeamMappingRepository.findByPduAndOffice(event.pdu, "St Albans")
+      } returns OfficeUpwTeamMappingEntity(
+        id = UUID.randomUUID(),
+        pdu = event.pdu,
+        office = "St Albans",
+        teamCode = "N56ST",
+      )
+      every { courseCompletionProjectResolutionService.resolveProjectCode(event, "N56ST") } returns "PROJECT1"
+
+      every { communityPaybackAndDeliusClient.getUpwDetailsSummary("X12345", null) } returns NDCaseDetailsSummary.valid().copy(unpaidWorkDetails = emptyList())
+      every { projectTypeEntityRepository.findByProjectTypeGroupOrderByCodeAsc(ProjectTypeGroup.ETE) } returns listOf(
+        ProjectTypeEntity.valid().copy(code = "ETE_TYPE"),
+      )
+
+      val saved = slot<EteCourseCompletionDraftResolutionEntity>()
+      every { draftResolutionRepository.save(capture(saved)) } answers { firstArg() }
+
+      service.resolveAndPersistDraft(event)
+
+      assertThat(saved.captured.teamCode).isEqualTo("N56ST")
+      assertThat(saved.captured.projectCode).isEqualTo("PROJECT1")
+      assertThat(saved.captured.appointmentIdToUpdate).isNull()
+    }
+
+    @Test
+    fun `persists draft without appointment ID when multiple events are found for the CRN`() {
+      val event = EteCourseCompletionEventEntity.valid().copy(office = "St Albans")
+      every { personSearchClient.searchPerson(any()) } returns listOf(
+        OffenderDetail(otherIds = IDs(crn = "X12345")),
+      )
+      every {
+        officeUpwTeamMappingRepository.findByPduAndOffice(event.pdu, "St Albans")
+      } returns OfficeUpwTeamMappingEntity(
+        id = UUID.randomUUID(),
+        pdu = event.pdu,
+        office = "St Albans",
+        teamCode = "N56ST",
+      )
+      every { courseCompletionProjectResolutionService.resolveProjectCode(event, "N56ST") } returns "PROJECT1"
+
+      every { communityPaybackAndDeliusClient.getUpwDetailsSummary("X12345", null) } returns NDCaseDetailsSummary.valid().copy(
+        unpaidWorkDetails = listOf(
+          NDUpwDetails.valid(),
+          NDUpwDetails.valid(),
+        ),
+      )
+      every { projectTypeEntityRepository.findByProjectTypeGroupOrderByCodeAsc(ProjectTypeGroup.ETE) } returns listOf(
+        ProjectTypeEntity.valid().copy(code = "ETE_TYPE"),
+      )
+
+      val saved = slot<EteCourseCompletionDraftResolutionEntity>()
+      every { draftResolutionRepository.save(capture(saved)) } answers { firstArg() }
+
+      service.resolveAndPersistDraft(event)
+
+      assertThat(saved.captured.teamCode).isEqualTo("N56ST")
+      assertThat(saved.captured.projectCode).isEqualTo("PROJECT1")
+      assertThat(saved.captured.appointmentIdToUpdate).isNull()
     }
   }
 

--- a/tools/scripts/send-course-completion-event
+++ b/tools/scripts/send-course-completion-event
@@ -7,6 +7,7 @@ print_help () {
   echo "Usage:"
   echo "  -f <first name>   If not provided a random first name is picked"
   echo "  -l <last name>    If not provided a random last name is picked"
+  echo "  -b <YYYY-MM-DD>   If not provided a random date of birth is used"
   echo "  -c <course name>  If not provided a random course name is picked"
   echo
   echo "  -P                Flag the course as being passed (default)"
@@ -17,13 +18,16 @@ print_help () {
   echo "  -h                Display this help message"
 }
 
-while getopts "f:l:c:PFn:x:h" opt; do
+while getopts "f:l:b:c:PFn:x:h" opt; do
   case $opt in
     f)
       firstName="$OPTARG"
       ;;
     l)
       lastName="$OPTARG"
+      ;;
+    b)
+      dateOfBirth="$OPTARG"
       ;;
     c)
       courseName="$OPTARG"
@@ -91,7 +95,9 @@ if [ -z $lastName ]; then
   lastName="$(randomFromList "Anderson" "Bridges" "Chorley" "Dreyfus" "Etherton" "Fanshaw" "Gardener" "Hill")"
 fi
 
-dateOfBirth="$(randomDob)"
+if [ -z $dateOfBirth ]; then
+  dateOfBirth="$(randomDob)"
+fi
 
 if [ -z $courseName ]; then
   courseName="How To $(randomFromList "Butter Toast" "Suck Eggs" "Bake Bread" "Roll Cheese")"


### PR DESCRIPTION
When creating auto-resolution drafts for course completions, if a CRN and project code has been found, these can be used to attempt to resolve an appointment to update.

Firstly, an attempt is made to get the event number for a CRN. If no event number is found, or multiple are found, then the appointment cannot be automatically resolved.

An appointment is a candidate if:
- The CRN, project code, and event number match the already resolved values
- The project's type belongs to the ETE group
- It is scheduled for today or the future
- There is no contact outcome.

The ID of the soonest candidate appointment, if any exist, is saved in the draft resolution for the course completion.