### PR TITLE
CPB-1200: Return Community Payback and Delius IDs in response when creating appointments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/client/CommunityPaybackAndDeliusClient.kt
@@ -464,7 +464,9 @@ data class NDAppointmentPickUpData(val time: LocalTime?, val location: NDCode?)
 data class NDCreatedAppointment(
   val id: Long,
   val reference: UUID,
-)
+) {
+  companion object
+}
 
 data class NDUpdateAppointment(
   val version: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/controller/admin/AdminAppointmentController.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.controller.internal.toRe
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreatedAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.DeliusAppointmentIdDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectTypeGroupDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentDto
@@ -165,8 +166,8 @@ class AdminAppointmentController(
   )
   fun createAppointment(
     @RequestBody createAppointment: CreateAppointmentDto,
-  ): ResponseEntity<Unit> {
-    val deliusAppointmentId = appointmentService.createAppointment(
+  ): ResponseEntity<CreatedAppointmentDto> {
+    val createdAppointment = appointmentService.createAppointment(
       createAppointment,
       AppointmentEventTrigger(
         triggeredAt = OffsetDateTime.now(),
@@ -176,8 +177,8 @@ class AdminAppointmentController(
     )
 
     return ResponseEntity
-      .created(URI("/admin/projects/${createAppointment.projectCode}/appointments/$deliusAppointmentId"))
-      .build()
+      .created(URI("/admin/projects/${createAppointment.projectCode}/appointments/${createdAppointment.deliusId}"))
+      .body(createdAppointment)
   }
 
   @GetMapping(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CreatedAppointmentDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/dto/CreatedAppointmentDto.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.dto
+
+import java.util.UUID
+
+data class CreatedAppointmentDto(
+  val id: UUID,
+  val deliusId: Long,
+) {
+  companion object
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentCreationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/AppointmentCreationService.kt
@@ -7,12 +7,14 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCreateAppointme
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCreatedAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentsDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreatedAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntityRepository
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.AppointmentValidationService.ValidatedAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.CommunityPaybackSpringEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.internal.SpringEventPublisher
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.ToAppointmentEntity.toAppointmentEntity
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toNDCreateAppointment
 import java.util.UUID
 
@@ -31,7 +33,7 @@ class AppointmentCreationService(
   fun createAppointment(
     appointment: CreateAppointmentDto,
     trigger: AppointmentEventTrigger,
-  ): Long = createAppointmentsForProject(
+  ): CreatedAppointmentDto = createAppointmentsForProject(
     CreateAppointmentsDto(
       projectCode = appointment.projectCode,
       appointments = listOf(appointment),
@@ -43,7 +45,7 @@ class AppointmentCreationService(
   fun createAppointmentsForProject(
     createAppointmentsDto: CreateAppointmentsDto,
     trigger: AppointmentEventTrigger,
-  ): List<Long> {
+  ): List<CreatedAppointmentDto> {
     val projectCode = createAppointmentsDto.projectCode
     val appointments = createAppointmentsDto.appointments
 
@@ -92,7 +94,7 @@ class AppointmentCreationService(
       )
     }
 
-    return creationResponse.map { it.id }
+    return creationResponse.map { it.toDto() }
   }
 
   data class AppointmentToCreate(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/EteService.kt
@@ -190,7 +190,7 @@ class EteService(
           courseCompletionEvent = courseCompletionEvent,
         ),
         trigger = appointmentEventTrigger,
-      )
+      ).deliusId
     } else {
       val appointmentId = DeliusAppointmentIdDto(
         projectCode = courseCompletionResolution.creditTimeDetails.projectCode,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/service/mappers/AppointmentMappers.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointmentSumm
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointmentWorkQuality
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCode
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCreateAppointment
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCreatedAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDUpdateAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.common.formatForUser
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentBehaviourDto
@@ -18,6 +19,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentSummaryDt
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AppointmentWorkQualityDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.AttendanceDataDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreatedAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.EnforcementDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.PickUpDataDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.UpdateAppointmentDto
@@ -323,3 +325,8 @@ fun NDAppointmentBehaviour.toDto() = when (this) {
   NDAppointmentBehaviour.SATISFACTORY -> AppointmentBehaviourDto.SATISFACTORY
   NDAppointmentBehaviour.UNSATISFACTORY -> AppointmentBehaviourDto.UNSATISFACTORY
 }
+
+fun NDCreatedAppointment.toDto() = CreatedAppointmentDto(
+  id = this.reference,
+  deliusId = this.id,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDCreatedAppointmentFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/client/NDCreatedAppointmentFactory.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client
+
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCreatedAppointment
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
+import java.util.UUID
+
+fun NDCreatedAppointment.Companion.valid() = NDCreatedAppointment(
+  id = Long.random(),
+  reference = UUID.randomUUID(),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/CreatedAppointmentDtoFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/factory/dto/CreatedAppointmentDtoFactory.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.communitypaybackapi.factory.dto
+
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreatedAppointmentDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.random
+import java.util.UUID
+
+fun CreatedAppointmentDto.Companion.full() = CreatedAppointmentDto(
+  id = UUID.randomUUID(),
+  deliusId = Long.random(),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentCreationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/AppointmentCreationServiceTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCreateAppointme
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCreatedAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreateAppointmentsDto
+import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.CreatedAppointmentDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.OffenderNameDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.dto.ProjectDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.entity.AppointmentEntityRepository
@@ -153,7 +154,10 @@ class AppointmentCreationServiceTest {
         trigger = TRIGGER,
       )
 
-      assertThat(result).containsExactlyInAnyOrder(ND_APPT1_ID, ND_APPT2_ID)
+      assertThat(result).containsExactlyInAnyOrder(
+        CreatedAppointmentDto(appointment1Id, ND_APPT1_ID),
+        CreatedAppointmentDto(appointment2Id, ND_APPT2_ID),
+      )
 
       verify {
         appointmentEntityRepository.saveAll(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/unit/service/mappers/AppointmentMappersTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDAppointmentWork
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCaseSummary
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCodeDescription
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDContactOutcome
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCreatedAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDEnforcementAction
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDEvent
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDName
@@ -61,6 +62,7 @@ import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.Appointm
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.ToAppointmentEntity.toAppointmentEntity
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.fromDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toAppointmentUpdatedDomainEvent
+import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toDto
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toNDCreateAppointment
 import uk.gov.justice.digital.hmpps.communitypaybackapi.service.mappers.toNDUpdateAppointment
 import java.time.Duration
@@ -855,6 +857,19 @@ class AppointmentMappersTest {
       expectedValue: Behaviour,
     ) {
       assertThat(Behaviour.fromDto(sourceValue)).isEqualTo(expectedValue)
+    }
+  }
+
+  @Nested
+  inner class NDCreatedAppointmentToDto {
+    @Test
+    fun success() {
+      val createdAppointment = NDCreatedAppointment.valid()
+
+      val result = createdAppointment.toDto()
+
+      assertThat(result.id).isEqualTo(createdAppointment.reference)
+      assertThat(result.deliusId).isEqualTo(createdAppointment.id)
     }
   }
 }


### PR DESCRIPTION
Currently, when creating an appointment using the `POST /admin/appointments` endpoint, only the Delius ID is returned, and only as part of the URL in the `Location` header. However, both the Community Payback ID and the Delius ID are needed.

This PR adds a new `CreatedAppointmentDto` model, which is returned when an appointment is successfully created. A response from the `POST /admin/appointments` endpoint now looks like this:

```jsonc
{
  "id": "50db8d43-3fe8-4301-81c6-26e2c05ec409", // Assigned by Community Payback
  "deliusId": "20260810163922" // Assigned by nDelius
}
```