### PR TITLE
CPB-1103: Add `GET /admin/offenders/{crn}/personal-circumstances` endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
@@ -140,6 +140,9 @@ interface CommunityPaybackAndDeliusClient {
   @GetExchange("/case/{crn}/summary")
   fun getUpwDetailsSummary(@PathVariable crn: String, @RequestParam username: String?): NDCaseDetailsSummary
 
+  @GetExchange("/case/{crn}/personal-circumstances")
+  fun getPersonalCircumstances(@PathVariable crn: String): List<NDPersonalCircumstances>
+
   @GetExchange("/adjustments")
   fun getAdjustments(@RequestParam crn: String, @RequestParam eventNumber: Int): NDAdjustmentResponse
 
@@ -680,3 +683,10 @@ data class NDAdjustmentPostResponse(
 data class NDPickUpLocationsResponse(
   val locations: List<NDPickUpLocation> = emptyList(),
 )
+
+data class NDPersonalCircumstances(
+  val type: NDCodeDescription,
+  val subType: NDCodeDescription?,
+) {
+  companion object
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminOffenderController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminOffenderController.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.notFound
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CaseDetailsSummaryDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PersonalCircumstancesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ContextService
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.OffenderService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
@@ -44,4 +45,28 @@ class AdminOffenderController(private val offenderService: OffenderService, priv
   )
   fun getOffenderSummary(@PathVariable crn: String): CaseDetailsSummaryDto = offenderService.getOffenderSummaryByCrn(crn, contextService.getUserName())
     ?: notFound("Offender Summary", crn)
+
+  @GetMapping(
+    path = ["/offenders/{crn}/personal-circumstances"],
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+  )
+  @Operation(
+    description = "Get personal circumstances by CRN",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Successful response with details of personal circumstances",
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Offender not found for the given CRN",
+        content = [
+          Content(
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun getPersonalCircumstances(@PathVariable crn: String): PersonalCircumstancesDto = offenderService.getPersonalCircumstances(crn) ?: notFound("Personal Circumstances", crn)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/PersonalCircumstancesDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/PersonalCircumstancesDto.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
+
+data class PersonalCircumstancesDto(
+  val isAllowedTravelTime: Boolean,
+) {
+  companion object
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/OffenderService.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.ArnsClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CaseDetailsSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderNameDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PersonalCircumstancesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UnpaidWorkDetailsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UnpaidWorkDetailsIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
@@ -37,6 +38,12 @@ class OffenderService(
 
   fun getNameIgnoringLimitedStatus(crn: String): OffenderNameDto? = try {
     communityPaybackAndDeliusClient.getUpwDetailsSummary(crn, null).case.toOffenderNameDto()
+  } catch (_: WebClientResponseException.NotFound) {
+    null
+  }
+
+  fun getPersonalCircumstances(crn: String): PersonalCircumstancesDto? = try {
+    communityPaybackAndDeliusClient.getPersonalCircumstances(crn).toDto()
   } catch (_: WebClientResponseException.NotFound) {
     null
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/PersonalCircumstancesMapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/PersonalCircumstancesMapper.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers
+
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPersonalCircumstances
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PersonalCircumstancesDto
+
+fun List<NDPersonalCircumstances>.toDto(): PersonalCircumstancesDto = PersonalCircumstancesDto(
+  isAllowedTravelTime = this.contains(PersonalCircumstances.ALLOWED_TRAVEL_TIME),
+)
+
+private fun List<NDPersonalCircumstances>.contains(personalCircumstances: PersonalCircumstances): Boolean = this.any {
+  it.type.code == personalCircumstances.typeCode && it.subType?.code == personalCircumstances.subTypeCode
+}
+
+private enum class PersonalCircumstances(val typeCode: String, val subTypeCode: String?) {
+  ALLOWED_TRAVEL_TIME("K", "K09"),
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDPersonalCircumstancesFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDPersonalCircumstancesFactory.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client
+
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCodeDescription
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPersonalCircumstances
+
+fun NDPersonalCircumstances.Companion.valid() = NDPersonalCircumstances(
+  type = NDCodeDescription.valid(),
+  subType = NDCodeDescription.valid(),
+)
+
+fun NDPersonalCircumstances.Companion.valid(typeCode: String, subTypeCode: String?) = NDPersonalCircumstances(
+  type = NDCodeDescription.valid().copy(code = typeCode),
+  subType = subTypeCode?.let { NDCodeDescription.valid().copy(code = it) },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminOffenderIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminOffenderIT.kt
@@ -5,8 +5,10 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseSummary
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPersonalCircumstances
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDUpwDetails
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CaseDetailsSummaryDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PersonalCircumstancesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UnpaidWorkDetailsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.util.bodyAsObject
@@ -142,6 +144,59 @@ class AdminOffenderIT : IntegrationTestBase() {
         .bodyAsObject<UnpaidWorkDetailsDto>()
 
       assertThat(result.eventNumber).isEqualTo(DELIUS_EVENT_NUMBER)
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /admin/offenders/{crn}/personal-circumstances")
+  inner class GetPersonalCircumstances {
+    @Test
+    fun `should return unauthorized if no token`() {
+      webTestClient.get()
+        .uri("/admin/offenders/$CRN/personal-circumstances")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden if no role`() {
+      webTestClient.get()
+        .uri("/admin/offenders/$CRN/personal-circumstances")
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `should return forbidden if wrong role`() {
+      webTestClient.get()
+        .uri("/admin/offenders/$CRN/personal-circumstances")
+        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `should return OK with details of personal circumstances`() {
+      CommunityPaybackAndDeliusMockServer.setupGetPersonalCircumstancesResponse(
+        crn = CRN,
+        personalCircumstances = listOf(
+          NDPersonalCircumstances.valid("K", "K09"),
+        ),
+      )
+
+      val result = webTestClient.get()
+        .uri("/admin/offenders/$CRN/personal-circumstances")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<PersonalCircumstancesDto>()
+
+      assertThat(result.isAllowedTravelTime).isTrue
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointmentSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseDetailsSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseSummary
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPersonalCircumstances
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPickUpLocation
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPickUpLocationsResponse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProject
@@ -459,6 +460,21 @@ object CommunityPaybackAndDeliusMockServer {
         aResponse()
           .withHeader("Content-Type", "application/json")
           .withBody(jsonMapper.writeValueAsString(ndCaseDetailsSummary)),
+      ),
+    )
+  }
+
+  fun setupGetPersonalCircumstancesResponse(
+    crn: String,
+    personalCircumstances: List<NDPersonalCircumstances>,
+  ) {
+    val builder = get(urlPathEqualTo("/community-payback-and-delius/case/$crn/personal-circumstances"))
+
+    WireMock.stubFor(
+      builder.willReturn(
+        aResponse()
+          .withHeader("Content-Type", "application/json")
+          .withBody(jsonMapper.writeValueAsString(personalCircumstances)),
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/OffenderServiceTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.AllRoshRisk
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.ArnsClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseDetailsSummary
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPersonalCircumstances
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDUpwDetails
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.OverallRiskLevel
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.RiskRoshSummary
@@ -216,6 +217,28 @@ class OffenderServiceTest {
       val result = service.getNameIgnoringLimitedStatus(CRN)
 
       assertThat(result).isNull()
+    }
+  }
+
+  @Nested
+  inner class GetPersonalCircumstancesTest {
+    @Test
+    fun `returns null when offender not found`() {
+      every { communityPaybackAndDeliusClient.getPersonalCircumstances(CRN) } throws WebClientResponseExceptionFactory.notFound()
+
+      val result = service.getPersonalCircumstances(CRN)
+
+      assertThat(result).isNull()
+    }
+
+    @Test
+    fun `returns personal circumstances when offender is found`() {
+      every { communityPaybackAndDeliusClient.getPersonalCircumstances(CRN) } returns listOf(NDPersonalCircumstances.valid("K", "K09"))
+
+      val result = service.getPersonalCircumstances(CRN)
+
+      assertThat(result).isNotNull
+      assertThat(result!!.isAllowedTravelTime).isTrue
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/PersonalCircumstancesMapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/PersonalCircumstancesMapperTest.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.service.mappers
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDPersonalCircumstances
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
+
+class PersonalCircumstancesMapperTest {
+  @Test
+  fun `returns when travel time is allowed`() {
+    val personalCircumstances = listOf(NDPersonalCircumstances.valid("K", "K09")).toDto()
+
+    assertThat(personalCircumstances.isAllowedTravelTime).isTrue
+  }
+
+  @Test
+  fun `returns default with travel time not allowed`() {
+    val personalCircumstances = listOf(NDPersonalCircumstances.valid()).toDto()
+
+    assertThat(personalCircumstances.isAllowedTravelTime).isFalse
+  }
+}


### PR DESCRIPTION
This PR adds an endpoint that provides personal circumstances for the person with a given CRN.

Currently, the only relevant personal circumstance to the Community Payback service is whether someone is entitled to being credited for travel time, so the response looks like this:

```jsonc
{
  "isAllowedTravelTime": true // or `false`
}
```