### PR TITLE
CPB-1150: Added support for filtering appointments by event number

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
@@ -214,6 +214,7 @@ class AdminAppointmentController(
     )
     @PageableDefault(size = 50, sort = ["name"], direction = Sort.Direction.ASC) pageable: Pageable,
     @RequestParam(required = false) crn: String?,
+    @RequestParam(required = false) eventNumber: String?,
     @Parameter(
       description = "Filter by one or more project codes",
       array = ArraySchema(schema = Schema(type = "string")),
@@ -231,6 +232,7 @@ class AdminAppointmentController(
     @RequestParam projectTypeGroup: ProjectTypeGroupDto?,
   ): Page<AppointmentSummaryDto> {
     val hasFilter = !crn.isNullOrBlank() ||
+      !eventNumber.isNullOrBlank() ||
       !projectCodes.isNullOrEmpty() ||
       fromDate != null ||
       toDate != null ||
@@ -255,7 +257,7 @@ class AdminAppointmentController(
       toDate = toDate,
       outcomeCodes = outcomeCodes,
       projectTypeGroup = projectTypeGroup,
-      eventNumber = null,
+      eventNumber = eventNumber,
       deliusAppointmentIds = null,
       pageable = pageable,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
@@ -387,12 +387,13 @@ class AdminAppointmentIT : IntegrationTestBase() {
 
       CommunityPaybackAndDeliusMockServer.setupGetAppointmentsResponse(
         crn = "CRN000",
+        eventNumber = 1,
         username = "theusername",
         appointments = listOf(appointment1, appointment2),
       )
 
       val pageResponse = webTestClient.get()
-        .uri("/admin/appointments?crn=CRN000")
+        .uri("/admin/appointments?crn=CRN000&eventNumber=1")
         .addAdminUiAuthHeader("theusername")
         .exchange()
         .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentRetrievalServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentRetrievalServiceTest.kt
@@ -113,8 +113,9 @@ class AppointmentRetrievalServiceTest {
   inner class GetAppointments {
 
     @Test
-    fun `should get appointments with crn`() {
+    fun `should get appointments with crn and event number`() {
       val crn = "CRN1"
+      val eventNumber = "2"
       val pageable = PageRequest.of(0, 10)
       val ndAppointmentSummary = NDAppointmentSummary.valid()
       val pageResponse = PageResponse(
@@ -131,7 +132,7 @@ class AppointmentRetrievalServiceTest {
           outcomeCodes = null,
           projectCodes = null,
           projectTypeCodes = null,
-          eventNumber = null,
+          eventNumber = eventNumber,
           appointmentIds = null,
           params = pageable.toMultiValueHttpParams(),
         )
@@ -147,6 +148,7 @@ class AppointmentRetrievalServiceTest {
         outcomeCodes = null,
         projectCodes = null,
         projectTypeGroup = null,
+        eventNumber = eventNumber,
         pageable = pageable,
       )
 


### PR DESCRIPTION
Added support for filtering appointments by event number in admin endpoints and updated relevant tests.