### PR TITLE
CPB-1159: Sort group session appointments by people's names alphabetically

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/SessionMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/SessionMappers.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummarie
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderDto.OffenderFullDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PageMetaDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionDto
@@ -13,12 +14,22 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionSummariesDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntityRepository
 import java.time.LocalDate
+import kotlin.comparisons.nullsLast
 
 @Service
 class SessionMappers(
   val appointmentMappers: AppointmentMappers,
   val contactOutcomeEntityRepository: ContactOutcomeEntityRepository,
 ) {
+
+  private val compareAppointmentsByPersonName: Comparator<AppointmentSummaryDto> = { a, b ->
+    val offenderA = a.offender as? OffenderFullDto
+    val offenderB = b.offender as? OffenderFullDto
+
+    val comparator = nullsLast(compareBy<OffenderFullDto> { it.surname }.thenBy { it.forename })
+
+    comparator.compare(offenderA, offenderB)
+  }
 
   fun toSessionDto(
     date: LocalDate,
@@ -29,7 +40,7 @@ class SessionMappers(
     projectName = project.projectName,
     location = project.location,
     date = date,
-    appointmentSummaries = appointments,
+    appointmentSummaries = appointments.sortedWith(compareAppointmentsByPersonName),
     // deprecated fields
     projectLocation = "",
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/SessionMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/SessionMappersTest.kt
@@ -15,12 +15,15 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDSessionSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.PageResponse
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ContactOutcomeDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderDto.OffenderFullDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderDto.OffenderLimitedDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.ContactOutcomeEntityRepository
-import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.valid
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto.validFull
 import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.entity.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.AppointmentMappers
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.SessionMappers
@@ -133,8 +136,9 @@ class SessionMappersTest {
         projectName = "Project Name 1",
       )
       val appointments = listOf(
-        AppointmentSummaryDto.valid(),
-        AppointmentSummaryDto.valid(),
+        AppointmentSummaryDto.valid().copy(offender = OffenderLimitedDto("X000000")),
+        AppointmentSummaryDto.valid().copy(offender = OffenderDto.validFull().copy(forename = "A", surname = "Z", crn = "X123456")),
+        AppointmentSummaryDto.valid().copy(offender = OffenderDto.validFull().copy(forename = "Z", surname = "A", crn = "X987654")),
       )
 
       val result = service.toSessionDto(
@@ -147,7 +151,15 @@ class SessionMappersTest {
       assertThat(result.projectName).isEqualTo("Project Name 1")
       assertThat(result.location).isEqualTo(project.location)
       assertThat(result.date).isEqualTo(LocalDate.of(2025, 9, 1))
-      assertThat(result.appointmentSummaries).isEqualTo(appointments)
+      assertThat(result.appointmentSummaries.size).isEqualTo(appointments.size)
+
+      assertThat(result.appointmentSummaries[0].offender).isInstanceOf(OffenderFullDto::class.java).extracting("forename").isEqualTo("Z")
+      assertThat(result.appointmentSummaries[0].offender).isInstanceOf(OffenderFullDto::class.java).extracting("surname").isEqualTo("A")
+      assertThat(result.appointmentSummaries[0].offender).isInstanceOf(OffenderFullDto::class.java).extracting { it.crn }.isEqualTo("X987654")
+      assertThat(result.appointmentSummaries[1].offender).isInstanceOf(OffenderFullDto::class.java).extracting("forename").isEqualTo("A")
+      assertThat(result.appointmentSummaries[1].offender).isInstanceOf(OffenderFullDto::class.java).extracting("surname").isEqualTo("Z")
+      assertThat(result.appointmentSummaries[1].offender).isInstanceOf(OffenderFullDto::class.java).extracting { it.crn }.isEqualTo("X123456")
+      assertThat(result.appointmentSummaries[2].offender).isInstanceOf(OffenderLimitedDto::class.java).extracting { it.crn }.isEqualTo("X000000")
 
       assertThat(result.projectLocation).isEqualTo("")
     }


### PR DESCRIPTION
When getting a group session, appointments are currently returned in whichever order they are received from Delius. User feedback has indicated that this should be sorted alphabetically in `Lastname Firstname` order.

This implements this change by updating the `SessionsMappers.toSessionDto` method so that it explicitly performs the sort on the provided list of appointments.

In the case that a person is a limited access offender, the name won't be available. In this case, the appointment should appear at the end of the list.