### PR TITLE
CPB-1140: Improve bulk appointment update performance by removing repeated validation of each appointment.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentBulkUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentBulkUpdateService.kt
@@ -38,10 +38,10 @@ class AppointmentBulkUpdateService(
       ?: return result(id, UpdateAppointmentOutcomeResultType.NOT_FOUND)
 
     return try {
-      appointmentUpdateValidationService.validateUpdate(existingAppointment, update)
+      val validatedUpdate = appointmentUpdateValidationService.validateUpdate(existingAppointment, update)
       appointmentUpdateService.updateAppointment(
         existingAppointment = existingAppointment,
-        update = update,
+        validatedUpdate = validatedUpdate,
         trigger = trigger,
       )
       result(id, UpdateAppointmentOutcomeResultType.SUCCESS)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentUpdateService.kt
@@ -31,24 +31,33 @@ class AppointmentUpdateService(
     existingAppointment: AppointmentDto,
     update: UpdateAppointmentOutcomeDto,
     trigger: AppointmentEventTrigger,
+  ) = updateAppointment(
+    existingAppointment = existingAppointment,
+    validatedUpdate = appointmentUpdateValidationService.validateUpdate(existingAppointment, update),
+    trigger = trigger,
+  )
+
+  @Transactional
+  fun updateAppointment(
+    existingAppointment: AppointmentDto,
+    validatedUpdate: ValidatedAppointment<UpdateAppointmentOutcomeDto>,
+    trigger: AppointmentEventTrigger,
   ) {
     val appointmentEntity = appointmentRetrievalService.getOrCreateAppointmentEntity(existingAppointment)
 
-    val validatedUpdateDto = appointmentUpdateValidationService.validateUpdate(existingAppointment, update)
-
     val updateEventDetails = AppointmentUpdatedEvent(
-      updateDto = appointmentUpdateValidationService.validateUpdate(existingAppointment, update),
+      updateDto = validatedUpdate,
       appointmentEntity = appointmentEntity,
       existingAppointment = existingAppointment,
       trigger = trigger,
     )
 
     if (appointmentEventService.hasUpdateAlreadyBeenSent(updateEventDetails)) {
-      log.debug("Not applying update for appointment ${update.deliusId} because the most recent update is logically identical")
+      log.debug("Not applying update for appointment ${validatedUpdate.dto.deliusId} because the most recent update is logically identical")
       return
     }
 
-    updateDelius(existingAppointment, validatedUpdateDto)
+    updateDelius(existingAppointment, validatedUpdate)
 
     springEventPublisher.publishEvent(updateEventDetails)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentBulkUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentBulkUpdateServiceTest.kt
@@ -62,7 +62,8 @@ class AppointmentBulkUpdateServiceTest {
       val update2 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 2L)
 
       every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update1.deliusId)) } returns appointment1Dto
-      every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
+      val validatedUpdate1 = ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
+      every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns validatedUpdate1
       every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update2.deliusId)) } returns appointment2Dto
       every { appointmentUpdateValidationService.validateUpdate(appointment2Dto, update2) } throws BadRequestException("oh dear")
 
@@ -80,8 +81,8 @@ class AppointmentBulkUpdateServiceTest {
       assertThat(result.results[1].result).isEqualTo(UpdateAppointmentOutcomeResultType.VALIDATION_ERROR)
       assertThat(result.results[1].errorMessage).isEqualTo("oh dear")
 
-      verify(exactly = 1) { appointmentUpdateService.updateAppointment(appointment1Dto, update1, TRIGGER) }
-      verify(exactly = 0) { appointmentUpdateService.updateAppointment(appointment2Dto, update2, TRIGGER) }
+      verify(exactly = 1) { appointmentUpdateService.updateAppointment(appointment1Dto, validatedUpdate1, TRIGGER) }
+      verify(exactly = 0) { appointmentUpdateService.updateAppointment(appointment2Dto, any<ValidatedAppointment<UpdateAppointmentOutcomeDto>>(), TRIGGER) }
     }
 
     @Test
@@ -109,8 +110,9 @@ class AppointmentBulkUpdateServiceTest {
       val update1 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 1L)
 
       every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update1.deliusId)) } returns appointment1Dto
