### PR TITLE
CPB-1131: Replace `GET /supervisor/sessions/future` endpoint with `GET /supervisor/sessions/recent`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorSessionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/supervisor/SupervisorSessionsController.kt
@@ -55,7 +55,7 @@ class SupervisorSessionsController(
     @PathVariable supervisorCode: String,
   ) = sessionService.getNextAllocationForSupervisor(supervisorCode) ?: throw NotFoundException("There are no future sessions for supervisor $supervisorCode")
 
-  @Deprecated("The GET /supervisor/sessions/future endpoint should be used instead.")
+  @Deprecated("The GET /supervisor/sessions/recent endpoint should be used instead.")
   @PageableAsQueryParam
   @GetMapping(
     path = [ "/supervisor/providers/{providerCode}/teams/{teamCode}/sessions/future"],
@@ -86,11 +86,11 @@ class SupervisorSessionsController(
 
   @PageableAsQueryParam
   @GetMapping(
-    path = ["/supervisor/sessions/future"],
+    path = ["/supervisor/sessions/recent"],
     produces = [MediaType.APPLICATION_JSON_VALUE],
   )
   @Operation(
-    description = "Get group sessions scheduled for the next 7 days (including today) that belong to the given teams.",
+    description = "Get recent group sessions that belong to the given teams.",
     responses = [
       ApiResponse(
         responseCode = "200",
@@ -98,14 +98,16 @@ class SupervisorSessionsController(
       ),
     ],
   )
-  fun getFutureSessions(
+  fun getRecentSessions(
     @RequestParam teamCodes: List<String> = emptyList(),
+    @RequestParam(defaultValue = "1") daysBefore: Long,
+    @RequestParam(defaultValue = "0") daysAfter: Long,
     @Parameter(hidden = true)
-    @PageableDefault(size = 50, sort = ["date"], direction = Sort.Direction.ASC) pageable: Pageable,
+    @PageableDefault(size = 50, sort = ["date"], direction = Sort.Direction.DESC) pageable: Pageable,
   ) = sessionService.getSessions(
     teamCodes,
-    LocalDate.now(),
-    LocalDate.now().plusDays(7),
+    LocalDate.now().minusDays(daysBefore),
+    LocalDate.now().plusDays(daysAfter),
     projectTypeGroup = ProjectTypeGroupDto.GROUP,
     pageable,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/SupervisorSessionsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/SupervisorSessionsIT.kt
@@ -194,8 +194,8 @@ class SupervisorSessionsIT : IntegrationTestBase() {
   }
 
   @Nested
-  @DisplayName("GET /supervisor/sessions/future")
-  inner class GetFutureSessionsEndpoint {
+  @DisplayName("GET /supervisor/sessions/recent")
+  inner class GetRecentSessionsEndpoint {
 
     @BeforeEach
     fun setUp() {
@@ -205,7 +205,7 @@ class SupervisorSessionsIT : IntegrationTestBase() {
     @Test
     fun `should return unauthorized if no token`() {
       webTestClient.get()
-        .uri("/supervisor/sessions/future?teamCodes=T456")
+        .uri("/supervisor/sessions/recent?teamCodes=T456")
         .exchange()
         .expectStatus()
         .isUnauthorized
@@ -214,7 +214,7 @@ class SupervisorSessionsIT : IntegrationTestBase() {
     @Test
     fun `should return forbidden if no role`() {
       webTestClient.get()
-        .uri("/supervisor/sessions/future?teamCodes=T456")
+        .uri("/supervisor/sessions/recent?teamCodes=T456")
         .headers(setAuthorisation())
         .exchange()
         .expectStatus()
@@ -224,7 +224,7 @@ class SupervisorSessionsIT : IntegrationTestBase() {
     @Test
     fun `should return forbidden if wrong role`() {
       webTestClient.get()
-        .uri("/supervisor/sessions/future?teamCodes=T456")
+        .uri("/supervisor/sessions/recent?teamCodes=T456")
         .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
         .exchange()
         .expectStatus()
@@ -243,18 +243,18 @@ class SupervisorSessionsIT : IntegrationTestBase() {
 
       CommunityPaybackAndDeliusMockServer.setupGetSessionsResponse(
         teamCodes = listOf("T456"),
-        startDate = LocalDate.now(),
-        endDate = LocalDate.now().plusDays(7),
+        startDate = LocalDate.now().minusDays(1),
+        endDate = LocalDate.now(),
         typeCode = listOf("NP1", "NP2", "PL"),
         sessions = PageResponse(
           content = sessions,
           page = PageResponse.PageMeta(50, 0, 2, 1),
         ),
-        sortString = "date,asc",
+        sortString = "date,desc",
       )
 
       val result = webTestClient.get()
-        .uri("/supervisor/sessions/future?teamCodes=T456")
+        .uri("/supervisor/sessions/recent?teamCodes=T456")
         .addSupervisorUiAuthHeader(username = "USER1")
         .exchange()
         .expectStatus()
@@ -272,6 +272,45 @@ class SupervisorSessionsIT : IntegrationTestBase() {
   }
 
   @Test
+  fun `should return OK with filtered response when daysBefore and daysAfter parameters are provided`() {
+    val projectName1 = "Community Garden Maintenance"
+    val projectName2 = "Park Cleanup"
+
+    val sessions = listOf(
+      NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = projectName1)),
+      NDSessionSummary.valid().copy(project = NDProjectSummary.valid().copy(description = projectName2)),
+    )
+
+    CommunityPaybackAndDeliusMockServer.setupGetSessionsResponse(
+      teamCodes = listOf("T456"),
+      startDate = LocalDate.now().minusDays(2),
+      endDate = LocalDate.now().plusDays(3),
+      typeCode = listOf("NP1", "NP2", "PL"),
+      sessions = PageResponse(
+        content = sessions,
+        page = PageResponse.PageMeta(50, 0, 2, 1),
+      ),
+      sortString = "date,desc",
+    )
+
+    val result = webTestClient.get()
+      .uri("/supervisor/sessions/recent?teamCodes=T456&daysBefore=2&daysAfter=3")
+      .addSupervisorUiAuthHeader(username = "USER1")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .bodyAsObject<PageResponse<SessionSummaryDto>>()
+
+    assertThat(result.content).hasSize(2)
+    assertThat(result.content[0].projectName).isEqualTo(projectName1)
+    assertThat(result.content[1].projectName).isEqualTo(projectName2)
+    assertThat(result.page.size).isEqualTo(50)
+    assertThat(result.page.totalPages).isEqualTo(1)
+    assertThat(result.page.totalElements).isEqualTo(2)
+    assertThat(result.page.number).isEqualTo(0)
+  }
+
+  @Test
   fun `should return OK with paginated response when pagination parameters are provided`() {
     val projectName1 = "Community Garden Maintenance"
     val projectName2 = "Park Cleanup"
@@ -283,8 +322,8 @@ class SupervisorSessionsIT : IntegrationTestBase() {
 
     CommunityPaybackAndDeliusMockServer.setupGetSessionsResponse(
       teamCodes = listOf("T456"),
-      startDate = LocalDate.now(),
-      endDate = LocalDate.now().plusDays(7),
+      startDate = LocalDate.now().minusDays(1),
+      endDate = LocalDate.now(),
       typeCode = listOf("NP1", "NP2", "PL"),
       sessions = PageResponse(
         content = sessions,
@@ -294,7 +333,7 @@ class SupervisorSessionsIT : IntegrationTestBase() {
     )
 
     val result = webTestClient.get()
-      .uri("/supervisor/sessions/future?teamCodes=T456&page=0&size=25&sort=projectName,asc")
+      .uri("/supervisor/sessions/recent?teamCodes=T456&page=0&size=25&sort=projectName,asc")
       .addSupervisorUiAuthHeader(username = "USER1")
       .exchange()
       .expectStatus()


### PR DESCRIPTION
The Supervisor UI should show, when a supervisor is logged in, today's group sessions, followed by yesterday's.

The `GET /supervisor/sessions/future` endpoint was introduced to replace the existing future sessions endpoint - however, the Supervisor UI has not been updated yet, so still uses the deprecated endpoint. The new endpoint is unused. This means that replacing this endpoint is safe to do.

The new `GET /supervisor/sessions/recent` endpoint is designed to encapsulate the behaviour of the old endpoint in a more flexible way. It exposes the `daysBefore` and `daysAfter` query parameters, which control how far ahead or behind from today is returned. If these parameters are not supplied, then their default values are:
- `daysBefore`: `1`
- `daysAfter`: `0`

To implement the new behaviour.

To replicate the behaviour of the replaced endpoint, the value can be set to:
- `daysBefore`: `0`
- `daysAfter`: `7`