### PR TITLE
Remove deprecated `GET /admin/projects/{projectCode}/sessions/{date}` endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminSessionController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminSessionController.kt
@@ -2,13 +2,10 @@ package uk.gov.justice.digital.hmpps.communitypaybackapi.controller.admin
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Content
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -16,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AllocateSupervisorToSessionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.SessionService
-import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.time.LocalDate
 
 @AdminUiController
@@ -25,37 +21,6 @@ import java.time.LocalDate
   produces = [MediaType.APPLICATION_JSON_VALUE],
 )
 class AdminSessionController(val sessionService: SessionService) {
-
-  @GetMapping(
-    path = [ "/{projectCode}/sessions/{date}"],
-    produces = [MediaType.APPLICATION_JSON_VALUE],
-  )
-  @Operation(
-    deprecated = true,
-    description = """Get project allocations within date range for a specific team. 
-      |Deprecated, should instead use /admin/projects/{projectCode} and /admin/appointments""",
-    responses = [
-      ApiResponse(
-        responseCode = "200",
-        description = "Successful project allocations response",
-      ),
-      ApiResponse(
-        responseCode = "400",
-        description = "Bad request - invalid date format or parameters",
-        content = [
-          Content(
-            schema = Schema(implementation = ErrorResponse::class),
-          ),
-        ],
-      ),
-    ],
-  )
-  fun getSession(
-    @PathVariable projectCode: String,
-    @Parameter(description = "Date", example = "2025-01-01")
-    @PathVariable
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
-  ) = sessionService.getSession(projectCode, date)
 
   @PostMapping(
     path = ["/{projectCode}/sessions/{date}/supervisor"],

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminSessionsIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/AdminSessionsIT.kt
@@ -5,90 +5,15 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointmentSummary
-import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProject
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AllocateSupervisorToSessionDto
-import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.SessionDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.SessionSupervisorEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.SessionSupervisorEntityRepository
-import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
-import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.util.bodyAsObject
-import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.wiremock.CommunityPaybackAndDeliusMockServer
 import java.time.LocalDate
 
 class AdminSessionsIT : IntegrationTestBase() {
 
   @Autowired
   lateinit var sessionSupervisorEntityRepository: SessionSupervisorEntityRepository
-
-  @Nested
-  @DisplayName("GET /admin/projects/123/sessions/2025-01-09")
-  inner class GetSessionEndpoint {
-
-    @Test
-    fun `should return unauthorized if no token`() {
-      webTestClient.get()
-        .uri("/admin/projects/123/sessions/2025-01-09")
-        .exchange()
-        .expectStatus()
-        .isUnauthorized
-    }
-
-    @Test
-    fun `should return forbidden if no role`() {
-      webTestClient.get()
-        .uri("/admin/projects/123/sessions/2025-01-09")
-        .headers(setAuthorisation())
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
-    @Test
-    fun `should return forbidden if wrong role`() {
-      webTestClient.get()
-        .uri("/admin/projects/123/sessions/2025-01-09")
-        .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
-        .exchange()
-        .expectStatus()
-        .isForbidden
-    }
-
-    @Test
-    fun `should return OK with project session`() {
-      CommunityPaybackAndDeliusMockServer.setupGetProjectResponse(
-        NDProject.valid(ctx).copy(
-          name = "Community Garden Maintenance",
-          code = "N123456789",
-        ),
-      )
-
-      CommunityPaybackAndDeliusMockServer.setupGetAppointmentsResponse(
-        username = "USER1",
-        pageSize = Int.MAX_VALUE,
-        fromDate = LocalDate.of(2025, 1, 9),
-        toDate = LocalDate.of(2025, 1, 9),
-        projectCodes = listOf("N123456789"),
-        appointments = listOf(
-          NDAppointmentSummary.valid().copy(outcome = null),
-          NDAppointmentSummary.valid().copy(outcome = null),
-        ),
-      )
-
-      val sessionSearchResults = webTestClient.get()
-        .uri("/admin/projects/N123456789/sessions/2025-01-09")
-        .addAdminUiAuthHeader(username = "USER1")
-        .exchange()
-        .expectStatus()
-        .isOk
-        .bodyAsObject<SessionDto>()
-
-      assertThat(sessionSearchResults.projectName).isEqualTo("Community Garden Maintenance")
-      assertThat(sessionSearchResults.projectCode).isEqualTo("N123456789")
-      assertThat(sessionSearchResults.date).isEqualTo(LocalDate.of(2025, 1, 9))
-      assertThat(sessionSearchResults.appointmentSummaries).hasSize(2)
-    }
-  }
 
   @Nested
   @DisplayName("POST /admin/projects/123/sessions/2025-01-09/supervisor")


### PR DESCRIPTION
This endpoint has been replaced by `GET /admin/projects/{projectCode}` and `GET /admin/appointments`.

As https://github.com/ministryofjustice/hmpps-community-payback-ui/pull/704 has now been merged, this endpoint is now unused, and can be removed.