### PR TITLE
CPB-1164: Increase timeout to 30s, to stop error screen showing on the UI for bulk updates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/config/WebClientConfiguration.kt
@@ -35,7 +35,7 @@ class WebClientConfiguration(
   /**
    * Before changing timeouts consider the impact on [DomainEventListener.MESSAGE_VISIBILITY_TIMEOUT]
    */
-  @param:Value("\${client.community-payback-and-delius.timeout:10s}") val communityPaybackAndDeliusTimeout: Duration,
+  @param:Value("\${client.community-payback-and-delius.timeout:30s}") val communityPaybackAndDeliusTimeout: Duration,
 
   @param:Value("\${client.arns.url}") val arnsUrl: String,
   @param:Value("\${client.arns.timeout:5s}") val arnsTimeout: Duration,


### PR DESCRIPTION
Increased `communityPaybackAndDeliusTimeout` default value from 10s to 30s in `WebClientConfiguration`.