### PR TITLE
CPB-1120: Create Helm cron job to clean up stale DB data

### DIFF
--- a/helm_deploy/hmpps-community-payback-api/files/db-scheduled-tasks/0001-delete-old-cached-forms.sql
+++ b/helm_deploy/hmpps-community-payback-api/files/db-scheduled-tasks/0001-delete-old-cached-forms.sql
@@ -1,0 +1,4 @@
+-- Deletes cached form data that has expired.
+
+DELETE FROM form_cache
+WHERE updated_at < current_timestamp - interval '7 days';

--- a/helm_deploy/hmpps-community-payback-api/files/db-scheduled-tasks/0002-delete-old-course-completions.sql
+++ b/helm_deploy/hmpps-community-payback-api/files/db-scheduled-tasks/0002-delete-old-course-completions.sql
@@ -1,0 +1,31 @@
+-- Deletes all course completions that have not been resolved by a case admin after a week.
+
+BEGIN;
+
+-- Clean up draft resolutions for CCs
+WITH course_completions_to_delete AS (
+  SELECT ev.id
+  FROM ete_course_completion_events ev
+  LEFT JOIN ete_course_completion_event_resolutions er
+    ON ev.id = er.ete_course_completion_event_id
+  WHERE
+    er.id IS NULL
+    AND ev.received_at < current_timestamp - interval '7 days'
+)
+DELETE FROM ete_course_completion_draft_resolutions
+WHERE ete_course_completion_event_id IN (SELECT id FROM course_completions_to_delete);
+
+-- Clean up the CCs themselves
+WITH course_completions_to_delete AS (
+  SELECT ev.id
+  FROM ete_course_completion_events ev
+  LEFT JOIN ete_course_completion_event_resolutions er
+    ON ev.id = er.ete_course_completion_event_id
+  WHERE
+    er.id IS NULL
+    AND ev.received_at < current_timestamp - interval '7 days'
+)
+DELETE FROM ete_course_completion_events
+WHERE id IN (SELECT id FROM course_completions_to_delete);
+
+COMMIT;

--- a/helm_deploy/hmpps-community-payback-api/templates/_db-scheduled-tasks.tpl
+++ b/helm_deploy/hmpps-community-payback-api/templates/_db-scheduled-tasks.tpl
@@ -1,0 +1,22 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Environment variables for scheduled database tasks
+*/}}
+{{- define "dbScheduledTasks.envs" -}}
+{{- if or .dbScheduledTasks.namespace_secrets .dbScheduledTasks.env -}}
+env:
+{{- range $secret, $envs := .dbScheduledTasks.namespace_secrets }}
+  {{- range $key, $val := $envs }}
+  - name: {{ $key }}
+    valueFrom:
+      secretKeyRef:
+        key: {{ trimSuffix "?" $val }}
+        name: {{ $secret }}{{ if hasSuffix "?" $val }}
+        optional: true{{ end }}  {{- end }}
+{{- end }}
+{{- range $key, $val := .dbScheduledTasks.env }}
+  - name: {{ $key }}
+    value: "{{ $val }}"
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/helm_deploy/hmpps-community-payback-api/templates/db-scheduled-tasks.yaml
+++ b/helm_deploy/hmpps-community-payback-api/templates/db-scheduled-tasks.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.dbScheduledTasks.enabled -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "hmpps-community-api-db-scheduled-tasks-files"
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -ue
+
+    psql_exec() { psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" -At -c "$@"; }
+
+    echo "${DB_HOST}:5432:${DB_NAME}:${DB_USER}:${DB_PASS}" > ~/.pgpass
+    chmod 0600 ~/.pgpass
+
+{{ range $path, $_ := .Files.Glob "files/db-scheduled-tasks/*.sql" }}
+{{- $sql := $.Files.Get $path }}
+{{ print "# " $path | indent 4 }}
+{{ print "psql_exec '" ($sql | replace "'" "'\"'\"'") "'" | indent 4 }}
+{{ print "# END " $path | indent 4 }}
+{{ end }}
+---
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: "hmpps-community-api-db-scheduled-tasks"
+spec:
+  schedule: {{ .Values.dbScheduledTasks.schedule | default "0 3 * * *" }}
+  concurrencyPolicy: "Forbid"
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      # Tidy up all jobs after 4 days
+      ttlSecondsAfterFinished: 345600
+      backoffLimit: 0
+      activeDeadlineSeconds: 2400
+      template:
+        spec:
+          containers:
+            - name: "hmpps-community-api-db-scheduled-tasks"
+              image: "ghcr.io/ministryofjustice/hmpps-postgres-tools:main"
+              command:
+                - /bin/entrypoint.sh
+              volumeMounts:
+                - name: "hmpps-community-api-db-scheduled-tasks"
+                  mountPath: /bin/entrypoint.sh
+                  readOnly: true
+                  subPath: entrypoint.sh
+              securityContext:
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                seccompProfile:
+                  type: RuntimeDefault
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 500Mi
+                requests:
+                  cpu: 500m
+                  memory: 500Mi
+    {{- include "dbScheduledTasks.envs" .Values | nindent 14 }}
+          restartPolicy: "Never"
+          serviceAccountName: {{ .Values.dbScheduledTasks.serviceAccountName | default (index .Values "generic-service").serviceAccountName }}
+          volumes:
+            - name: "hmpps-community-api-db-scheduled-tasks"
+              configMap:
+                name: "hmpps-community-api-db-scheduled-tasks"
+                defaultMode: 0755
+{{- end }}

--- a/helm_deploy/hmpps-community-payback-api/values.yaml
+++ b/helm_deploy/hmpps-community-payback-api/values.yaml
@@ -89,3 +89,16 @@ deploy_stubs: false
 retryDlqCronjob:
   enabled: false
   retryDlqSchedule: "*/20 * * * *"
+
+# Override this configuration in the environment-specific Values files.
+# Set `enabled` to `true` to run the scheduled tasks on the database for that environment.
+# Set `schedule` to override the schedule for that environment. The default is '0 3 * * *', which runs at 3am every morning.
+dbScheduledTasks:
+  enabled: false
+  #schedule: "0 3 * * *"
+  namespace_secrets:
+    rds-postgresql-instance-output:
+      DB_USER: "database_username"
+      DB_PASS: "database_password"
+      DB_HOST: "rds_instance_endpoint"
+      DB_NAME: "database_name"


### PR DESCRIPTION
This approach configures a Kubernetes job to run a series of SQL scripts on a regular schedule. It's largely modelled on the
[prison-progress-restore](https://github.com/ministryofjustice/hmpps-helm-charts/blob/main/charts/generic-service/prison-postgres-restore.sh) job provided by the generic-service Helm chart.

The advantages of this approach are:
- individual tasks are defined as SQL scripts, which can be run manually during local development
- it aligns with the wider MoJ approach for regularly scheduled tasks involving a database
- it can be run independently of the API, such as in environments where it is disabled out-of-hours

See #744 for the other proposed approach