### PR TITLE
CPB-1152: Add `group` query parameter to `GET /common/references/project-types`

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -10,5 +10,10 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore: {}
+ignore:
+  SNYK-JAVA-IOOPENTELEMETRY-17280222:
+    - '*':
+        reason: Suppression for baggage limits issue as we use header size limits
+        expires: 2026-07-11T00:00:00.000Z
+        created: 2026-06-11T07:38:00.250Z
 patch: {}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/common/CommonReferenceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/common/CommonReferenceController.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CommunityCampusPdusD
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ContactOutcomeGroupDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ContactOutcomesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EnforcementActionsDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.ReferenceService
 
@@ -47,7 +48,10 @@ class CommonReferenceController(val referenceService: ReferenceService) {
     ],
   )
   @Cacheable(CacheKey.Api.GET_PROJECT_TYPES)
-  fun getProjectTypes(): ProjectTypesDto = referenceService.getProjectTypes()
+  fun getProjectTypes(
+    @RequestParam("group", required = false)
+    groups: List<ProjectTypeGroupDto> = emptyList(),
+  ): ProjectTypesDto = referenceService.getProjectTypes(groups)
 
   @GetMapping("/contact-outcomes")
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/ProjectTypeEntityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/entity/ProjectTypeEntityRepository.kt
@@ -9,4 +9,5 @@ interface ProjectTypeEntityRepository : JpaRepository<ProjectTypeEntity, UUID> {
   fun getByCode(code: String): ProjectTypeEntity?
   fun findByProjectTypeGroupOrderByCodeAsc(projectTypeGroup: ProjectTypeGroup): List<ProjectTypeEntity>
   fun findAllByOrderByNameAsc(): List<ProjectTypeEntity>
+  fun findByProjectTypeGroupInOrderByNameAsc(projectTypeGroups: List<ProjectTypeGroup>): List<ProjectTypeEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/ReferenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/ReferenceService.kt
@@ -2,12 +2,14 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ContactOutcomeGroupDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AdjustmentReasonEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.CommunityCampusPduEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeGroup
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.EnforcementActionEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeGroup
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
 
 @Service
@@ -20,7 +22,11 @@ class ReferenceService(
 ) {
   fun getAdjustmentReasons() = adjustmentReasonEntity.findAllByOrderByNameAsc().toDto()
 
-  fun getProjectTypes() = projectTypeEntityRepository.findAllByOrderByNameAsc().toDto()
+  fun getProjectTypes(groups: List<ProjectTypeGroupDto>) = if (groups.isEmpty()) {
+    projectTypeEntityRepository.findAllByOrderByNameAsc().toDto()
+  } else {
+    projectTypeEntityRepository.findByProjectTypeGroupInOrderByNameAsc(groups.map { ProjectTypeGroup.fromDto(it) }).toDto()
+  }
 
   fun getContactOutcomes(
     group: ContactOutcomeGroupDto?,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/CommonReferencesIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/CommonReferencesIT.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ContactOutcomesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EnforcementActionsDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeEntityRepository
+import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ProjectTypeGroup
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.util.bodyAsObject
 
 class CommonReferencesIT : IntegrationTestBase() {
@@ -100,7 +101,7 @@ class CommonReferencesIT : IntegrationTestBase() {
     }
 
     @Test
-    fun `should return OK with project types`() {
+    fun `should return OK with all project types when type group is not specified`() {
       val seededProjectTypes = projectTypeEntityRepository.findAll()
 
       val projectTypes = webTestClient.get()
@@ -117,6 +118,55 @@ class CommonReferencesIT : IntegrationTestBase() {
         assertThat(seededProjectTypes).anyMatch { seeded -> seeded.code == it.code }
         assertThat(seededProjectTypes).anyMatch { seeded -> seeded.name == it.name }
         assertThat(seededProjectTypes).anyMatch { seeded -> seeded.id == it.id }
+      }
+    }
+
+    @Test
+    fun `should return OK with project types filtered by a single type group`() {
+      val seededProjectTypes = projectTypeEntityRepository.findAll().filter { it.projectTypeGroup == ProjectTypeGroup.INDIVIDUAL }
+
+      assertThat(seededProjectTypes).isNotEmpty
+
+      val projectTypes = webTestClient.get()
+        .uri("/common/references/project-types?group=INDIVIDUAL")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<ProjectTypesDto>()
+
+      assertThat(projectTypes.projectTypes).hasSize(seededProjectTypes.size)
+
+      projectTypes.projectTypes.forEach {
+        assertThat(seededProjectTypes).anyMatch { seeded -> seeded.code == it.code }
+        assertThat(seededProjectTypes).anyMatch { seeded -> seeded.name == it.name }
+        assertThat(seededProjectTypes).anyMatch { seeded -> seeded.id == it.id }
+        assertThat(seededProjectTypes).allMatch { seeded -> seeded.projectTypeGroup?.name == "INDIVIDUAL" }
+      }
+    }
+
+    @Test
+    fun `should return OK with project types filtered by multiple type groups`() {
+      val seededProjectTypes = projectTypeEntityRepository.findAll().filter { it.projectTypeGroup == ProjectTypeGroup.INDIVIDUAL || it.projectTypeGroup == ProjectTypeGroup.ETE }
+
+      assertThat(seededProjectTypes.any { it.projectTypeGroup == ProjectTypeGroup.INDIVIDUAL }).isTrue
+      assertThat(seededProjectTypes.any { it.projectTypeGroup == ProjectTypeGroup.ETE }).isTrue
+
+      val projectTypes = webTestClient.get()
+        .uri("/common/references/project-types?group=INDIVIDUAL&group=ETE")
+        .addAdminUiAuthHeader()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<ProjectTypesDto>()
+
+      assertThat(projectTypes.projectTypes).hasSize(seededProjectTypes.size)
+
+      projectTypes.projectTypes.forEach {
+        assertThat(seededProjectTypes).anyMatch { seeded -> seeded.code == it.code }
+        assertThat(seededProjectTypes).anyMatch { seeded -> seeded.name == it.name }
+        assertThat(seededProjectTypes).anyMatch { seeded -> seeded.id == it.id }
+        assertThat(seededProjectTypes).allMatch { seeded -> seeded.projectTypeGroup?.name == "INDIVIDUAL" || seeded.projectTypeGroup?.name == "ETE" }
       }
     }
   }


### PR DESCRIPTION


Currently, the `GET /common/references/project-types` endpoint returns all project types. This means that if the caller wants to filter the results by the group, they must do this manually.

This change provides the `group` query parameter to allow this filtering to be done by the API. It can be provided one or more times. A project type is returned if it belongs to any of the specified groups. If the `group` parameter is not included, the existing behaviour is preserved, and all project types are returned.