-      every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
-      every { appointmentUpdateService.updateAppointment(appointment1Dto, update1, TRIGGER) } throws ConflictException("oh no")
+      val validatedUpdate1 = ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
+      every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns validatedUpdate1
+      every { appointmentUpdateService.updateAppointment(appointment1Dto, validatedUpdate1, TRIGGER) } throws ConflictException("oh no")
 
       val result = service.updateAppointments(
         projectCode = PROJECT_CODE,
@@ -129,10 +131,11 @@ class AppointmentBulkUpdateServiceTest {
       val update1 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 1L)
 
       every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update1.deliusId)) } returns appointment1Dto
-      every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
+      val validatedUpdate1 = ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
+      every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns validatedUpdate1
 
       val exceptionReturned = IllegalStateException("oh no")
-      every { appointmentUpdateService.updateAppointment(appointment1Dto, update1, TRIGGER) } throws exceptionReturned
+      every { appointmentUpdateService.updateAppointment(appointment1Dto, validatedUpdate1, TRIGGER) } throws exceptionReturned
 
       val result = service.updateAppointments(
         projectCode = PROJECT_CODE,
@@ -153,7 +156,8 @@ class AppointmentBulkUpdateServiceTest {
       val update1 = UpdateAppointmentOutcomeDto.valid().copy(deliusId = 1L)
 
       every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update1.deliusId)) } returns appointment1Dto
-      every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
+      val validatedUpdate1 = ValidatedAppointment.validUpdateAppointment().copy(dto = update1)
+      every { appointmentUpdateValidationService.validateUpdate(appointment1Dto, update1) } returns validatedUpdate1
 
       val result = service.updateAppointments(
         projectCode = PROJECT_CODE,
@@ -165,7 +169,7 @@ class AppointmentBulkUpdateServiceTest {
       assertThat(result.results[0].deliusId).isEqualTo(1L)
       assertThat(result.results[0].result).isEqualTo(UpdateAppointmentOutcomeResultType.SUCCESS)
 
-      verify { appointmentUpdateService.updateAppointment(appointment1Dto, update1, TRIGGER) }
+      verify { appointmentUpdateService.updateAppointment(appointment1Dto, validatedUpdate1, TRIGGER) }
     }
 
     @Test
@@ -187,13 +191,16 @@ class AppointmentBulkUpdateServiceTest {
       every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update4.deliusId)) } returns existing4
       every { appointmentRetrievalService.getAppointment(DeliusAppointmentIdDto(PROJECT_CODE, update5.deliusId)) } returns existing5
 
-      every { appointmentUpdateValidationService.validateUpdate(existing2, update2) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update2)
+      val validatedUpdate2 = ValidatedAppointment.validUpdateAppointment().copy(dto = update2)
+      val validatedUpdate4 = ValidatedAppointment.validUpdateAppointment().copy(dto = update4)
+      val validatedUpdate5 = ValidatedAppointment.validUpdateAppointment().copy(dto = update5)
+      every { appointmentUpdateValidationService.validateUpdate(existing2, update2) } returns validatedUpdate2
       every { appointmentUpdateValidationService.validateUpdate(existing3, update3) } throws BadRequestException("validation failed")
-      every { appointmentUpdateValidationService.validateUpdate(existing4, update4) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update4)
-      every { appointmentUpdateValidationService.validateUpdate(existing5, update5) } returns ValidatedAppointment.validUpdateAppointment().copy(dto = update5)
+      every { appointmentUpdateValidationService.validateUpdate(existing4, update4) } returns validatedUpdate4
+      every { appointmentUpdateValidationService.validateUpdate(existing5, update5) } returns validatedUpdate5
 
-      every { appointmentUpdateService.updateAppointment(existing2, update2, TRIGGER) } throws ConflictException("oh no")
-      every { appointmentUpdateService.updateAppointment(existing4, update4, TRIGGER) } throws IllegalStateException("oh no")
+      every { appointmentUpdateService.updateAppointment(existing2, validatedUpdate2, TRIGGER) } throws ConflictException("oh no")
+      every { appointmentUpdateService.updateAppointment(existing4, validatedUpdate4, TRIGGER) } throws IllegalStateException("oh no")
 
       val result = service.updateAppointments(
         projectCode = PROJECT_CODE,


### PR DESCRIPTION
Improves bulk appointment update performance by removing repeated validation of each appointment.

Previously, every appointment in a bulk update was validated three times:

1. Once in AppointmentBulkUpdateService.
2. Once in AppointmentUpdateService before updating Delius.
3. Once again when constructing the appointment update event.

The validation result is now passed from AppointmentBulkUpdateService into AppointmentUpdateService and reused throughout the update.
Each appointment is therefore validated once instead of three times.

