### PR TITLE
CPB-1139: Removed validation restricting contact outcome modifications 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentValidationService.kt
@@ -149,7 +149,6 @@ class AppointmentValidationService(
         }
       }
     }
-
   }
 
   private fun ValidationContext.validateStartAndEndTime() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentValidationService.kt
@@ -150,9 +150,6 @@ class AppointmentValidationService(
       }
     }
 
-    if (existingContactOutcome != null && contactOutcome != existingContactOutcome) {
-      badRequest("The existing contact outcome of '${existingContactOutcome.name}' cannot be modified")
-    }
   }
 
   private fun ValidationContext.validateStartAndEndTime() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/DeliusEventTelemetryPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/internal/DeliusEventTelemetryPublisher.kt
@@ -47,6 +47,22 @@ class DeliusEventTelemetryPublisher(
         "eventType" to "UPDATED",
       ),
     )
+
+    val previousContactOutcome = event.existingAppointment.contactOutcomeCode
+    val updatedContactOutcome = event.updateDto.contactOutcome?.code
+    if (previousContactOutcome != null && previousContactOutcome != updatedContactOutcome) {
+      telemetryService.trackEvent(
+        "AppointmentOutcomeChangedEvent",
+        properties = mapOf(
+          "crn" to event.appointmentEntity.crn,
+          "deliusAppointmentId" to event.appointmentEntity.deliusId.toString(),
+          "previousContactOutcome" to previousContactOutcome,
+          "updatedContactOutcome" to updatedContactOutcome,
+          "triggeredAt" to event.trigger.triggeredAt.toString(),
+          "triggeredBy" to event.trigger.triggeredBy,
+        ),
+      )
+    }
   }
 
   @EventListener

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentValidationServiceTest.kt
@@ -1145,21 +1145,23 @@ class AppointmentValidationServiceTest {
       }
 
       @Test
-      fun `existing contact outcome cannot be modified`() {
+      fun `existing contact outcome can be modified`() {
         every { contactOutcomeEntityRepository.findByCode("outcome1") } returns ContactOutcomeEntity.valid().copy(code = "outcome1", name = "outcome 1")
         every { contactOutcomeEntityRepository.findByCode("outcome2") } returns ContactOutcomeEntity.valid().copy(code = "outcome2")
+        val existingAppointment = baselineExistingAppointment.copy(
+          contactOutcomeCode = "outcome1",
+          startTime = LocalTime.of(10, 0),
+          endTime = LocalTime.of(11, 0),
+        )
 
-        assertThatThrownBy {
-          service.validateUpdate(
-            existingAppointment = baselineExistingAppointment.copy(
-              contactOutcomeCode = "outcome1",
-            ),
-            update = baselineUpdate.copy(
-              contactOutcomeCode = "outcome2",
-            ),
-          )
-        }.isInstanceOf(BadRequestException::class.java)
-          .hasMessage("The existing contact outcome of 'outcome 1' cannot be modified")
+        service.validateUpdate(
+          existingAppointment = existingAppointment,
+          update = baselineUpdate.copy(
+            contactOutcomeCode = "outcome2",
+            startTime = existingAppointment.startTime,
+            endTime = existingAppointment.endTime,
+          ),
+        )
       }
     }
 


### PR DESCRIPTION
Updated DeliusEventTelemetryPublisher to track appointment outcome changes. Removed validation restricting contact outcome modifications and updated related tests.