### PR TITLE
Removed validation logic for contact outcome time modifications.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentValidationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentValidationService.kt
@@ -23,7 +23,6 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDayOfW
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.LocalTime
 
 @Suppress("ThrowsCount")
 @Service
@@ -81,9 +80,6 @@ class AppointmentValidationService(
       unpaidWorkDetails = offenderService.getUnpaidWorkDetails(upwDetailsId) ?: badRequest("Cannot find unpaid work details for CRN ${upwDetailsId.crn} and event number ${upwDetailsId.deliusEventNumber}"),
       appointmentDate = update.resolveDate(existingAppointment),
       appointmentMinutesAlreadyCredited = existingAppointment.minutesCredited?.let { Duration.ofMinutes(it) } ?: Duration.ZERO,
-      existingContactOutcome = loadContactOutcome(existingAppointment.contactOutcomeCode),
-      existingStartTime = existingAppointment.startTime,
-      existingEndTime = existingAppointment.endTime,
     )
 
     ctx.applyValidations()
@@ -155,15 +151,6 @@ class AppointmentValidationService(
     if (command.endTime <= command.startTime) {
       badRequest("End Time '${command.endTime.formatForUser()}' must be after Start Time '${command.startTime.formatForUser()}'")
     }
-
-    if (existingContactOutcome != null) {
-      if (existingStartTime != null && existingStartTime != command.startTime) {
-        badRequest("The start time cannot be modified once a contact outcome has been set. Current start time is '${existingStartTime.formatForUser()}', proposed start time is '${command.startTime.formatForUser()}'")
-      }
-      if (existingEndTime != null && existingEndTime != command.endTime) {
-        badRequest("The end time cannot be modified once a contact outcome has been set. Current end time is '${existingEndTime.formatForUser()}', proposed end time is '${command.endTime.formatForUser()}'")
-      }
-    }
   }
 
   private fun ValidationContext.validatePenaltyTime() {
@@ -225,9 +212,6 @@ class AppointmentValidationService(
     val unpaidWorkDetails: UnpaidWorkDetailsDto,
     val appointmentDate: LocalDate,
     val appointmentMinutesAlreadyCredited: Duration = Duration.ZERO,
-    val existingContactOutcome: ContactOutcomeEntity? = null,
-    val existingStartTime: LocalTime? = null,
-    val existingEndTime: LocalTime? = null,
   ) {
     fun appointmentIsInFuture() = appointmentDate.atTime(command.startTime).isAfter(LocalDateTime.now())
     fun appointmentIsInPast() = appointmentDate.atTime(command.endTime).isBefore(LocalDateTime.now())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentValidationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentValidationServiceTest.kt
@@ -1229,44 +1229,6 @@ class AppointmentValidationServiceTest {
           ),
         )
       }
-
-      @Test
-      fun `if contact outcome is already set and start time is modified, throw exception`() {
-        assertThatThrownBy {
-          service.validateUpdate(
-            existingAppointment = baselineExistingAppointment.copy(
-              contactOutcomeCode = OUTCOME_CODE,
-              startTime = LocalTime.of(10, 0),
-              endTime = LocalTime.of(10, 5),
-            ),
-            baselineUpdate.copy(
-              contactOutcomeCode = OUTCOME_CODE,
-              startTime = LocalTime.of(10, 1),
-              endTime = LocalTime.of(10, 5),
-            ),
-          )
-        }.isInstanceOf(BadRequestException::class.java)
-          .hasMessage("The start time cannot be modified once a contact outcome has been set. Current start time is '10:00', proposed start time is '10:01'")
-      }
-
-      @Test
-      fun `if contact outcome is already set and end time is modified, throw exception`() {
-        assertThatThrownBy {
-          service.validateUpdate(
-            existingAppointment = baselineExistingAppointment.copy(
-              contactOutcomeCode = OUTCOME_CODE,
-              startTime = LocalTime.of(10, 0),
-              endTime = LocalTime.of(10, 5),
-            ),
-            baselineUpdate.copy(
-              contactOutcomeCode = OUTCOME_CODE,
-              startTime = LocalTime.of(10, 0),
-              endTime = LocalTime.of(10, 10),
-            ),
-          )
-        }.isInstanceOf(BadRequestException::class.java)
-          .hasMessage("The end time cannot be modified once a contact outcome has been set. Current end time is '10:05', proposed end time is '10:10'")
-      }
     }
 
     @Nested


### PR DESCRIPTION
Removed validation logic for contact outcome time modifications in `AppointmentValidationService` and corresponding tests.