### PR TITLE
CPB-1164: Bulk update performance improvement with coroutines

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
   implementation("net.javacrumbs.shedlock:shedlock-provider-redis-spring:7.7.0")
 
   implementation("com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20260313.1")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
 
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
 
@@ -57,8 +58,6 @@ dependencies {
   testImplementation("com.lemonappdev:konsist:0.17.3")
   testImplementation("uk.gov.justice.service.hmpps:hmpps-subject-access-request-test-support:2.6.2")
   testImplementation("org.zalando:logbook-spring-boot-starter:4.0.4")
-  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
-
   testImplementation("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/CallerContext.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/common/CallerContext.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.common
+
+import org.springframework.security.concurrent.DelegatingSecurityContextCallable
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.web.context.request.RequestAttributes
+import org.springframework.web.context.request.RequestContextHolder
+
+fun <T : Any> runWithCallerContext(
+  securityContext: SecurityContext,
+  requestAttributes: RequestAttributes?,
+  action: () -> T,
+): T = DelegatingSecurityContextCallable<T>(
+  {
+    RequestContextHolder.setRequestAttributes(requestAttributes)
+    try {
+      action()
+    } finally {
+      RequestContextHolder.resetRequestAttributes()
+    }
+  },
+  securityContext,
+).call()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentBulkUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentBulkUpdateService.kt
@@ -1,7 +1,14 @@
 package uk.gov.justice.digital.hmpps.communitypaybackapi.service
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
+import org.springframework.web.context.request.RequestContextHolder
+import uk.gov.justice.digital.hmpps.communitypaybackapi.common.runWithCallerContext
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentOutcomeResultDto
@@ -19,6 +26,9 @@ class AppointmentBulkUpdateService(
   private val appointmentUpdateService: AppointmentUpdateService,
   private val sentryService: SentryService,
 ) {
+  private companion object {
+    const val MAX_CONCURRENT_UPDATES = 4
+  }
 
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -26,9 +36,20 @@ class AppointmentBulkUpdateService(
     projectCode: String,
     request: UpdateAppointmentOutcomesDto,
     trigger: AppointmentEventTrigger,
-  ): UpdateAppointmentsOutcomesResultDto = UpdateAppointmentsOutcomesResultDto(
-    results = request.updates.map { update -> updateAppointment(projectCode, update, trigger) },
-  )
+  ): UpdateAppointmentsOutcomesResultDto = runBlocking {
+    val dispatcher = Dispatchers.IO.limitedParallelism(MAX_CONCURRENT_UPDATES)
+    val securityContext = SecurityContextHolder.getContext()
+    val requestAttributes = RequestContextHolder.getRequestAttributes()
+    val results = request.updates.map { update ->
+      async(dispatcher) {
+        runWithCallerContext(securityContext, requestAttributes) {
+          updateAppointment(projectCode, update, trigger)
+        }
+      }
+    }.awaitAll()
+
+    UpdateAppointmentsOutcomesResultDto(results)
+  }
 
   @SuppressWarnings("TooGenericExceptionCaught")
   private fun updateAppointment(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/NDeliusRollbackService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/NDeliusRollbackService.kt
@@ -67,9 +67,11 @@ class NDeliusRollbackService(
   proxyMode = ScopedProxyMode.TARGET_CLASS,
 )
 class RequestScopedEvents {
-  val events = mutableListOf<CommunityPaybackSpringEvent>()
+  private val events = mutableListOf<CommunityPaybackSpringEvent>()
 
+  @Synchronized
   fun add(event: CommunityPaybackSpringEvent) = events.add(event)
 
+  @Synchronized
   fun getAll() = events.toList()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
@@ -44,6 +44,8 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.wiremock.Com
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDate
 import java.time.LocalTime
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.measureTimedValue
 
 class AdminAppointmentIT : IntegrationTestBase() {
 
@@ -669,6 +671,58 @@ class AdminAppointmentIT : IntegrationTestBase() {
       CommunityPaybackAndDeliusMockServer.verifyPutAppointmentRequest("PC01", 5678L)
 
       domainEventAsserter.assertEventCount("community-payback.appointment.updated", 2)
+    }
+
+    @Test
+    fun `updates appointments concurrently and preserves response order`() {
+      val projectAndLocation = NDProjectAndLocation.valid().copy(code = "PC01")
+      val project = NDProject.valid(ctx).copy(code = "PC01")
+      val pickup = NDAppointmentPickUp.valid()
+      val appointmentIds = listOf(1234L, 2345L, 3456L, 4567L)
+
+      appointmentIds.forEach { appointmentId ->
+        CommunityPaybackAndDeliusMockServer.Aggregates.setupGetDataMocksForUpdateAppointment(
+          existingAppointment = NDAppointment.validNoOutcome(ctx).copy(
+            id = appointmentId,
+            project = projectAndLocation,
+            date = LocalDate.now(),
+            event = NDEvent.valid().copy(number = EVENT_NUMBER),
+            case = NDCaseSummary.valid().copy(crn = "$CRN$appointmentId"),
+            pickUpData = pickup,
+          ),
+          project = project,
+          username = "theusername",
+        )
+        CommunityPaybackAndDeliusMockServer.setupPutAppointmentResponse(
+          projectCode = "PC01",
+          appointmentId = appointmentId,
+          fixedDelayMilliseconds = 1000,
+        )
+      }
+
+      val (result, elapsed) = measureTimedValue {
+        webTestClient.put()
+          .uri("/admin/projects/PC01/appointments/bulk")
+          .addAdminUiAuthHeader("theusername")
+          .bodyValue(
+            UpdateAppointmentsDto(
+              updates = appointmentIds.map { appointmentId ->
+                UpdateAppointmentDto.valid(ctx).copy(deliusId = appointmentId)
+              },
+            ),
+          )
+          .exchange()
+          .expectStatus()
+          .isOk
+          .bodyAsObject<UpdateAppointmentsOutcomesResultDto>()
+      }
+
+      assertThat(elapsed).isLessThan(3.seconds)
+      assertThat(result.results.map { it.deliusId }).containsExactlyElementsOf(appointmentIds)
+      assertThat(result.results.map { it.result }).containsOnly(UpdateAppointmentOutcomeResultType.SUCCESS)
+      appointmentIds.forEach { appointmentId ->
+        CommunityPaybackAndDeliusMockServer.verifyPutAppointmentRequest("PC01", appointmentId)
+      }
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/wiremock/CommunityPaybackAndDeliusMockServer.kt
@@ -513,11 +513,14 @@ object CommunityPaybackAndDeliusMockServer {
   fun setupPutAppointmentResponse(
     projectCode: String,
     appointmentId: Long,
+    fixedDelayMilliseconds: Int = 0,
   ) {
     WireMock.stubFor(
       put("/community-payback-and-delius/projects/$projectCode/appointments/$appointmentId")
         .willReturn(
-          aResponse().withStatus(200),
+          aResponse()
+            .withStatus(200)
+            .withFixedDelay(fixedDelayMilliseconds),
         ),
     )
   }


### PR DESCRIPTION
Implemented concurrent bulk appointment updates with response order preservation, added coroutine support, and introduced `runWithCallerContext` utility. Updated tests for new functionality.

Previously, the bulk endpoint updated appointments one at a time:
`Update 1 finishes → Update 2 finishes → Update 3 finishes → Update 4 finishes
`
If each update took two seconds, four updates could take roughly eight seconds.
Now, coroutines allow up to four appointments to be processed at the same time:

```
Update 1 ─┐
Update 2 ─┤
Update 3 ─┤── all running together
Update 4 ─┘
```

In the same example, four updates could finish in roughly two seconds instead of eight.
A coroutine is a lightweight unit of work. The dispatcher decides where that work runs. Here, Dispatchers.IO is appropriate because most of the time is spent waiting for network and database responses.

Dispatchers.IO is a shared pool of worker threads designed for operations that spend much of their time waiting, such as:
- Calling Delius over HTTP
- Reading from or writing to the database
- Reading files

Dispatchers.IO means “run this work on threads intended for blocking input/output operations.”
limitedParallelism(4) means “for this part of the application, allow at most four jobs to execute at once.”

The limit of four prevents a large request from overwhelming the database or the upstream Delius service. For example, twelve updates are processed in approximately three groups of four.

awaitAll() waits until every update has completed and returns the results in the same order as the original request.
In short: the endpoint spends less time waiting on appointments sequentially, while the concurrency limit keeps the extra load controlled. 

The exact improvement depends on upstream response times, but for sufficiently large batches it could approach four times faster.

```
Bulk request
    |
    | creates one coroutine per appointment
    v
Waiting queue
    |
    | Dispatcher.IO selects up to four
    v
+----------+ +----------+ +----------+ +----------+
| Update 1 | | Update 2 | | Update 3 | | Update 4 |
| Delius   | | Delius   | | Delius   | | Delius   |
| database | | database | | database | | database |
+----------+ +----------+ +----------+ +----------+
      |
      | When one finishes, another queued update starts
      v
  Update 5
```