### PR TITLE
Update `application.yml` to fix `max-in-memory-size` configuration placement

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,8 +12,9 @@ spring:
     sql-migration-prefix: ""
   application:
     name: hmpps-community-payback-api
-  codec:
-    max-in-memory-size: 10MB
+  http:
+    codecs:
+      max-in-memory-size: 10MB
 
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/config/WebClientRetryIT.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/communitypaybackapi/integration/config/WebClientRetryIT.kt
@@ -17,8 +17,11 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.TestPropertySource
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.CommunityPaybackAndDeliusClient
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDCreateAppointments
+import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProjectOutcomeStats
 import uk.gov.justice.digital.hmpps.communitypaybackapi.client.NDProviderSummaries
+import uk.gov.justice.digital.hmpps.communitypaybackapi.factory.client.valid
 import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.communitypaybackapi.integration.wiremock.CommunityPaybackAndDeliusMockServer
 
 @TestPropertySource(
   properties = [
@@ -29,6 +32,29 @@ class WebClientRetryIT : IntegrationTestBase() {
 
   @Autowired
   private lateinit var communityPaybackAndDeliusClient: CommunityPaybackAndDeliusClient
+
+  @Test
+  fun `response larger than the default codec buffer is decoded`() {
+    val projects = (1..100).map { index ->
+      NDProjectOutcomeStats.valid().let { stats ->
+        stats.copy(project = stats.project.copy(code = "project-$index", name = "Project $index ${"x".repeat(3_000)}"))
+      }
+    }
+    CommunityPaybackAndDeliusMockServer.setupGetProjectsResponse(
+      providerCode = "N56",
+      teamCode = "N56CPB",
+      response = projects,
+    )
+
+    val response = communityPaybackAndDeliusClient.getProjects(
+      providerCode = "N56",
+      teamCode = "N56CPB",
+      typeCode = null,
+      params = mapOf("page" to "0", "size" to "100", "sort" to "name,asc"),
+    )
+
+    assertThat(response.content).hasSize(100)
+  }
 
   @Test
   fun `GET request is retried on timeout`() {


### PR DESCRIPTION
Update `application.yml` to fix `max-in-memory-size` configuration placement

The failure came from Spring WebClient’s default response buffer limit of 256 KiB (262144 bytes).
The endpoint calls the downstream community-payback-and-delius projects endpoint and deserializes the complete JSON response into a PageResponse<NDProjectOutcomeStats>. 
For team N56CPB, that response exceeds 256 KiB, so WebClient threw the error before it could deserialize the JSON.


The application already intended to raise the limit to 10 MB:
`spring:
  codec:
    max-in-memory-size: 10MB`

However, the project now uses Spring Boot 4.1. In that version, the property is located under spring.http.codecs. The old property was therefore ignored, leaving WebClient at its 256 KiB default.
It now uses:
`spring:
  http:
    codecs:
      max-in-memory-size: 10MB`

Spring Boot applies this setting to the shared WebClient.Builder, which is used to construct the authorized communityPaybackAndDeliusWebClient. Consequently, responses up to 10 MB can now be buffered and deserialized successfully.

The regression test returns roughly 300 KiB of project data, proving that the client can process a response larger than the previous 262,144-byte limit.