### PR TITLE
CPB-1120: Create Spring scheduled job to clean up stale course completions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionDraftResolutionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionDraftResolutionRepository.kt
@@ -5,4 +5,6 @@ import java.util.UUID
 
 interface EteCourseCompletionDraftResolutionRepository : JpaRepository<EteCourseCompletionDraftResolutionEntity, UUID> {
   fun findByEteCourseCompletionEventId(id: UUID): EteCourseCompletionDraftResolutionEntity?
+
+  fun findByEteCourseCompletionEventIdIn(ids: List<UUID>): List<EteCourseCompletionDraftResolutionEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionEventEntityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/EteCourseCompletionEventEntityRepository.kt
@@ -67,6 +67,15 @@ interface EteCourseCompletionEventEntityRepository : JpaRepository<EteCourseComp
     endAttempt: Int,
   ): List<EteCourseCompletionEventEntity>
 
+  @Query(
+    """
+    SELECT e FROM EteCourseCompletionEventEntity e
+    WHERE e.resolution IS NULL
+    AND e.receivedAt < :timestamp
+    """,
+  )
+  fun getUnresolvedCourseCompletionsBefore(timestamp: OffsetDateTime): List<EteCourseCompletionEventEntity>
+
   enum class ResolutionStatus {
     ANY,
     RESOLVED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/scheduledjobs/ScheduledJobCourseCompletionExpiry.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/scheduledjobs/ScheduledJobCourseCompletionExpiry.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.scheduledjobs
+
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionDraftResolutionRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository
+import java.time.OffsetDateTime
+
+@Component
+class ScheduledJobCourseCompletionExpiry(
+  private val courseCompletionEventEntityRepository: EteCourseCompletionEventEntityRepository,
+  private val draftResolutionRepository: EteCourseCompletionDraftResolutionRepository,
+) {
+  companion object {
+    private val log = LoggerFactory.getLogger(ScheduledJobCourseCompletionExpiry::class.java)
+
+    private const val TTL_DAYS: Long = 7
+  }
+
+  @Scheduled(cron = "0 0 0/2 * * *")
+  @SchedulerLock(
+    name = "course_completion_expiry",
+    lockAtMostFor = "1m",
+    lockAtLeastFor = "1m",
+  )
+  @Transactional
+  fun removeExpiredCourseCompletions() {
+    val timestamp = OffsetDateTime.now().minusDays(TTL_DAYS)
+    log.info("Removing unresolved course completions that were received before {} ({} days ago)", timestamp, TTL_DAYS)
+
+    val courseCompletions = courseCompletionEventEntityRepository.getUnresolvedCourseCompletionsBefore(timestamp)
+    log.info("Found {} unresolved course completion events", courseCompletions.size)
+
+    if (courseCompletions.isEmpty()) {
+      log.info("No unresolved course completion events to remove.")
+      return
+    }
+
+    val draftResolutions = draftResolutionRepository.findByEteCourseCompletionEventIdIn(courseCompletions.map { it.id })
+    log.info("Found {} draft resolutions", draftResolutions.size)
+
+    draftResolutionRepository.deleteAllInBatch(draftResolutions)
+    log.info("Draft resolutions removed")
+    courseCompletionEventEntityRepository.deleteAllInBatch(courseCompletions)
+    log.info("Course completion events removed")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/ScheduledJobCourseCompletionExpiryIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/ScheduledJobCourseCompletionExpiryIT.kt
@@ -1,0 +1,119 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionDraftResolutionEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionDraftResolutionRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventResolutionEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EteCourseCompletionEventResolutionRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
+import uk.gov.justice.digital.hmpps.communitypaybackapi.scheduledjobs.ScheduledJobCourseCompletionExpiry
+import java.time.OffsetDateTime
+
+class ScheduledJobCourseCompletionExpiryIT : IntegrationTestBase() {
+  @Autowired
+  lateinit var job: ScheduledJobCourseCompletionExpiry
+
+  @Autowired
+  lateinit var courseCompletionEventEntityRepository: EteCourseCompletionEventEntityRepository
+
+  @Autowired
+  lateinit var draftResolutionRepository: EteCourseCompletionDraftResolutionRepository
+
+  @Autowired
+  lateinit var courseCompletionResolutionRepository: EteCourseCompletionEventResolutionRepository
+
+  private fun assertThatCourseCompletionIsAbsent(courseCompletion: EteCourseCompletionEventEntity) {
+    assertThat(courseCompletionEventEntityRepository.findAll().map { it.id }).doesNotContain(courseCompletion.id)
+  }
+
+  private fun assertThatCourseCompletionIsPresent(courseCompletion: EteCourseCompletionEventEntity) {
+    assertThat(courseCompletionEventEntityRepository.findAll().map { it.id }).contains(courseCompletion.id)
+  }
+
+  private fun assertThatDraftResolutionIsAbsent(draftResolution: EteCourseCompletionDraftResolutionEntity) {
+    assertThat(draftResolutionRepository.findAll().map { it.id }).doesNotContain(draftResolution.id)
+  }
+
+  private fun assertThatDraftResolutionIsPresent(draftResolution: EteCourseCompletionDraftResolutionEntity) {
+    assertThat(draftResolutionRepository.findAll().map { it.id }).contains(draftResolution.id)
+  }
+
+  @Test
+  fun `removes unresolved course completion events received over 7 days ago`() {
+    val courseCompletion = EteCourseCompletionEventEntity.valid(ctx).copy(receivedAt = OffsetDateTime.now().minusDays(7).minusSeconds(1))
+    courseCompletionEventEntityRepository.save(courseCompletion)
+
+    job.removeExpiredCourseCompletions()
+
+    assertThatCourseCompletionIsAbsent(courseCompletion)
+  }
+
+  @Test
+  fun `removes draft resolutions for unresolved course completion events received over 7 days ago`() {
+    val courseCompletion = EteCourseCompletionEventEntity.valid(ctx).copy(receivedAt = OffsetDateTime.now().minusDays(7).minusSeconds(1))
+    courseCompletionEventEntityRepository.save(courseCompletion)
+
+    val draftResolution = EteCourseCompletionDraftResolutionEntity.valid().copy(eteCourseCompletionEvent = courseCompletion)
+    draftResolutionRepository.save(draftResolution)
+
+    job.removeExpiredCourseCompletions()
+
+    assertThatDraftResolutionIsAbsent(draftResolution)
+  }
+
+  @Test
+  fun `does not remove resolved course completion events received over 7 days ago`() {
+    val courseCompletion = EteCourseCompletionEventEntity.valid(ctx).copy(receivedAt = OffsetDateTime.now().minusDays(7).minusSeconds(1))
+    courseCompletionEventEntityRepository.save(courseCompletion)
+
+    val resolution = EteCourseCompletionEventResolutionEntity.valid(ctx).copy(eteCourseCompletionEvent = courseCompletion)
+    courseCompletionResolutionRepository.save(resolution)
+
+    job.removeExpiredCourseCompletions()
+
+    assertThatCourseCompletionIsPresent(courseCompletion)
+  }
+
+  @Test
+  fun `does not remove draft resolutions for resolved course completion events received over 7 days ago`() {
+    val courseCompletion = EteCourseCompletionEventEntity.valid(ctx).copy(receivedAt = OffsetDateTime.now().minusDays(7).minusSeconds(1))
+    courseCompletionEventEntityRepository.save(courseCompletion)
+
+    val resolution = EteCourseCompletionEventResolutionEntity.valid(ctx).copy(eteCourseCompletionEvent = courseCompletion)
+    courseCompletionResolutionRepository.save(resolution)
+
+    val draftResolution = EteCourseCompletionDraftResolutionEntity.valid().copy(eteCourseCompletionEvent = courseCompletion)
+    draftResolutionRepository.save(draftResolution)
+
+    job.removeExpiredCourseCompletions()
+
+    assertThatDraftResolutionIsPresent(draftResolution)
+  }
+
+  @Test
+  fun `does not remove unresolved course completion events received less than 7 days ago`() {
+    val courseCompletion = EteCourseCompletionEventEntity.valid(ctx).copy(receivedAt = OffsetDateTime.now().minusDays(7).plusSeconds(1))
+    courseCompletionEventEntityRepository.save(courseCompletion)
+
+    job.removeExpiredCourseCompletions()
+
+    assertThatCourseCompletionIsPresent(courseCompletion)
+  }
+
+  @Test
+  fun `does not remove draft resolutions for unresolved course completion events received less than 7 days ago`() {
+    val courseCompletion = EteCourseCompletionEventEntity.valid(ctx).copy(receivedAt = OffsetDateTime.now().minusDays(7).plusSeconds(1))
+    courseCompletionEventEntityRepository.save(courseCompletion)
+
+    val draftResolution = EteCourseCompletionDraftResolutionEntity.valid().copy(eteCourseCompletionEvent = courseCompletion)
+    draftResolutionRepository.save(draftResolution)
+
+    job.removeExpiredCourseCompletions()
+
+    assertThatDraftResolutionIsPresent(draftResolution)
+  }
+}


### PR DESCRIPTION
This approach uses the Spring `@Scheduled` annotation to define a regularly run task to clean up expired course completions. It's modelled on the existing `ScheduledJobFormCacheExpiry` job which already exists in the API to clean up stale form data.

The advantages of this approach are:
- It's more easily testable, as integration tests can ensure the behaviour of the task is as expected
- There's less plumbing required, as scheduled tasks are provided out of the box by Spring

See #745 for the other proposed approach