### PR TITLE
CPB-1192: Fix appointment sorting when building a `SessionDTO`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/SessionMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/SessionMappers.kt
@@ -24,7 +24,7 @@ class SessionMappers(
     val offenderA = a.offender as? OffenderFullDto
     val offenderB = b.offender as? OffenderFullDto
 
-    val comparator = nullsLast(compareBy<OffenderFullDto> { it.surname }.thenBy { it.forename })
+    val comparator = nullsLast(compareBy<OffenderFullDto> { it.surname?.lowercase() }.thenBy { it.forename?.lowercase() })
 
     comparator.compare(offenderA, offenderB)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/SessionMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/SessionMappersTest.kt
@@ -105,6 +105,32 @@ class SessionMappersTest {
 
       assertThat(result.projectLocation).isEqualTo("")
     }
+
+    @Test
+    fun `should sort appointment summaries case-insensitively by name`() {
+      val project = ProjectDto.valid()
+      val appointments = listOf(
+        AppointmentSummaryDto.valid().copy(offender = OffenderDto.validFull().copy(forename = "John", surname = "STEVENS", crn = "X123456")),
+        AppointmentSummaryDto.valid().copy(offender = OffenderDto.validFull().copy(forename = "John", surname = "Smith", crn = "X987654")),
+      )
+
+      val result = service.toSessionDto(
+        date = LocalDate.of(2025, 9, 1),
+        project = project,
+        appointments = appointments,
+      )
+
+      assertThat(result.appointmentSummaries.size).isEqualTo(appointments.size)
+
+      assertThat(result.appointmentSummaries[0].offender).isInstanceOf(OffenderFullDto::class.java).extracting("forename").isEqualTo("John")
+      assertThat(result.appointmentSummaries[0].offender).isInstanceOf(OffenderFullDto::class.java).extracting("surname").isEqualTo("Smith")
+      assertThat(result.appointmentSummaries[0].offender).isInstanceOf(OffenderFullDto::class.java).extracting { it.crn }.isEqualTo("X987654")
+      assertThat(result.appointmentSummaries[1].offender).isInstanceOf(OffenderFullDto::class.java).extracting("forename").isEqualTo("John")
+      assertThat(result.appointmentSummaries[1].offender).isInstanceOf(OffenderFullDto::class.java).extracting("surname").isEqualTo("STEVENS")
+      assertThat(result.appointmentSummaries[1].offender).isInstanceOf(OffenderFullDto::class.java).extracting { it.crn }.isEqualTo("X123456")
+
+      assertThat(result.projectLocation).isEqualTo("")
+    }
   }
 
   @Nested


### PR DESCRIPTION
Currently, the way appointments are sorted means that surnames in all caps are sorted before surnames in standard casing. For example, this means that appointments for a session would be presented like this:

1. Roberts, John
2. STEVENS, John
3. Smith, John

This error was introduced in https://github.com/ministryofjustice/hmpps-community-payback-api/pull/762, as it implements alphabetical sorting of the appointments, but does not normalise for case.

This changes the comparator used for sorting so that all names are compared by their lowercase representations. This means that the above example now sorts correctly as:

1. Roberts, John
2. Smith, John
3. STEVENS, John