### PR TITLE
Improve tiebreaker sorting for `GET /admin/appointments` endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
@@ -243,7 +243,9 @@ class AdminAppointmentController(
       badRequest("At least one filter parameter must be provided")
     }
 
-    val pageable = if (pageable.sort.getOrderFor("name") == null) {
+    val needsTiebreakerSort = listOf("name", "forename", "surname").all { pageable.sort.getOrderFor(it) == null }
+
+    val pageable = if (needsTiebreakerSort) {
       val sort = pageable.sort.and(Sort.by(Sort.Direction.ASC, "name"))
       PageRequest.of(pageable.pageNumber, pageable.pageSize, sort)
     } else {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminAppointmentIT.kt
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointmentPickUp
@@ -409,8 +411,38 @@ class AdminAppointmentIT : IntegrationTestBase() {
       assertThat(pageResponse.page.number).isEqualTo(0)
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = ["name", "forename", "surname"])
+    fun `should not add a tiebreak sort if sorting by name, forename, or surname is specified`(sort: String) {
+      val appointment1 = NDAppointmentSummary.valid(ctx)
+      val appointment2 = NDAppointmentSummary.valid(ctx)
+
+      CommunityPaybackAndDeliusMockServer.setupGetAppointmentsResponse(
+        crn = "CRN000",
+        username = "theusername",
+        appointments = listOf(appointment1, appointment2),
+        sortStrings = arrayOf("$sort,asc"),
+      )
+
+      val pageResponse = webTestClient.get()
+        .uri("/admin/appointments?crn=CRN000&sort=$sort,asc")
+        .addAdminUiAuthHeader("theusername")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .bodyAsObject<PageResponse<AppointmentSummaryDto>>()
+
+      assertThat(pageResponse.content).hasSize(2)
+      assertThat(pageResponse.content[0].id).isEqualTo(appointment1.id)
+      assertThat(pageResponse.content[1].id).isEqualTo(appointment2.id)
+      assertThat(pageResponse.page.size).isEqualTo(50)
+      assertThat(pageResponse.page.totalPages).isEqualTo(1)
+      assertThat(pageResponse.page.totalElements).isEqualTo(2)
+      assertThat(pageResponse.page.number).isEqualTo(0)
+    }
+
     @Test
-    fun `should automatically add name alphabetical order sorting as a tiebreak if sorting by name is not specified`() {
+    fun `should automatically add name alphabetical order sorting as a tiebreak if sorting by name, forename, or surname is not specified`() {
       val appointment1 = NDAppointmentSummary.valid(ctx)
       val appointment2 = NDAppointmentSummary.valid(ctx)
 


### PR DESCRIPTION
As the PI team have introduced the ability to separately sort by forename and surname in their API, these should be accounted for when checking whether a tiebreaker sort is needed.

This PR updates the check in `AdminAppointmentController` to only apply `name` as an additional sort if none of `name`, `forename`, or `surname` have been specified as sorts.