### PR TITLE
CPB-1133: Sort group and individual appointments by name

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonUnwrapped
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.util.MultiValueMap
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
@@ -133,7 +134,7 @@ interface CommunityPaybackAndDeliusClient {
     @RequestParam projectTypeCodes: List<String>?,
     @RequestParam eventNumber: String?,
     @RequestParam appointmentIds: List<Long>?,
-    @RequestParam params: Map<String, String>,
+    @RequestParam params: MultiValueMap<String, String>,
   ): PageResponse<NDAppointmentSummary>
 
   @GetExchange("/case/{crn}/summary")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import org.springdoc.core.converters.models.PageableAsQueryParam
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
@@ -251,7 +252,7 @@ class AdminAppointmentController(
         description = "Only crn, name, date, startTime, endTime and daysOverdue fields are supported for sorting",
       ),
     )
-    @PageableDefault(size = 50, sort = ["name"], direction = Sort.Direction.DESC) pageable: Pageable,
+    @PageableDefault(size = 50, sort = ["name"], direction = Sort.Direction.ASC) pageable: Pageable,
     @RequestParam(required = false) crn: String?,
     @Parameter(
       description = "Filter by one or more project codes",
@@ -278,6 +279,13 @@ class AdminAppointmentController(
 
     if (!hasFilter) {
       badRequest("At least one filter parameter must be provided")
+    }
+
+    val pageable = if (pageable.sort.getOrderFor("name") == null) {
+      val sort = pageable.sort.and(Sort.by(Sort.Direction.ASC, "name"))
+      PageRequest.of(pageable.pageNumber, pageable.pageSize, sort)
+    } else {
+      pageable
     }
 
     return appointmentService.getAppointments(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentRetrievalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentRetrievalService.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdD
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntityRepository
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.toHttpParams
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.toMultiValueHttpParams
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.AppointmentMappers
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.ToAppointmentEntity.toAppointmentEntity
 import java.time.LocalDate
@@ -63,7 +63,7 @@ class AppointmentRetrievalService(
       projectTypeCodes = projectTypeGroup?.let { projectTypeGroup -> projectService.projectTypesForGroup(projectTypeGroup).map { it.code } },
       eventNumber = eventNumber,
       appointmentIds = deliusAppointmentIds,
-      params = pageable.toHttpParams(),
+      params = pageable.toMultiValueHttpParams(),
     )
     return pageResponse.asPage(pageable) { appointmentMappers.toSummaryDto(it) }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/CourseCompletionAutoResolutionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/CourseCompletionAutoResolutionService.kt
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompleti
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.OfficeUpwTeamMappingRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeGroup
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.toHttpParams
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.toMultiValueHttpParams
 import java.time.LocalDate
 import java.util.UUID
 
@@ -119,7 +119,7 @@ class CourseCompletionAutoResolutionService(
       projectTypeCodes = eteProjectTypeCodes,
       eventNumber = eventNumber,
       appointmentIds = null,
-      params = Pageable.unpaged().toHttpParams(), // Unsorted because the PI API does not support sorting by both date and start time
+      params = Pageable.unpaged().toMultiValueHttpParams(), // Unsorted because the PI API does not support sorting by both date and start time
     ).content
       // Perform the sorting that was unable to be done through the client.
       .sortedWith(compareBy<NDAppointmentSummary> { it.date }.thenBy { it.startTime })

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/SessionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/SessionService.kt
@@ -156,6 +156,6 @@ class SessionService(
     fromDate = date,
     toDate = date,
     projectCodes = listOf(projectCode),
-    pageable = PageRequest.of(0, Int.MAX_VALUE, Sort.by("name").descending()),
+    pageable = PageRequest.of(0, Int.MAX_VALUE, Sort.by("name")),
   ).content
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/PageableUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/PageableUtils.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal
 
 import org.springframework.data.domain.Pageable
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.util.MultiValueMap
 
 fun Pageable.toHttpParams(): Map<String, String> = buildMap {
   put("page", if (isPaged) pageNumber.toString() else "0")
@@ -10,4 +12,18 @@ fun Pageable.toHttpParams(): Map<String, String> = buildMap {
       put("sort", "${order.property},${order.direction.name.lowercase()}")
     }
   }
+}
+
+fun Pageable.toMultiValueHttpParams(): MultiValueMap<String, String> {
+  val map: MultiValueMap<String, String> = LinkedMultiValueMap()
+
+  map.add("page", if (isPaged) pageNumber.toString() else "0")
+  map.add("size", if (isPaged) pageSize.toString() else Integer.MAX_VALUE.toString())
+  if (sort.isSorted) {
+    sort.forEach { order ->
+      map.add("sort", "${order.property},${order.direction.name.lowercase()}")
+    }
+  }
+
+  return map
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
@@ -513,6 +513,7 @@ class AdminAppointmentIT : IntegrationTestBase() {
         crn = "CRN000",
         username = "theusername",
         appointments = listOf(appointment1, appointment2),
+        sortString = "name,desc",
       )
 
       val pageResponse = webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
@@ -513,11 +513,39 @@ class AdminAppointmentIT : IntegrationTestBase() {
         crn = "CRN000",
         username = "theusername",
         appointments = listOf(appointment1, appointment2),
-        sortString = "name,desc",
       )
 
       val pageResponse = webTestClient.get()
         .uri("/admin/appointments?crn=CRN000")
+        .addAdminUiAuthHeader("theusername")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<PageResponse<AppointmentSummaryDto>>()
+
+      assertThat(pageResponse.content).hasSize(2)
+      assertThat(pageResponse.content[0].id).isEqualTo(appointment1.id)
+      assertThat(pageResponse.content[1].id).isEqualTo(appointment2.id)
+      assertThat(pageResponse.page.size).isEqualTo(50)
+      assertThat(pageResponse.page.totalPages).isEqualTo(1)
+      assertThat(pageResponse.page.totalElements).isEqualTo(2)
+      assertThat(pageResponse.page.number).isEqualTo(0)
+    }
+
+    @Test
+    fun `should automatically add name alphabetical order sorting as a tiebreak if sorting by name is not specified`() {
+      val appointment1 = NDAppointmentSummary.valid(ctx)
+      val appointment2 = NDAppointmentSummary.valid(ctx)
+
+      CommunityPaybackAndDeliusMockServer.setupGetAppointmentsResponse(
+        crn = "CRN000",
+        username = "theusername",
+        appointments = listOf(appointment1, appointment2),
+        sortStrings = arrayOf("date,asc", "name,asc"),
+      )
+
+      val pageResponse = webTestClient.get()
+        .uri("/admin/appointments?crn=CRN000&sort=date,asc")
         .addAdminUiAuthHeader("theusername")
         .exchange()
         .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
@@ -38,6 +38,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSupervisorSumma
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDUnpaidWorkRequirement
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDUpwDetails
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse.PageMeta
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.unallocated
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
@@ -108,6 +109,32 @@ object CommunityPaybackAndDeliusMockServer {
     sortString: String? = "name,asc",
     appointmentIds: List<Long> = emptyList(),
     appointments: List<NDAppointmentSummary> = emptyList(),
+  ): Unit = setupGetAppointmentsResponse(
+    crn,
+    username,
+    fromDate,
+    toDate,
+    projectCodes,
+    eventNumber,
+    pageNumber,
+    pageSize,
+    sortString?.let { arrayOf(it) } ?: emptyArray(),
+    appointmentIds,
+    appointments,
+  )
+
+  fun setupGetAppointmentsResponse(
+    crn: String? = null,
+    username: String,
+    fromDate: LocalDate? = null,
+    toDate: LocalDate? = null,
+    projectCodes: List<String> = emptyList(),
+    eventNumber: Int? = null,
+    pageNumber: Int = 0,
+    pageSize: Int = 50,
+    sortStrings: Array<String>,
+    appointmentIds: List<Long> = emptyList(),
+    appointments: List<NDAppointmentSummary> = emptyList(),
   ) {
     val url = buildString {
       append("/community-payback-and-delius/appointments")
@@ -125,10 +152,12 @@ object CommunityPaybackAndDeliusMockServer {
       }
       append("&page=$pageNumber")
       append("&size=$pageSize")
-      sortString?.let { append("&sort=${URLEncoder.encode(it, "UTF-8")}") }
+      sortStrings.forEach {
+        append("&sort=${URLEncoder.encode(it, "UTF-8")}")
+      }
     }
 
-    val pageResponse = PageResponse(appointments, PageResponse.PageMeta(pageSize, pageNumber, appointments.size.toLong(), 1))
+    val pageResponse = PageResponse(appointments, PageMeta(pageSize, pageNumber, appointments.size.toLong(), 1))
 
     WireMock.stubFor(
       get(url)
@@ -215,7 +244,7 @@ object CommunityPaybackAndDeliusMockServer {
       append("page=$pageNumber&size=$pageSize&sort=${URLEncoder.encode(sortString, "UTF-8")}")
     }
 
-    val pageResponse = PageResponse(response, PageResponse.PageMeta(pageSize, pageNumber, response.size.toLong(), 1))
+    val pageResponse = PageResponse(response, PageMeta(pageSize, pageNumber, response.size.toLong(), 1))
 
     WireMock.stubFor(
       get(url)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
@@ -105,7 +105,7 @@ object CommunityPaybackAndDeliusMockServer {
     eventNumber: Int? = null,
     pageNumber: Int = 0,
     pageSize: Int = 50,
-    sortString: String? = "name,desc",
+    sortString: String? = "name,asc",
     appointmentIds: List<Long> = emptyList(),
     appointments: List<NDAppointmentSummary> = emptyList(),
   ) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentRetrievalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentRetrievalServiceTest.kt
@@ -32,7 +32,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentRetri
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ContextService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.OffenderService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ProjectService
-import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.toHttpParams
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.toMultiValueHttpParams
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.AppointmentMappers
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.ToAppointmentEntity.toAppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
@@ -133,7 +133,7 @@ class AppointmentRetrievalServiceTest {
           projectTypeCodes = null,
           eventNumber = null,
           appointmentIds = null,
-          params = pageable.toHttpParams(),
+          params = pageable.toMultiValueHttpParams(),
         )
       } returns pageResponse
 
@@ -183,7 +183,7 @@ class AppointmentRetrievalServiceTest {
           projectTypeCodes = listOf("PT1"),
           eventNumber = null,
           appointmentIds = null,
-          params = pageable.toHttpParams(),
+          params = pageable.toMultiValueHttpParams(),
         )
       } returns pageResponse
 


### PR DESCRIPTION
This PR updates group session appointments and individual placements to correctly order appointments by the name of the person booked on the appointment.

For group placements, this sort is always fixed, and has been updated to be the name in alphabetical order (instead of reverse alphabetical order as it was before). This also applies to the selection form for bulk updates, which uses the same endpoint in this API.

For individual placements, this allows appointments at a given location to be sorted by any of the sortable columns and retain name order as a secondary sort (e.g. for appointments that are on the same date). This is only applied when the `name` property does not have an explicit sort, so that it is possible for the user to specifically sort by name in reverse alphabetical order if they need to find someone towards the end of the list.