### PR TITLE
500 or 400 when all the bulk update errors are the same

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.badRequest
 import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.notFound
+import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.toResponseEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
@@ -314,12 +315,11 @@ class AdminAppointmentController(
       ),
       ApiResponse(
         responseCode = "400",
-        description = "Validation error. If this occurs then no appointments have been updated",
-        content = [
-          Content(
-            schema = Schema(implementation = ErrorResponse::class),
-          ),
-        ],
+        description = "Every appointment update failed validation",
+      ),
+      ApiResponse(
+        responseCode = "500",
+        description = "Every appointment update failed with a server error",
       ),
     ],
   )
@@ -334,5 +334,5 @@ class AdminAppointmentController(
       triggerType = AppointmentEventTriggerType.USER,
       triggeredBy = contextService.getUserName(),
     ),
-  )
+  ).toResponseEntity()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/internal/BulkUpdateResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/internal/BulkUpdateResponse.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeResultType
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentsOutcomesResultDto
+
+fun UpdateAppointmentsOutcomesResultDto.toResponseEntity(): ResponseEntity<UpdateAppointmentsOutcomesResultDto> {
+  val status = when {
+    results.isNotEmpty() && results.all { it.result == UpdateAppointmentOutcomeResultType.SERVER_ERROR } -> HttpStatus.INTERNAL_SERVER_ERROR
+    results.isNotEmpty() && results.all { it.result == UpdateAppointmentOutcomeResultType.VALIDATION_ERROR } -> HttpStatus.BAD_REQUEST
+    else -> HttpStatus.OK
+  }
+
+  return ResponseEntity.status(status).body(this)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/controller/internal/BulkUpdateResponseTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/controller/internal/BulkUpdateResponseTest.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.unit.controller.internal
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.toResponseEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeResultDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeResultType
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentsOutcomesResultDto
+
+class BulkUpdateResponseTest {
+
+  @Test
+  fun `returns internal server error when every update has a server error`() {
+    val result = bulkResult(
+      UpdateAppointmentOutcomeResultType.SERVER_ERROR,
+      UpdateAppointmentOutcomeResultType.SERVER_ERROR,
+    )
+
+    assertThat(result.toResponseEntity().statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+  }
+
+  @Test
+  fun `returns bad request when every update has a validation error`() {
+    val result = bulkResult(
+      UpdateAppointmentOutcomeResultType.VALIDATION_ERROR,
+      UpdateAppointmentOutcomeResultType.VALIDATION_ERROR,
+    )
+
+    assertThat(result.toResponseEntity().statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+  }
+
+  @Test
+  fun `returns OK for mixed results`() {
+    val result = bulkResult(
+      UpdateAppointmentOutcomeResultType.SUCCESS,
+      UpdateAppointmentOutcomeResultType.SERVER_ERROR,
+    )
+
+    assertThat(result.toResponseEntity().statusCode).isEqualTo(HttpStatus.OK)
+  }
+
+  @Test
+  fun `returns OK for no results`() {
+    assertThat(bulkResult().toResponseEntity().statusCode).isEqualTo(HttpStatus.OK)
+  }
+
+  private fun bulkResult(vararg types: UpdateAppointmentOutcomeResultType) = UpdateAppointmentsOutcomesResultDto(
+    results = types.mapIndexed { index, type ->
+      UpdateAppointmentOutcomeResultDto(deliusId = index.toLong(), result = type)
+    },
+  )
+}


### PR DESCRIPTION
Refactored bulk appointment update response handling to use `toResponseEntity` extension function. Added tests to verify HTTP status code scenarios.